### PR TITLE
Fix: Updater fixes and improvements

### DIFF
--- a/.github/workflows/build_v3.yml
+++ b/.github/workflows/build_v3.yml
@@ -17,7 +17,7 @@ on:
       - "src/Whisparr.Api.*/openapi.json"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-pr-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 env:
@@ -91,6 +91,8 @@ jobs:
     steps:
       - name: Check out
         uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
 
       - name: Build
         uses: ./.github/actions/build
@@ -106,6 +108,8 @@ jobs:
     steps:
       - name: Check out
         uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
 
       - name: Volta
         uses: volta-cli/action@v4
@@ -151,6 +155,8 @@ jobs:
     steps:
       - name: Check out
         uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
 
       - name: Test
         uses: ./.github/actions/test
@@ -170,6 +176,8 @@ jobs:
     steps:
       - name: Check out
         uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
 
       - name: Test
         uses: ./.github/actions/test
@@ -207,6 +215,8 @@ jobs:
     steps:
       - name: Check out
         uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
       - name: Test
         uses: ./.github/actions/test
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -69,6 +69,9 @@ jobs:
     steps:
       - name: Check out
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: Download release artifacts
         uses: actions/download-artifact@v4
@@ -84,23 +87,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         with:
           latest: true
-          prerelease: ${{ inputs.branch != 'main' }}
-
-      - name: Generate Release Notes
-        id: generate-release-notes
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ github.token }}
-          result-encoding: string
-          script: |
-            const { data } = await github.rest.repos.generateReleaseNotes({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              tag_name: 'v${{ inputs.version }}',
-              target_commitish: '${{ github.sha }}',
-              previous_tag_name: '${{ steps.previous-release.outputs.tag_name }}',
-            })
-            return data.body
+          prerelease: ${{ inputs.branch != 'eros' }}
 
       - name: Enable GPG signing
         uses: crazy-max/ghaction-import-gpg@v6
@@ -118,13 +105,22 @@ jobs:
         env:
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
 
+      - name: Generate Commit Changelog
+        id: generate-commit-changelog
+        run: |
+          PREV_TAG="${{ steps.previous-release.outputs.tag_name }}"
+          CUR_TAG="v${{ inputs.version }}"
+          echo "## What's Changed" > changelog.md
+          git log "$PREV_TAG..$CUR_TAG" --pretty=format:"- %s (%h) - @%an" >> changelog.md
+          cat changelog.md
+
       - name: Create release
         uses: ncipollo/release-action@v1
         with:
           artifacts: _artifacts/Whisparr.*
           commit: ${{ github.sha }}
           generateReleaseNotes: false
-          body: ${{ steps.generate-release-notes.outputs.result }}
+          bodyFile: changelog.md
           name: ${{ inputs.version }}
           prerelease: ${{ inputs.branch != 'eros' }}
           skipIfReleaseExists: true

--- a/frontend/src/System/Updates/Updates.css
+++ b/frontend/src/System/Updates/Updates.css
@@ -51,3 +51,7 @@
   margin-left: 10px;
   font-size: 14px;
 }
+
+a {
+  color: var(--linkColor);
+}

--- a/frontend/src/System/Updates/Updates.tsx
+++ b/frontend/src/System/Updates/Updates.tsx
@@ -269,7 +269,7 @@ function Updates() {
                     return (
                       <InlineMarkdown
                         data={translate('MaintenanceReleaseWithLink', {
-                          url: 'https://github.com/Whisparr/Whisparr/commits/eros/',
+                          url: 'https://github.com/Whisparr/Whisparr-Eros/commits/eros/',
                         })}
                       />
                     );

--- a/src/NzbDrone.Core.Test/HealthCheck/Checks/ReleaseBranchCheckFixture.cs
+++ b/src/NzbDrone.Core.Test/HealthCheck/Checks/ReleaseBranchCheckFixture.cs
@@ -35,10 +35,10 @@ namespace NzbDrone.Core.Test.HealthCheck.Checks
             Subject.Check().ShouldBeWarning();
         }
 
-        [TestCase("nightly")]
-        [TestCase("Nightly")]
-        [TestCase("develop")]
-        [TestCase("master")]
+        [TestCase("eros")]
+        [TestCase("eros-develop")]
+        [TestCase("Eros")]
+        [TestCase("Eros-Develop")]
         public void should_return_no_warning_when_branch_valid(string branch)
         {
             GivenValidBranch(branch);

--- a/src/NzbDrone.Core/HealthCheck/Checks/ReleaseBranchCheck.cs
+++ b/src/NzbDrone.Core/HealthCheck/Checks/ReleaseBranchCheck.cs
@@ -19,7 +19,7 @@ namespace NzbDrone.Core.HealthCheck.Checks
 
         public override HealthCheck Check()
         {
-            var currentBranch = _configFileService.Branch.ToLower();
+            var currentBranch = _configFileService.Branch.ToLower().Replace("-", "");
 
             if (!Enum.GetNames(typeof(ReleaseBranches)).Any(x => x.ToLower() == currentBranch))
             {
@@ -31,10 +31,8 @@ namespace NzbDrone.Core.HealthCheck.Checks
 
         public enum ReleaseBranches
         {
-            Master,
-            Develop,
-            Nightly,
-            Eros
+            Eros,
+            ErosDevelop
         }
     }
 }

--- a/src/NzbDrone.Core/Update/InstallUpdateService.cs
+++ b/src/NzbDrone.Core/Update/InstallUpdateService.cs
@@ -139,6 +139,31 @@ namespace NzbDrone.Core.Update
             _archiveService.Extract(packageDestination, updateSandboxFolder);
             _logger.Info("Update package extracted successfully");
 
+            // Log the contents of the updateSandboxFolder after extraction
+
+            try
+            {
+                var extractedDirs = _diskProvider.GetDirectories(updateSandboxFolder);
+                var extractedFiles = _diskProvider.GetFiles(updateSandboxFolder, true); // true = recursive
+                _logger.Info("[Update Debug] Contents of updateSandboxFolder after extraction:");
+                foreach (var dir in extractedDirs)
+                {
+                    _logger.Info("[Update Debug] Dir: {0}", dir);
+                }
+
+                foreach (var file in extractedFiles)
+                {
+                    _logger.Info("[Update Debug] File: {0}", file);
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.Warn(ex, "[Update Debug] Failed to enumerate extracted updateSandboxFolder contents");
+            }
+
+            var expectedUpdateClientFolder = _appFolderInfo.GetUpdateClientFolder();
+            _logger.Info("[Update Debug] Expected update client folder: {0}", expectedUpdateClientFolder);
+
             EnsureValidBranch(updatePackage);
 
             _backupService.Backup(BackupType.Update);


### PR DESCRIPTION
* Fix: Style and error handling for updater
* Fix: Maintenance release update URL
* Fix: Accessibility coloring for links on Updates page
* Fix: Version check when app needs an update
* Fix: macOS update attempting .app update instead of binary package update
* Chore: Change release notes generation to commit-based

#### Database Migration
NO

#### Description
There were numerous issues with the internal updater, mostly due to changing how we fetch the list of available releases and parse version numbers between .NET assembly version and SemVer.  In addition, I fixed how release notes are generated during merges, gave an accessibility touch-up to the Updates page, and did an end to end test of the macOS update flow.

#### Screenshot (if UI related)
<img width="600" alt="image" src="https://github.com/user-attachments/assets/30725557-bb18-455d-9836-1d965cb92e24" />

<img width="610" height="241" alt="image" src="https://github.com/user-attachments/assets/a8bda4bd-5143-4346-9fe9-6037fafd959b" />


#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR
* Fixes Whisparr/Whisparr-Eros#750