### PR TITLE
Fix: Force scene title token in scene folder naming

### DIFF
--- a/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
@@ -52,6 +52,10 @@ namespace NzbDrone.Core.Organizer
         public static readonly Regex SceneFolderRegex = new Regex(@"(?<token>\{((?:(Studio|Original))(?<separator>[- ._])(Clean)?(Original)?(Title|Filename)(The)?)(?::(?<customFormat>[a-z0-9|]+))?\})",
                                                                             RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
+        // Matches any of the four scene title tokens: {Scene Title}, {Scene CleanTitle}, {Scene CleanTitleNoSeasonEpisode}, {Scene TitleThe}
+        public static readonly Regex SceneTitleTokenRegex = new Regex(@"\{Scene (Title|CleanTitle|CleanTitleNoSeasonEpisode|TitleThe)\}",
+                                          RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
         public static readonly Regex MainFolderRegex = new Regex(@"^(?<main>(?:[a-zA-Z0-9]+(?:\\|\/)))",
                                                                             RegexOptions.Compiled | RegexOptions.IgnoreCase);
 

--- a/src/NzbDrone.Core/Organizer/FileNameValidation.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameValidation.cs
@@ -37,15 +37,17 @@ namespace NzbDrone.Core.Organizer
             ruleBuilder.SetValidator(new NotEmptyValidator(null));
             ruleBuilder.SetValidator(new IllegalCharactersValidator());
 
-            return ruleBuilder.SetValidator(new RegularExpressionValidator(FileNameBuilder.SceneFolderRegex)).WithMessage("Must contain scene studio");
+            return ruleBuilder.SetValidator(new RegularExpressionValidator(FileNameBuilder.SceneFolderRegex)).WithMessage("Must contain scene studio token, ex. {Studio CleanTitle}");
         }
 
         public static IRuleBuilderOptions<T, string> ValidMainSceneFolderFormat<T>(this IRuleBuilder<T, string> ruleBuilder)
         {
             ruleBuilder.SetValidator(new NotEmptyValidator(null));
             ruleBuilder.SetValidator(new IllegalCharactersValidator());
-
-            return ruleBuilder.SetValidator(new RegularExpressionValidator(FileNameBuilder.MainFolderRegex)).WithMessage("Must start with a relative path inside root folder, ex. 'scenes/'");
+            ruleBuilder.SetValidator(new RegularExpressionValidator(FileNameBuilder.MainFolderRegex)).WithMessage("Must start with a relative path inside root folder, ex. 'scenes/'");
+            return ruleBuilder.Must(value =>
+                value is string s && FileNameBuilder.SceneTitleTokenRegex.IsMatch(s))
+                    .WithMessage("Must contain a Scene Title naming token, ex. {Scene CleanTitle}");
         }
 
         public static IRuleBuilderOptions<T, string> ValidSceneImportFolderFormat<T>(this IRuleBuilder<T, string> ruleBuilder)
@@ -61,7 +63,7 @@ namespace NzbDrone.Core.Organizer
             ruleBuilder.SetValidator(new NotEmptyValidator(null));
             ruleBuilder.SetValidator(new IllegalCharactersValidator());
 
-            return ruleBuilder.SetValidator(new RegularExpressionValidator(FileNameBuilder.SceneTitleRegex)).WithMessage("Must contain scene title");
+            return ruleBuilder.SetValidator(new RegularExpressionValidator(FileNameBuilder.SceneTitleRegex)).WithMessage("Must contain scene title, ex {Scene CleanTitle}");
         }
     }
 


### PR DESCRIPTION
Corrects a common misconfiguration where users want all scenes in a studio folder, but we require Radarr-style per-scene folders.  Accepts any of the 4 current scene tytle naming tokens.

#### Database Migration
NO

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX