### PR TITLE
Fix:  Package early to support Hotio PR build containers

### DIFF
--- a/.github/actions/package/package.sh
+++ b/.github/actions/package/package.sh
@@ -1,9 +1,15 @@
 #!/bin/bash
 
+
 outputFolder=_output
 artifactsFolder=_artifacts
 uiFolder="$outputFolder/UI"
 framework="${FRAMEWORK:=net10.0}"
+
+
+# Sanitize BRANCH for safe file names (replace / with _)
+safeBranch="${BRANCH//\//_}"
+export SAFE_BRANCH="$safeBranch"
 
 rm -rf $artifactsFolder
 mkdir $artifactsFolder
@@ -13,7 +19,7 @@ do
   name="${runtime##*/}"
   folderName="$runtime/$framework"
   whisparrFolder="$folderName/Whisparr"
-  archiveName="Whisparr.$BRANCH.$WHISPARR_VERSION.$name"
+  archiveName="Whisparr.$safeBranch.$WHISPARR_VERSION.$name"
 
   if [[ "$name" == 'UI' ]]; then
     continue

--- a/.github/workflows/build_v3.yml
+++ b/.github/workflows/build_v3.yml
@@ -229,7 +229,6 @@ jobs:
           binary_path: ${{ matrix.binary_path }}
 
   deploy:
-    if: ${{ github.ref_name == 'eros-develop' || github.ref_name == 'eros' }}
     needs:
       [
         prepare,

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -62,6 +62,7 @@ jobs:
           version: ${{ inputs.version }}
 
   release:
+    if: ${{ github.ref_name == 'eros-develop' || github.ref_name == 'eros' }}
     needs: package
     runs-on: ubuntu-latest
     permissions:

--- a/distribution/windows/setup/build.bat
+++ b/distribution/windows/setup/build.bat
@@ -1,7 +1,8 @@
 @REM SET WHISPARR_MAJOR_VERSION=3
 @REM SET WHISPARR_VERSION=3.1.0.0
 @REM SET BRANCH=eros-develop
+@REM SET SAFE_BRANCH=eros-develop
 @REM SET FRAMEWORK=net10.0
 @REM SET RUNTIME=win-x64
 
-inno\ISCC.exe whisparr.iss
+inno\ISCC.exe /DSAFE_BRANCH="%SAFE_BRANCH%" whisparr.iss

--- a/distribution/windows/setup/whisparr.iss
+++ b/distribution/windows/setup/whisparr.iss
@@ -9,7 +9,7 @@
 #define BuildNumber "3.1"
 #define BuildNumber GetEnv('WHISPARR_VERSION')
 #define MajorVersion GetEnv('WHISPARR_MAJOR_VERSION')
-#define BranchName GetEnv('BRANCH')
+#define BranchName GetEnv('SAFE_BRANCH')
 #define Framework GetEnv('FRAMEWORK')
 #define Runtime GetEnv('RUNTIME')
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Hotio noted that the container builds for PR's were lacking the front end.  This was because the packaging was gated behind the commit to the repo, which happens on PR merge.  I moved the gate so that the build process does everything but the creation of the Release, so he can get the built packages from artifacts.

This PR should stop short of creating a release, but should create the packages.

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX