### PR TITLE
Fix: Import visual indicator for video selection

### DIFF
--- a/frontend/src/InteractiveImport/Interactive/InteractiveImportRow.tsx
+++ b/frontend/src/InteractiveImport/Interactive/InteractiveImportRow.tsx
@@ -260,7 +260,7 @@ function InteractiveImportRow(props: InteractiveImportRowProps) {
 
   const movieTitle = movie ? movie.title : '';
 
-  const showMoviePlaceholder = isSelected && !movie;
+  const showMoviePlaceholder = !movie;
   const showReleaseGroupPlaceholder = isSelected && !releaseGroup;
   const showQualityPlaceholder = isSelected && !quality;
   const showLanguagePlaceholder = isSelected && !languages;


### PR DESCRIPTION
Fixed the "Movie" column to show the dashed outline when a video needs to be selected.  This had a logic issue where it would only show if selected, but if selected, wouldn't need to show .

#### Database Migration
NO

#### Screenshot (if UI related)
<img width="1147" height="347" alt="image" src="https://github.com/user-attachments/assets/46c64e60-f083-4175-b0f7-b141acc6b98a" />


#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX