### PR TITLE
Fix: Use StashId for Tag Exclusion

### DIFF
--- a/frontend/src/Settings/ImportLists/ImportListExclusions/EditImportListExclusionModalContent.tsx
+++ b/frontend/src/Settings/ImportLists/ImportListExclusions/EditImportListExclusionModalContent.tsx
@@ -29,7 +29,6 @@ import styles from './EditImportListExclusionModalContent.css';
 
 const newImportListExclusion = {
   movieTitle: '',
-  movieYear: 0,
   type: 'scene',
   foreignId: '',
 };
@@ -80,7 +79,7 @@ function EditImportListExclusionModalContent({
   const { isFetching, isSaving, item, error, saveError, ...otherProps } =
     useSelector(createImportListExclusionSelector(id));
 
-  const { movieTitle, movieYear, foreignId, type } = item;
+  const { movieTitle, foreignId, type } = item;
 
   const dispatch = useDispatch();
   const previousIsSaving = usePrevious(isSaving);
@@ -175,18 +174,6 @@ function EditImportListExclusionModalContent({
                 onChange={onInputChange}
               />
             </FormGroup>
-
-            <FormGroup>
-              <FormLabel>{translate('Year')}</FormLabel>
-
-              <FormInputGroup
-                type={inputTypes.NUMBER}
-                name="movieYear"
-                helpText={translate('MovieYearToExcludeHelpText')}
-                {...movieYear}
-                onChange={onInputChange}
-              />
-            </FormGroup>
           </Form>
         )}
       </ModalBody>
@@ -201,7 +188,6 @@ function EditImportListExclusionModalContent({
             {translate('Delete')}
           </Button>
         )}
-        : null
         <Button onPress={onModalClose}>{translate('Cancel')}</Button>
         <SpinnerErrorButton
           isSpinning={isSaving}

--- a/frontend/src/Settings/ImportLists/ImportListExclusions/ImportListExclusionRow.tsx
+++ b/frontend/src/Settings/ImportLists/ImportListExclusions/ImportListExclusionRow.tsx
@@ -20,15 +20,8 @@ interface ImportListExclusionRowProps extends ImportListExclusion {
 }
 
 function ImportListExclusionRow(props: ImportListExclusionRowProps) {
-  const {
-    id,
-    foreignId,
-    type,
-    movieTitle,
-    movieYear,
-    isSelected,
-    onSelectedChange,
-  } = props;
+  const { id, foreignId, type, movieTitle, isSelected, onSelectedChange } =
+    props;
 
   const dispatch = useDispatch();
 
@@ -59,7 +52,6 @@ function ImportListExclusionRow(props: ImportListExclusionRowProps) {
       <TableRowCell>{movieTitle}</TableRowCell>
       <TableRowCell className={styles.foreignId}>{foreignId}</TableRowCell>
       <TableRowCell>{type}</TableRowCell>
-      <TableRowCell>{movieYear}</TableRowCell>
 
       <TableRowCell className={styles.actions}>
         <IconButton

--- a/frontend/src/Settings/ImportLists/ImportListExclusions/ImportListExclusions.tsx
+++ b/frontend/src/Settings/ImportLists/ImportListExclusions/ImportListExclusions.tsx
@@ -61,12 +61,6 @@ const COLUMNS: Column[] = [
     isSortable: true,
   },
   {
-    name: 'movieYear',
-    label: () => translate('Year'),
-    isVisible: true,
-    isSortable: true,
-  },
-  {
     className: styles.actions,
     name: 'actions',
     label: '',
@@ -261,7 +255,7 @@ function ImportListExclusions() {
             })}
 
             <TableRow>
-              <TableRowCell colSpan={5}>
+              <TableRowCell colSpan={4}>
                 <SpinnerButton
                   kind={kinds.DANGER}
                   isSpinning={isDeleting}

--- a/frontend/src/typings/ImportListExclusion.ts
+++ b/frontend/src/typings/ImportListExclusion.ts
@@ -3,6 +3,5 @@ import ModelBase from 'App/ModelBase';
 export default interface ImportListExclusion extends ModelBase {
   foreignId: string;
   movieTitle: string;
-  movieYear: number;
   type: string;
 }

--- a/src/NzbDrone.Core/Datastore/TableMapping.cs
+++ b/src/NzbDrone.Core/Datastore/TableMapping.cs
@@ -173,7 +173,8 @@ namespace NzbDrone.Core.Datastore
 
                   Mapper.Entity<UpdateHistory>("UpdateHistory").RegisterModel();
 
-                  Mapper.Entity<MovieMetadata>("MovieMetadata").RegisterModel();
+                  Mapper.Entity<MovieMetadata>("MovieMetadata").RegisterModel()
+                    .Ignore(i => i.TagIds);
 
                   Mapper.Entity<Performer>("Performers").RegisterModel()
                         .Ignore(e => e.MergedIntoId);

--- a/src/NzbDrone.Core/ImportLists/ImportExclusions/ImportListExclusion.cs
+++ b/src/NzbDrone.Core/ImportLists/ImportExclusions/ImportListExclusion.cs
@@ -7,11 +7,10 @@ namespace NzbDrone.Core.ImportLists.ImportExclusions
         public string ForeignId { get; set; }
         public string MovieTitle { get; set; }
         public ImportExclusionType Type { get; set; }
-        public int? MovieYear { get; set; }
 
         public new string ToString()
         {
-            return string.Format("Exclusion: [{0}][{1}][{2} {3}]", Type, ForeignId, MovieTitle, MovieYear);
+            return string.Format("Exclusion: [{0}][{1}][{2}]", Type, ForeignId, MovieTitle);
         }
     }
 }

--- a/src/NzbDrone.Core/ImportLists/ImportExclusions/ImportListExclusionService.cs
+++ b/src/NzbDrone.Core/ImportLists/ImportExclusions/ImportListExclusionService.cs
@@ -121,7 +121,7 @@ namespace NzbDrone.Core.ImportLists.ImportExclusions
             {
                 _logger.Debug("Adding {0} Deleted Movies to Import Exclusions", message.Movies.Count);
 
-                var exclusions = message.Movies.Select(m => new ImportListExclusion { ForeignId = m.ForeignId, Type = ToImportExclusionType(m.MovieMetadata.Value.ItemType), MovieTitle = m.Title, MovieYear = m.Year }).ToList();
+                var exclusions = message.Movies.Select(m => new ImportListExclusion { ForeignId = m.ForeignId, Type = ToImportExclusionType(m.MovieMetadata.Value.ItemType), MovieTitle = m.ToFormattedString() }).ToList();
                 _exclusionRepository.InsertMany(DeDupeExclusions(exclusions));
             }
         }

--- a/src/NzbDrone.Core/Localization/Core/en.json
+++ b/src/NzbDrone.Core/Localization/Core/en.json
@@ -1302,7 +1302,7 @@
   "MovieSearchResultsLoadError": "Unable to load results for this movie search. Try again later",
   "MoviesSelectedInterp": "{count} Movie(s) Selected",
   "MovieTitle": "Movie Title",
-  "MovieTitleToExcludeHelpText": "The title of the movie to exclude (can be anything meaningful)",
+  "MovieTitleToExcludeHelpText": "The title of the item to exclude",
   "MovieYear": "Movie Year",
   "MovieYearToExcludeHelpText": "The year of the movie to exclude",
   "MultiLanguage": "Multi-Language",

--- a/src/NzbDrone.Core/MetadataSource/SkyHook/Resource/MovieResource.cs
+++ b/src/NzbDrone.Core/MetadataSource/SkyHook/Resource/MovieResource.cs
@@ -16,6 +16,7 @@ namespace NzbDrone.Core.MetadataSource.SkyHook.Resource
         public int? Duration { get; set; }
         public List<ImageResource> Images { get; set; }
         public List<string> Genres { get; set; }
+        public List<TagResource> Tags { get; set; }
         public string Code { get; set; }
         public int Year { get; set; }
         public string ReleaseDate { get; set; }

--- a/src/NzbDrone.Core/MetadataSource/SkyHook/Resource/TagResource.cs
+++ b/src/NzbDrone.Core/MetadataSource/SkyHook/Resource/TagResource.cs
@@ -1,0 +1,9 @@
+namespace NzbDrone.Core.MetadataSource.SkyHook.Resource
+{
+    public class TagResource
+    {
+        public string Name { get; set; }
+
+        public ExternalIdResource ForeignIds { get; set; }
+    }
+}

--- a/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
+++ b/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
@@ -527,6 +527,17 @@ namespace NzbDrone.Core.MetadataSource.SkyHook
             movie.Ratings = MapRatings(resource.Ratings) ?? new Ratings();
 
             movie.Genres = resource.Genres;
+
+            // Check for tags with StashIDs as used for exclusion/tagging in Whisparr not stored locally
+            if (resource.Tags != null && resource.Tags.Where(t => !string.IsNullOrEmpty(t.ForeignIds?.StashId)).Any())
+            {
+                movie.TagIds = resource.Tags.Select(t => t.ForeignIds.StashId).ToList();
+            }
+            else
+            {
+                movie.TagIds = new List<string>();
+            }
+
             movie.Images = resource.Images.Select(MapImage).ToList();
 
             movie.ItemType = resource.ItemType;

--- a/src/NzbDrone.Core/Movies/Movie.cs
+++ b/src/NzbDrone.Core/Movies/Movie.cs
@@ -103,7 +103,7 @@ namespace NzbDrone.Core.Movies
             return MovieMetadata.Value.ReleaseDateUtc;
         }
 
-        public override string ToString()
+        public string ToFormattedString()
         {
             var result = string.Empty;
 
@@ -111,25 +111,37 @@ namespace NzbDrone.Core.Movies
             {
                 if (MovieMetadata.Value.Title != null)
                 {
-                    result += string.Format("[{0} - {1} - {2}]", MovieMetadata.Value.StudioTitle.NullSafe(), MovieMetadata.Value.ReleaseDate.NullSafe(), MovieMetadata.Value.Title.NullSafe());
+                    result += string.Format("{0} - {1} - {2}", MovieMetadata.Value.StudioTitle.NullSafe(), MovieMetadata.Value.ReleaseDate.NullSafe(), MovieMetadata.Value.Title.NullSafe());
                 }
             }
             else
             {
                 if (MovieMetadata.Value.Title != null)
                 {
-                    result += string.Format("[{0} ({1})]", MovieMetadata.Value.Title.NullSafe(), MovieMetadata.Value.Year.NullSafe());
+                    result += string.Format("{0} ({1})", MovieMetadata.Value.Title.NullSafe(), MovieMetadata.Value.Year.NullSafe());
                 }
             }
 
+            return result;
+        }
+
+        public override string ToString()
+        {
+            var result = ToFormattedString();
+
             if (MovieMetadata.Value.ImdbId != null)
             {
-                result += $"[{MovieMetadata.Value.ImdbId}]";
+                result += $" [{MovieMetadata.Value.ImdbId}]";
             }
 
             if (MovieMetadata.Value.ForeignId != null)
             {
-                result += $"[{MovieMetadata.Value.ForeignId}]";
+                result += $" [{MovieMetadata.Value.ForeignId}]";
+            }
+
+            if (result.IsNullOrWhiteSpace())
+            {
+                result = $"[{result}]";
             }
 
             return result;

--- a/src/NzbDrone.Core/Movies/MovieMetadata.cs
+++ b/src/NzbDrone.Core/Movies/MovieMetadata.cs
@@ -19,12 +19,14 @@ namespace NzbDrone.Core.Movies
             OriginalLanguage = Language.English;
             Recommendations = new List<int>();
             Ratings = new Ratings();
+            TagIds = new List<string>();
         }
 
         public string ForeignId { get; set; }
 
         public List<MediaCover.MediaCover> Images { get; set; }
         public List<string> Genres { get; set; }
+        public List<string> TagIds { get; set; }
         public DateTime? ReleaseDateUtc { get; set; }
         public string ReleaseDate { get; set; }
         public int Year { get; set; }

--- a/src/Whisparr.Api.V3/ImportLists/ImportListExclusionController.cs
+++ b/src/Whisparr.Api.V3/ImportLists/ImportListExclusionController.cs
@@ -41,7 +41,6 @@ namespace Whisparr.Api.V3.ImportLists
                 .SetValidator(importListExclusionExistsValidator);
 
             SharedValidator.RuleFor(c => c.MovieTitle).NotEmpty();
-            SharedValidator.RuleFor(c => c.MovieYear).GreaterThan(0);
         }
 
         // Endpoint only used by stasharr to show excluded scenes

--- a/src/Whisparr.Api.V3/ImportLists/ImportListExclusionResource.cs
+++ b/src/Whisparr.Api.V3/ImportLists/ImportListExclusionResource.cs
@@ -10,7 +10,6 @@ namespace Whisparr.Api.V3.ImportLists
         public string ForeignId { get; set; }
         public string MovieTitle { get; set; }
         public ImportExclusionType Type { get; set; }
-        public int? MovieYear { get; set; }
     }
 
     public static class ImportListExclusionResourceMapper
@@ -28,7 +27,6 @@ namespace Whisparr.Api.V3.ImportLists
                 ForeignId = model.ForeignId,
                 MovieTitle = model.MovieTitle,
                 Type = model.Type,
-                MovieYear = model.MovieYear
             };
         }
 
@@ -45,7 +43,6 @@ namespace Whisparr.Api.V3.ImportLists
                 ForeignId = resource.ForeignId,
                 MovieTitle = resource.MovieTitle,
                 Type = resource.Type,
-                MovieYear = resource.MovieYear ?? 0
             };
         }
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Remove the year as it serves no purpose. (Field currently left can be removed via a data mitigation but needs to be manual SQL)
Change the title to show more information. 
The StashId for a Tag is now used for exclusions. The contains on a string may not have worked correctly for all tags, and the use of the Id is constant with other exclusions. 


#### Screenshot (if UI related)
<img width="1700" height="274" alt="image" src="https://github.com/user-attachments/assets/7a919968-101e-4eda-b0df-652ca6839f24" />

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX