### PR TITLE
Fix: Redirect 401 to login page

### DIFF
--- a/src/NzbDrone.Host/Startup.cs
+++ b/src/NzbDrone.Host/Startup.cs
@@ -304,6 +304,7 @@ namespace NzbDrone.Host
             });
 
             app.UseAuthentication();
+            app.UseBrowserRedirect();  // workaround to convert 401 to 302 for browser requests
             app.UseAuthorization();
             app.UseResponseCompression();
             app.Properties["host.AppName"] = BuildInfo.AppName;

--- a/src/Whisparr.Http/Middleware/BrowserRedirectMiddleware.cs
+++ b/src/Whisparr.Http/Middleware/BrowserRedirectMiddleware.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+
+namespace Whisparr.Http.Middleware
+{
+    public class BrowserRedirectMiddleware
+    {
+        private readonly RequestDelegate _next;
+        private readonly ILogger<BrowserRedirectMiddleware> _logger;
+
+        public BrowserRedirectMiddleware(RequestDelegate next, ILogger<BrowserRedirectMiddleware> logger)
+        {
+            _next = next;
+            _logger = logger;
+        }
+
+        public async Task InvokeAsync(HttpContext context)
+        {
+            // Only act on browser requests (Accept: text/html), not /api or /signalr
+            var path = context.Request.Path.Value ?? string.Empty;
+            if (path.StartsWith("/api", StringComparison.OrdinalIgnoreCase) ||
+                path.StartsWith("/signalr", StringComparison.OrdinalIgnoreCase))
+            {
+                await _next(context);
+                return;
+            }
+
+            // Buffer the response
+            var originalBody = context.Response.Body;
+            using (var memStream = new System.IO.MemoryStream())
+            {
+                context.Response.Body = memStream;
+                await _next(context);
+                memStream.Position = 0;
+
+                // Check if we should redirect
+                var isBrowser = context.Request.Headers["Accept"].ToString().Contains("text/html", StringComparison.OrdinalIgnoreCase);
+                var is401 = context.Response.StatusCode == StatusCodes.Status401Unauthorized;
+                var hasLocation = context.Response.Headers.ContainsKey("Location");
+
+                if (isBrowser && is401 && hasLocation)
+                {
+                    var location = context.Response.Headers["Location"].ToString();
+                    _logger.LogDebug("BrowserRedirectMiddleware: Converting 401+Location to 302 for {Path} -> {Location}", path, location);
+                    context.Response.Clear();
+                    context.Response.StatusCode = StatusCodes.Status302Found;
+                    context.Response.Headers["Location"] = location;
+                }
+                else
+                {
+                    memStream.Position = 0;
+                    await memStream.CopyToAsync(originalBody);
+                }
+
+                context.Response.Body = originalBody;
+            }
+        }
+    }
+
+    public static class BrowserRedirectMiddlewareExtensions
+    {
+        public static Microsoft.AspNetCore.Builder.IApplicationBuilder UseBrowserRedirect(this Microsoft.AspNetCore.Builder.IApplicationBuilder builder)
+        {
+            return builder.UseMiddleware<BrowserRedirectMiddleware>();
+        }
+    }
+}


### PR DESCRIPTION
#### Database Migration
NO

#### Description
As reported on Discord, recent app updates broke the 401 redirect to the login page.  I found some quirks related to .NET 10 and the use of multiple middleware handlers (which we have), so ended up putting a shim in place to override the 401 if a higher layer set a Location (intended a redirect).  The API doesn't do this, so this should be safe for non-API requests (e.g., UI-only).

#### Tested
- Auth keys removed from config.xml
- AUth disabled (forces enablement
- Private tab redirects to login form
- API/integration tests pass locally

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes whisparr/whisparr#947