### PR TITLE
Fix: Remove the old monitor setting in local storage

### DIFF
--- a/frontend/src/Store/Migrators/migrateMonitorToEnum.js
+++ b/frontend/src/Store/Migrators/migrateMonitorToEnum.js
@@ -1,26 +1,7 @@
 import _ from 'lodash';
 
 export default function migrateMonitorToEnum(persistedState) {
-  const addMovie = _.get(persistedState, 'addMovie.movieDefaults.monitor');
-  const discoverMovie = _.get(persistedState, 'discoverMovie.movieDefaults.monitor');
-
-  if (addMovie) {
-    if (addMovie === 'true') {
-      persistedState.addMovie.movieDefaults.monitor = 'movieOnly';
-    }
-
-    if (addMovie === 'false') {
-      persistedState.addMovie.movieDefaults.monitor = 'none';
-    }
-  }
-
-  if (discoverMovie) {
-    if (discoverMovie === 'true') {
-      persistedState.discoverMovie.movieDefaults.monitor = 'movieOnly';
-    }
-
-    if (discoverMovie === 'false') {
-      persistedState.discoverMovie.movieDefaults.monitor = 'none';
-    }
-  }
+  _.remove(persistedState, 'addMovie.movieDefaults.monitor');
+  _.remove(persistedState, 'addMovie.performerDefaults.monitor');
+  _.remove(persistedState, 'addMovie.studioDefaults.monitor');
 }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Remove the old monitor drop-down value as it is causing issues on some clients. 

The new boolean is monitored.

Test by looking in the local storage before, then attempt to add a scene. 

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX