### PR TITLE
New: Record Import Exclusion reasons

### DIFF
--- a/frontend/src/Settings/ImportLists/ImportListExclusions/ImportListExclusionRow.tsx
+++ b/frontend/src/Settings/ImportLists/ImportListExclusions/ImportListExclusionRow.tsx
@@ -20,8 +20,15 @@ interface ImportListExclusionRowProps extends ImportListExclusion {
 }
 
 function ImportListExclusionRow(props: ImportListExclusionRowProps) {
-  const { id, foreignId, type, movieTitle, isSelected, onSelectedChange } =
-    props;
+  const {
+    id,
+    foreignId,
+    type,
+    reason,
+    movieTitle,
+    isSelected,
+    onSelectedChange,
+  } = props;
 
   const dispatch = useDispatch();
 
@@ -52,6 +59,7 @@ function ImportListExclusionRow(props: ImportListExclusionRowProps) {
       <TableRowCell>{movieTitle}</TableRowCell>
       <TableRowCell className={styles.foreignId}>{foreignId}</TableRowCell>
       <TableRowCell>{type}</TableRowCell>
+      <TableRowCell>{reason}</TableRowCell>
 
       <TableRowCell className={styles.actions}>
         <IconButton

--- a/frontend/src/Settings/ImportLists/ImportListExclusions/ImportListExclusions.tsx
+++ b/frontend/src/Settings/ImportLists/ImportListExclusions/ImportListExclusions.tsx
@@ -61,6 +61,12 @@ const COLUMNS: Column[] = [
     isSortable: true,
   },
   {
+    name: 'reason',
+    label: () => translate('Reason'),
+    isVisible: true,
+    isSortable: true,
+  },
+  {
     className: styles.actions,
     name: 'actions',
     label: '',
@@ -255,7 +261,7 @@ function ImportListExclusions() {
             })}
 
             <TableRow>
-              <TableRowCell colSpan={4}>
+              <TableRowCell colSpan={5}>
                 <SpinnerButton
                   kind={kinds.DANGER}
                   isSpinning={isDeleting}

--- a/frontend/src/typings/ImportListExclusion.ts
+++ b/frontend/src/typings/ImportListExclusion.ts
@@ -4,4 +4,5 @@ export default interface ImportListExclusion extends ModelBase {
   foreignId: string;
   movieTitle: string;
   type: string;
+  reason: string;
 }

--- a/src/NzbDrone.Core/Datastore/Migration/014_import_exclusion_reason.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/014_import_exclusion_reason.cs
@@ -1,0 +1,15 @@
+using FluentMigrator;
+using NzbDrone.Core.Datastore.Migration.Framework;
+
+namespace NzbDrone.Core.Datastore.Migration
+{
+    [Migration(014)]
+    public class import_exclusion_reason : NzbDroneMigrationBase
+    {
+        protected override void MainDbUpgrade()
+        {
+            // Add 'Reason' column to 'ImportExclusions' table with default value 0 (Manual)
+            Alter.Table("ImportExclusions").AddColumn("Reason").AsInt32().WithDefaultValue(0);
+        }
+    }
+}

--- a/src/NzbDrone.Core/ImportLists/ImportExclusions/ImportExclusionReason.cs
+++ b/src/NzbDrone.Core/ImportLists/ImportExclusions/ImportExclusionReason.cs
@@ -1,0 +1,12 @@
+namespace NzbDrone.Core.ImportLists.ImportExclusions
+{
+    public enum ImportExclusionReason
+    {
+        Manual,
+        Deleted,
+        PerformerExclusion,
+        StudioExcluded,
+        StudioAfterDate,
+        TagExclusion
+    }
+}

--- a/src/NzbDrone.Core/ImportLists/ImportExclusions/ImportExclusionReason.cs
+++ b/src/NzbDrone.Core/ImportLists/ImportExclusions/ImportExclusionReason.cs
@@ -3,9 +3,9 @@ namespace NzbDrone.Core.ImportLists.ImportExclusions
     public enum ImportExclusionReason
     {
         Manual,
-        Deleted,
+        DuringDelete,
         PerformerExclusion,
-        StudioExcluded,
+        StudioExclusion,
         StudioAfterDate,
         TagExclusion
     }

--- a/src/NzbDrone.Core/ImportLists/ImportExclusions/ImportListExclusion.cs
+++ b/src/NzbDrone.Core/ImportLists/ImportExclusions/ImportListExclusion.cs
@@ -4,13 +4,19 @@ namespace NzbDrone.Core.ImportLists.ImportExclusions
 {
     public class ImportListExclusion : ModelBase
     {
+        public ImportListExclusion()
+        {
+            Reason = ImportExclusionReason.Manual;
+        }
+
         public string ForeignId { get; set; }
         public string MovieTitle { get; set; }
         public ImportExclusionType Type { get; set; }
+        public ImportExclusionReason Reason { get; set; }
 
         public new string ToString()
         {
-            return string.Format("Exclusion: [{0}][{1}][{2}]", Type, ForeignId, MovieTitle);
+            return string.Format("Exclusion: [{0}-{1}] [{2}] [{3}]", Type, Reason, ForeignId, MovieTitle);
         }
     }
 }

--- a/src/NzbDrone.Core/Movies/AddMovieService.cs
+++ b/src/NzbDrone.Core/Movies/AddMovieService.cs
@@ -263,6 +263,7 @@ namespace NzbDrone.Core.Movies
                     {
                         if (_configService.WhisparrAlwaysExcludeStudiosTag.IsNullOrWhiteSpace())
                         {
+                            newExclusion.Reason = ImportExclusionReason.StudioExcluded;
                             _importListExclusionService.AddExclusion(newExclusion);
                             throw new ValidationException($"Studio: [{newMovie.MovieMetadata.Value.Studio.Title}] has been excluded");
                         }
@@ -288,6 +289,7 @@ namespace NzbDrone.Core.Movies
                             {
                                 if (_configService.WhisparrAlwaysExcludeStudiosAfterTag.IsNullOrWhiteSpace())
                                 {
+                                    newExclusion.Reason = ImportExclusionReason.StudioAfterDate;
                                     _importListExclusionService.AddExclusion(newExclusion);
                                     throw new ValidationException($"Studio After Date: [{newMovie.MovieMetadata.Value.Studio.Title}] has an after date of {dateTime.ToString("yyyy-MM-dd")}. Marking movie as unmonitored.");
                                 }
@@ -316,6 +318,7 @@ namespace NzbDrone.Core.Movies
                     {
                         if (_configService.WhisparrAlwaysExcludePerformersTag.IsNullOrWhiteSpace())
                         {
+                            newExclusion.Reason = ImportExclusionReason.PerformerExclusion;
                             _importListExclusionService.AddExclusion(newExclusion);
                             throw new ValidationException($"Performer: [{string.Join(",", excludedPerformers.Select(ep => ep.ToString()).ToList())}] has been excluded");
                         }
@@ -351,6 +354,7 @@ namespace NzbDrone.Core.Movies
                 {
                     if (_configService.WhisparrAlwaysExcludeTagsTag.IsNullOrWhiteSpace())
                     {
+                        newExclusion.Reason = ImportExclusionReason.TagExclusion;
                         _importListExclusionService.AddExclusion(newExclusion);
                         throw new ValidationException($"Tag(s): [{string.Join(",", exclusions.Select(et => et.ToString()).ToList())}] excluded");
                     }

--- a/src/NzbDrone.Core/Movies/AddMovieService.cs
+++ b/src/NzbDrone.Core/Movies/AddMovieService.cs
@@ -263,7 +263,7 @@ namespace NzbDrone.Core.Movies
                     {
                         if (_configService.WhisparrAlwaysExcludeStudiosTag.IsNullOrWhiteSpace())
                         {
-                            newExclusion.Reason = ImportExclusionReason.StudioExcluded;
+                            newExclusion.Reason = ImportExclusionReason.StudioExclusion;
                             _importListExclusionService.AddExclusion(newExclusion);
                             throw new ValidationException($"Studio: [{newMovie.MovieMetadata.Value.Studio.Title}] has been excluded");
                         }

--- a/src/Whisparr.Api.V3/ImportLists/ImportListExclusionController.cs
+++ b/src/Whisparr.Api.V3/ImportLists/ImportListExclusionController.cs
@@ -98,7 +98,8 @@ namespace Whisparr.Api.V3.ImportLists
                     "id",
                     "foreignId",
                     "movieTitle",
-                    "movieYear"
+                    "type",
+                    "reason"
                 },
                 "id",
                 SortDirection.Descending);

--- a/src/Whisparr.Api.V3/ImportLists/ImportListExclusionResource.cs
+++ b/src/Whisparr.Api.V3/ImportLists/ImportListExclusionResource.cs
@@ -10,6 +10,7 @@ namespace Whisparr.Api.V3.ImportLists
         public string ForeignId { get; set; }
         public string MovieTitle { get; set; }
         public ImportExclusionType Type { get; set; }
+        public ImportExclusionReason Reason { get; set; }
     }
 
     public static class ImportListExclusionResourceMapper
@@ -27,6 +28,7 @@ namespace Whisparr.Api.V3.ImportLists
                 ForeignId = model.ForeignId,
                 MovieTitle = model.MovieTitle,
                 Type = model.Type,
+                Reason = model.Reason,
             };
         }
 
@@ -43,6 +45,7 @@ namespace Whisparr.Api.V3.ImportLists
                 ForeignId = resource.ForeignId,
                 MovieTitle = resource.MovieTitle,
                 Type = resource.Type,
+                Reason = resource.Reason,
             };
         }
 

--- a/src/Whisparr.Api.V3/Performers/PerformerController.cs
+++ b/src/Whisparr.Api.V3/Performers/PerformerController.cs
@@ -206,7 +206,7 @@ namespace Whisparr.Api.V3.Performers
                 exclusion.ForeignId = performer.ForeignId;
                 exclusion.MovieTitle = performer.Name;
                 exclusion.Type = ImportExclusionType.Performer;
-                exclusion.Reason = ImportExclusionReason.Deleted;
+                exclusion.Reason = ImportExclusionReason.DuringDelete;
 
                 _exclusionService.AddExclusion(exclusion);
             }

--- a/src/Whisparr.Api.V3/Performers/PerformerController.cs
+++ b/src/Whisparr.Api.V3/Performers/PerformerController.cs
@@ -206,6 +206,7 @@ namespace Whisparr.Api.V3.Performers
                 exclusion.ForeignId = performer.ForeignId;
                 exclusion.MovieTitle = performer.Name;
                 exclusion.Type = ImportExclusionType.Performer;
+                exclusion.Reason = ImportExclusionReason.Deleted;
 
                 _exclusionService.AddExclusion(exclusion);
             }

--- a/src/Whisparr.Api.V3/Studios/StudioController.cs
+++ b/src/Whisparr.Api.V3/Studios/StudioController.cs
@@ -173,7 +173,7 @@ namespace Whisparr.Api.V3.Studios
                 exclusion.ForeignId = studio.ForeignId;
                 exclusion.MovieTitle = studio.Title;
                 exclusion.Type = ImportExclusionType.Studio;
-                exclusion.Reason = ImportExclusionReason.Deleted;
+                exclusion.Reason = ImportExclusionReason.DuringDelete;
 
                 _exclusionService.AddExclusion(exclusion);
             }

--- a/src/Whisparr.Api.V3/Studios/StudioController.cs
+++ b/src/Whisparr.Api.V3/Studios/StudioController.cs
@@ -173,6 +173,7 @@ namespace Whisparr.Api.V3.Studios
                 exclusion.ForeignId = studio.ForeignId;
                 exclusion.MovieTitle = studio.Title;
                 exclusion.Type = ImportExclusionType.Studio;
+                exclusion.Reason = ImportExclusionReason.Deleted;
 
                 _exclusionService.AddExclusion(exclusion);
             }


### PR DESCRIPTION
#### Database Migration
YES - 0014 

#### Description
Record why an exclusion was added, via a delete, manunual, or automatically via another exclusion, or rule after date on studio. Can help determine why there is an exclusion on a scene.

Testing delete and exclude some items and then refresh studios and performer to see scenes exclusions being automatically created with the reason recorded. Can explain if someone deletes and excludes a performer because they do not want to see them in whisparr but does not understand why scenes are missing / excluded.

#### Screenshot (if UI related)
<img width="1707" height="279" alt="image" src="https://github.com/user-attachments/assets/75a3e96b-bcd9-4217-be26-7b09ad1c0958" />

<img width="1705" height="413" alt="image" src="https://github.com/user-attachments/assets/33e2f1ff-fd5e-4fbb-8f25-4b231e1aa4ce" />

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes whisparr/whisparr#946