### PR TITLE
Fix: Performer API SQLite error on huge libraries

### DIFF
--- a/src/NzbDrone.Core/Movies/Performers/PerformerService.cs
+++ b/src/NzbDrone.Core/Movies/Performers/PerformerService.cs
@@ -76,7 +76,17 @@ namespace NzbDrone.Core.Movies.Performers
 
         public List<Performer> FindByForeignIds(List<string> foreignIds)
         {
-            return _performerRepo.FindByForeignIds(foreignIds);
+            // SQLite has a default variable limit of 999, so use a safe chunk size
+            // this prevents the API layer from triggering SQLite fauls based on UI requests
+            const int chunkSize = 500;
+            var results = new List<Performer>();
+            for (var i = 0; i < foreignIds.Count; i += chunkSize)
+            {
+                var chunk = foreignIds.Skip(i).Take(chunkSize).ToList();
+                results.AddRange(_performerRepo.FindByForeignIds(chunk));
+            }
+
+            return results;
         }
 
         public List<Performer> SearchPerformers(string query)

--- a/src/NzbDrone.Core/Movies/Studios/StudioService.cs
+++ b/src/NzbDrone.Core/Movies/Studios/StudioService.cs
@@ -120,7 +120,17 @@ namespace NzbDrone.Core.Movies.Studios
 
         public List<Studio> FindByForeignIds(List<string> foreignIds)
         {
-            return _studioRepo.FindByForeignIds(foreignIds);
+            // SQLite has a default variable limit of 999, so use a safe chunk size
+            // this prevents the API layer from triggering SQLite fauls based on UI requests
+            const int chunkSize = 500;
+            var results = new List<Studio>();
+            for (var i = 0; i < foreignIds.Count; i += chunkSize)
+            {
+                var chunk = foreignIds.Skip(i).Take(chunkSize).ToList();
+                results.AddRange(_studioRepo.FindByForeignIds(chunk));
+            }
+
+            return results;
         }
 
         public List<Studio> SearchStudios(string query)


### PR DESCRIPTION
Added batching to the API calls for "all performers" and "all studios" to prevent SQLite from choking on parameter count.

#### Database Migration
NO

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX