### PR TITLE
Fix: Update API Documentation Navigation

### DIFF
--- a/frontend/src/Helpers/Props/icons.ts
+++ b/frontend/src/Helpers/Props/icons.ts
@@ -30,6 +30,7 @@ import {
   faBan as fasBan,
   faBars as fasBars,
   faBolt as fasBolt,
+  faBook as faBook,
   faBookmark as fasBookmark,
   faBookReader as fasBookReader,
   faBroadcastTower as fasBroadcastTower,
@@ -161,6 +162,7 @@ export const COMPUTER = fasDesktop;
 export const DANGER = fasExclamationCircle;
 export const DELETE = fasTrashAlt;
 export const DISC = fasCompactDisc;
+export const DOCUMENTATION = faBook;
 export const DOWNLOAD = fasDownload;
 export const DOWNLOADED = fasDownload;
 export const DOWNLOADING = fasCloudDownloadAlt;

--- a/frontend/src/Settings/General/SecuritySettings.js
+++ b/frontend/src/Settings/General/SecuritySettings.js
@@ -241,10 +241,12 @@ class SecuritySettings extends Component {
                 key="apidocumentation"
                 kind={kinds.PRIMARY}
                 to="/docs"
+                target='_blank'
+                title={translate=('ApiDocumentation')}
                 noRouter={true}
               >
                 <Icon
-                  name={icons.UNKNOWN}
+                  name={icons.DOCUMENTATION}
                 />
               </FormInputButton>
             ]}

--- a/src/NzbDrone.Core/Localization/Core/en.json
+++ b/src/NzbDrone.Core/Localization/Core/en.json
@@ -95,6 +95,7 @@
   "AnnouncedMovieAvailabilityDescription": "Movies are considered available as soon as they are added to {appName}.",
   "AnnouncedMovieDescription": "Movie is announced",
   "Any": "Any",
+  "ApiDocumentation": "API Documentation",
   "ApiKey": "API Key",
   "ApiKeyValidationHealthCheckMessage": "Please update your API key to be at least {length} characters long. You can do this via settings or the config file",
   "AppDataDirectory": "AppData Directory",


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Tweak the API Documentation navigation.
- new window as it is not part of the Whisparr client.
- change icon Book as Documentation
- Hover text for what it is.

#### Screenshot (if UI related)
<img width="157" height="56" alt="image" src="https://github.com/user-attachments/assets/570af8c5-2a93-4884-90d6-1c1762a290e4" />

#### Todos
- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX