### PR TITLE
Fix: Browser 401 redirect to login form

### DIFF
--- a/src/NzbDrone.Host/Startup.cs
+++ b/src/NzbDrone.Host/Startup.cs
@@ -18,6 +18,7 @@ using NzbDrone.Common.EnvironmentInfo;
 using NzbDrone.Common.Instrumentation;
 using NzbDrone.Common.Processes;
 using NzbDrone.Common.Serializer;
+using NzbDrone.Core.Authentication;
 using NzbDrone.Core.Configuration;
 using NzbDrone.Core.Datastore;
 using NzbDrone.Core.Instrumentation;
@@ -197,8 +198,15 @@ namespace NzbDrone.Host
                     policy.RequireAuthenticatedUser();
                 });
 
+                // API key policy for API endpoints
+                options.AddPolicy("ApiKeyPolicy", policy =>
+                {
+                    policy.AuthenticationSchemes.Add("API");
+                    policy.RequireAuthenticatedUser();
+                });
+
                 // Require auth on everything except those marked [AllowAnonymous]
-                options.FallbackPolicy = new AuthorizationPolicyBuilder("API")
+                options.FallbackPolicy = new AuthorizationPolicyBuilder(nameof(AuthenticationType.Forms))
                 .RequireAuthenticatedUser()
                 .Build();
             });
@@ -280,6 +288,9 @@ namespace NzbDrone.Host
                 ExceptionHandler = errorHandler.HandleException
             });
 
+            // Middleware to rewrite 401+Location to 302 for browser requests
+            app.UseBrowserRedirect();
+
             app.UseRouting();
             app.UseCors();
 
@@ -320,6 +331,14 @@ namespace NzbDrone.Host
             app.UseEndpoints(x =>
             {
                 x.MapHub<MessageHub>("/signalr/messages").RequireAuthorization("SignalR");
+
+                // Map API v3 endpoints with API key policy
+                x.MapControllerRoute(
+                    name: "apiv3",
+                    pattern: "api/v3/{**slug}")
+                    .RequireAuthorization("ApiKeyPolicy");
+
+                // Map all other controllers (UI, etc.)
                 x.MapControllers();
             });
         }

--- a/src/Whisparr.Http/Authentication/ApiKeyAuthenticationHandler.cs
+++ b/src/Whisparr.Http/Authentication/ApiKeyAuthenticationHandler.cs
@@ -79,8 +79,17 @@ namespace Whisparr.Http.Authentication
 
         protected override Task HandleChallengeAsync(AuthenticationProperties properties)
         {
-            Response.StatusCode = 401;
-            return Task.CompletedTask;
+            var path = Request.Path.Value?.ToLowerInvariant() ?? string.Empty;
+
+            // Only return 401 for API or SignalR endpoints, otherwise let the next handler (e.g. Cookie) handle it
+            if (path.StartsWith("/api") || path.StartsWith("/signalr"))
+            {
+                Response.StatusCode = 401;
+                return Task.CompletedTask;
+            }
+
+            // For non-API requests, let the next handler (cookie/forms) handle the challenge
+            return base.HandleChallengeAsync(properties);
         }
 
         protected override Task HandleForbiddenAsync(AuthenticationProperties properties)

--- a/src/Whisparr.Http/Authentication/AuthenticationBuilderExtensions.cs
+++ b/src/Whisparr.Http/Authentication/AuthenticationBuilderExtensions.cs
@@ -46,20 +46,24 @@ namespace Whisparr.Http.Authentication
                     options.ReturnUrlParameter = "returnUrl";
                 });
 
-            return services.AddAuthentication()
-                .AddNone(nameof(AuthenticationType.None))
-                .AddExternal(nameof(AuthenticationType.External))
-                .AddCookie(nameof(AuthenticationType.Forms))
-                .AddApiKey("API", options =>
-                {
-                    options.HeaderName = "X-Api-Key";
-                    options.QueryName = "apikey";
-                })
-                .AddApiKey("SignalR", options =>
-                {
-                    options.HeaderName = "X-Api-Key";
-                    options.QueryName = "access_token";
-                });
+            return services.AddAuthentication(options =>
+            {
+                options.DefaultScheme = nameof(AuthenticationType.Forms);
+                options.DefaultChallengeScheme = nameof(AuthenticationType.Forms);
+            })
+            .AddNone(nameof(AuthenticationType.None))
+            .AddExternal(nameof(AuthenticationType.External))
+            .AddCookie(nameof(AuthenticationType.Forms))
+            .AddApiKey("API", options =>
+            {
+                options.HeaderName = "X-Api-Key";
+                options.QueryName = "apikey";
+            })
+            .AddApiKey("SignalR", options =>
+            {
+                options.HeaderName = "X-Api-Key";
+                options.QueryName = "access_token";
+            });
         }
     }
 }

--- a/src/Whisparr.Http/Middleware/BrowserRedirectMiddleware.cs
+++ b/src/Whisparr.Http/Middleware/BrowserRedirectMiddleware.cs
@@ -1,0 +1,42 @@
+using System.Linq;
+
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+
+namespace Whisparr.Http.Middleware
+{
+    /// <summary>
+    /// Middleware to convert 401+Location responses to 302 for browser (text/html) requests.
+    /// This ensures browsers are redirected to login instead of receiving a 401 with a Location header.
+    /// </summary>
+    public class BrowserRedirectMiddleware
+    {
+        private readonly RequestDelegate _next;
+
+        public BrowserRedirectMiddleware(RequestDelegate next)
+        {
+            _next = next;
+        }
+
+        public async Task InvokeAsync(HttpContext context)
+        {
+            await _next(context);
+
+            if (context.Response.StatusCode == 401 &&
+                context.Response.Headers.ContainsKey("Location") &&
+                context.Request.Headers["Accept"].Any(a => a.Contains("text/html")))
+            {
+                context.Response.StatusCode = 302;
+            }
+        }
+    }
+
+    public static class BrowserRedirectMiddlewareExtensions
+    {
+        public static IApplicationBuilder UseBrowserRedirect(this IApplicationBuilder builder)
+        {
+            return builder.UseMiddleware<BrowserRedirectMiddleware>();
+        }
+    }
+}


### PR DESCRIPTION
#### Database Migration
NO

#### Description
As reported on Discord, recent app updates broke the 401 redirect to the login page.  I found some quirks related to .NET 10 and the use of multiple middleware handlers (which we have), so ended up putting a shim in place to override the 401 if a higher layer set a Location (intended a redirect).  The API doesn't do this, so this should be safe for non-API requests (e.g., UI-only).

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes whisparr/whisparr#947