### PR TITLE
Fix: macOS sporadic build failure

### DIFF
--- a/src/NzbDrone.Integration.Test/Client/ClientBase.cs
+++ b/src/NzbDrone.Integration.Test/Client/ClientBase.cs
@@ -73,7 +73,7 @@ namespace NzbDrone.Integration.Test.Client
             // cache control header gets reordered on net core
             var headers = response.Headers;
             ((string)headers.SingleOrDefault(c => c.Name == "Cache-Control")?.Value ?? string.Empty).Split(',').Select(x => x.Trim())
-                .Should().BeEquivalentTo("no-store, no-cache".Split(',').Select(x => x.Trim()));
+                .Should().BeEquivalentTo(new[] { "no-store", "no-cache" }, options => options.WithoutStrictOrdering());
             headers.Single(c => c.Name == "Pragma").Value.Should().Be("no-cache");
             headers.Single(c => c.Name == "Expires").Value.Should().Be("-1");
         }


### PR DESCRIPTION
Should fix the sporadic failure we were seeing on macOS builds related to thie cache control header.  The underlying cause was the header pair being out of an exppected order, but ultimately, that order shouldn't matter.

#### Database Migration
NO

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX