### PR TITLE
Chore: Hide chores on updates, fix maintenance URL

### DIFF
--- a/frontend/src/System/Updates/Updates.tsx
+++ b/frontend/src/System/Updates/Updates.tsx
@@ -208,7 +208,7 @@ function Updates() {
                       {formatDate(update.releaseDate, shortDateFormat)}
                     </div>
 
-                    {update.branch === 'master' ? null : (
+                    {update.branch === 'eros' ? null : (
                       <Label className={styles.label}>{update.branch}</Label>
                     )}
 
@@ -241,35 +241,34 @@ function Updates() {
                     ) : null}
                   </div>
 
-                  {/* Render release notes or changes or fallback */}
+                  {/* Render release notes, or maintenance URL as fallback */}
                   {(() => {
-                    if (typeof update.changes === 'string' && update.changes) {
-                      // If changes is a markdown string, render as markdown
-                      return (
-                        <UpdateChanges
-                          title={translate('New')}
-                          changes={[update.changes]}
-                        />
+                    if (
+                      update.changes &&
+                      typeof update.changes !== 'string' &&
+                      Array.isArray((update.changes as { new?: unknown }).new)
+                    ) {
+                      const nonEmptyLines = (
+                        (update.changes as { new?: unknown }).new as string[]
+                      ).filter(
+                        (line: string) =>
+                          typeof line === 'string' && line.trim() !== ''
                       );
-                    }
-                    if (update.changes && typeof update.changes === 'object') {
-                      return (
-                        <div>
-                          <UpdateChanges
-                            title={translate('New')}
-                            changes={update.changes.new}
-                          />
-                          <UpdateChanges
-                            title={translate('Fixed')}
-                            changes={update.changes.fixed}
-                          />
-                        </div>
-                      );
+                      if (nonEmptyLines.length > 0) {
+                        return (
+                          <div>
+                            <UpdateChanges
+                              title={translate('New')}
+                              changes={nonEmptyLines}
+                            />
+                          </div>
+                        );
+                      }
                     }
                     return (
                       <InlineMarkdown
                         data={translate('MaintenanceReleaseWithLink', {
-                          url: 'https://github.com/Whisparr/Whisparr-Eros/commits/eros/',
+                          url: `https://github.com/Whisparr/Whisparr-Eros/commits/${update.branch}`,
                         })}
                       />
                     );

--- a/src/NzbDrone.Core/Update/GithubUpdatePackageProvider.cs
+++ b/src/NzbDrone.Core/Update/GithubUpdatePackageProvider.cs
@@ -185,6 +185,14 @@ namespace NzbDrone.Core.Update
                 var body = release?.body != null
                     ? Regex.Replace(release.body, @"^## What's Changed\s*\r?\n", "", RegexOptions.Multiline)
                     : string.Empty;
+
+                // Strip out lines that are not New: or Fix:
+                body = string.Join("\n",
+                    body.Split('\n')
+                        .Where(line => line.StartsWith("- New", StringComparison.OrdinalIgnoreCase) ||
+                                       line.StartsWith("- Fix", StringComparison.OrdinalIgnoreCase))
+                        .Select(line => line.Trim()));
+
                 var version = SemVersion.Parse(tag);
                 if (version == null)
                 {


### PR DESCRIPTION
#### Database Migration
NO

#### Description
- Hide chores (anything not "new" or "fix" on updates page
- Fix maintenance URL to point at the commit lists' branch used for updates

This brings the GitHub provider updates view back in line with previous Servarr view.

I did this in the controller and frontend as the GitHub API returns this pre-formatted as Markdown, rather than a list.

#### Screenshot (if UI related)
<img width="1280" height="637" alt="image" src="https://github.com/user-attachments/assets/1451722e-21ac-4d2a-9cf1-3e5fc85aa3ca" />

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX