### PR TITLE
Fix: remove unused navigation path for importing scenes

### DIFF
--- a/frontend/src/RootFolder/RootFolderRow.tsx
+++ b/frontend/src/RootFolder/RootFolderRow.tsx
@@ -17,11 +17,10 @@ interface RootFolderRowProps {
   path: string;
   accessible: boolean;
   freeSpace?: number;
-  unmappedFolders: object[];
 }
 
 function RootFolderRow(props: RootFolderRowProps) {
-  const { id, path, accessible, freeSpace = 0, unmappedFolders = [] } = props;
+  const { id, path, accessible, freeSpace = 0 } = props;
 
   const isUnavailable = !accessible;
 
@@ -55,9 +54,7 @@ function RootFolderRow(props: RootFolderRowProps) {
             </Label>
           </div>
         ) : (
-          <Link className={styles.link} to={`/add/import/${id}`}>
-            {path}
-          </Link>
+          <Link className={styles.link}>{path}</Link>
         )}
       </TableRowCell>
 
@@ -65,10 +62,6 @@ function RootFolderRow(props: RootFolderRowProps) {
         {isUnavailable || isNaN(Number(freeSpace))
           ? '-'
           : formatBytes(freeSpace)}
-      </TableRowCell>
-
-      <TableRowCell className={styles.unmappedFolders}>
-        {isUnavailable ? '-' : unmappedFolders.length}
       </TableRowCell>
 
       <TableRowCell className={styles.actions}>

--- a/frontend/src/RootFolder/RootFolders.tsx
+++ b/frontend/src/RootFolder/RootFolders.tsx
@@ -23,11 +23,6 @@ const rootFolderColumns: Column[] = [
     isVisible: true,
   },
   {
-    name: 'unmappedFolders',
-    label: () => translate('UnmappedFolders'),
-    isVisible: true,
-  },
-  {
     name: 'actions',
     label: '',
     isVisible: true,
@@ -66,7 +61,6 @@ function RootFolders() {
               path={rootFolder.path}
               accessible={rootFolder.accessible}
               freeSpace={rootFolder.freeSpace}
-              unmappedFolders={rootFolder.unmappedFolders}
             />
           );
         })}


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Media Management had a navigation path for the root folders that did not do anything.

The Root Path showed unmapped folders that does not mean anything in Whisparr.

The link goes to a path that does not do anything.

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes whisparr/whisparr#970