### PR TITLE
Fix: Improve accessibility of nav links in dark theme

### DIFF
--- a/frontend/src/Components/Page/Sidebar/PageSidebarItem.css
+++ b/frontend/src/Components/Page/Sidebar/PageSidebarItem.css
@@ -15,8 +15,7 @@
 
   &:hover,
   &:focus {
-    color: var(--themePurple);
-    text-decoration: none;
+    color: var(--themeLightPurple);
   }
 
 }
@@ -29,16 +28,18 @@
 }
 
 .isActiveLink {
-  color: var(--themePurple);
+  color: var(--themeLightPurple);
+  text-decoration: underline;
+  text-underline-offset: 4px;
 }
 
 .isActiveParentLink {
   background-color: var(--sidebarActiveBackgroundColor);
-    color: var(--white);
+    color: var(--themeLightPurple);
     }
-    
+
     .sectionHeading {
-      color: var(--white);
+      color: var(--themeLightPurple);
 }
 
 .iconContainer {

--- a/frontend/src/Styles/Themes/dark.js
+++ b/frontend/src/Styles/Themes/dark.js
@@ -38,6 +38,7 @@ module.exports = {
 
   themePink: whisparrPink,
   themePurple: whisparrPurple,
+  themeLightPurple: '#c084fc',
   themeAlternatePink: '#c4337c',
   themeRed: '#c4273c',
   themeDarkColor: '#494949',


### PR DESCRIPTION
#### Database Migration
NO

#### Description
- Achieves contrast ratio of 4.78:1 when backed by the lighter grey
- Achieves 5.43:1 when backed by the darker grey
- Active link is underlined
- Still purple-ish :)

https://webaim.org/resources/contrastchecker/?fcolor=C084FC&bcolor=333333

#### Screenshot (if UI related)
<img width="450" height="508" alt="image" src="https://github.com/user-attachments/assets/a5893b49-02c0-4197-8b13-d5cc36e8b2e1" />

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes whisparr/whisparr#615