### PR TITLE
Fix: StashDB Import List fields not showing existing values

### DIFF
--- a/frontend/src/Components/Form/ProviderFieldFormGroup.tsx
+++ b/frontend/src/Components/Form/ProviderFieldFormGroup.tsx
@@ -55,6 +55,8 @@ function ProviderFieldFormGroup<T>({
         return 'captcha';
       case 'checkbox':
         return 'check';
+      case 'date':
+        return 'date';
       case 'device':
         return 'device';
       case 'keyValueList':

--- a/src/NzbDrone.Core/Datastore/Migration/017_migrate_stashdb_enum_fields.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/017_migrate_stashdb_enum_fields.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Text.Json;
+using FluentMigrator;
+using NzbDrone.Core.Datastore.Migration.Framework;
+using NzbDrone.Core.ImportLists.StashDB;
+
+namespace NzbDrone.Core.Datastore.Migration
+{
+    [Migration(017)]
+    public class migrate_stashdb_enum_fields : NzbDroneMigrationBase
+    {
+        protected override void MainDbUpgrade()
+        {
+            // Read all relevant rows into memory first, then update as needed (avoids holding SELECT open during UPDATE)
+            Execute.WithConnection((conn, tran) =>
+            {
+                var importLists = new System.Collections.Generic.List<(int Id, System.Text.Json.Nodes.JsonObject SettingsObj)>();
+                using (var cmd = conn.CreateCommand())
+                {
+                    cmd.CommandText = "SELECT \"Id\", \"Settings\", \"Implementation\" FROM \"ImportLists\" WHERE \"Implementation\" LIKE 'StashDB%'";
+                    using (var reader = cmd.ExecuteReader())
+                    {
+                        while (reader.Read())
+                        {
+                            var id = reader.GetInt32(0);
+                            var settingsJson = reader.GetString(1);
+
+                            var settingsObj = System.Text.Json.Nodes.JsonNode.Parse(settingsJson) as System.Text.Json.Nodes.JsonObject;
+                            importLists.Add((id, settingsObj));
+                        }
+                    }
+                }
+
+                foreach (var (id, settingsObj) in importLists)
+                {
+                    var changed = false;
+                    changed |= ConvertEnumField(settingsObj, "sort", typeof(SceneSort), id);
+                    changed |= ConvertEnumField(settingsObj, "studiosFilter", typeof(FilterModifier), id);
+                    changed |= ConvertEnumField(settingsObj, "tagsFilter", typeof(FilterModifier), id);
+                    changed |= ConvertEnumField(settingsObj, "filter", typeof(FavoriteFilter), id);
+
+                    if (changed)
+                    {
+                        var newJson = settingsObj.ToJsonString(new JsonSerializerOptions { WriteIndented = true });
+                        using (var updateCmd = conn.CreateCommand())
+                        {
+                            updateCmd.CommandText = "UPDATE \"ImportLists\" SET \"Settings\" = @settings WHERE \"Id\" = @id";
+                            var settingsParam = updateCmd.CreateParameter();
+                            settingsParam.ParameterName = "@settings";
+                            settingsParam.Value = newJson;
+                            updateCmd.Parameters.Add(settingsParam);
+
+                            var idParam = updateCmd.CreateParameter();
+                            idParam.ParameterName = "@id";
+                            idParam.Value = id;
+                            updateCmd.Parameters.Add(idParam);
+
+                            updateCmd.ExecuteNonQuery();
+                        }
+                    }
+                }
+            });
+        }
+
+        private static bool ConvertEnumField(object settings, string field, Type enumType, int id)
+        {
+            var obj = settings as System.Text.Json.Nodes.JsonObject;
+            if (obj == null || !obj.ContainsKey(field))
+            {
+                return false;
+            }
+
+            var valueNode = obj[field];
+            if (valueNode is System.Text.Json.Nodes.JsonValue jsonValue)
+            {
+                if (jsonValue.TryGetValue<string>(out var str))
+                {
+                    if (Enum.TryParse(enumType, str, true, out var enumValue))
+                    {
+                        obj[field] = (int)enumValue;
+                        Console.WriteLine($"[Migration] ImportList Id={id} Field={field} Converted '{str}' to {(int)enumValue}");
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/NzbDrone.Core/ImportLists/StashDB/Favorite/StashDBFavoriteRequestGenerator.cs
+++ b/src/NzbDrone.Core/ImportLists/StashDB/Favorite/StashDBFavoriteRequestGenerator.cs
@@ -43,7 +43,14 @@ namespace NzbDrone.Core.ImportLists.StashDB.Favorite
 
             Logger.Info(parameterLog);
 
-            var querySceneQuery = new QueryFavoriteSceneQuery(1, _pageSize, Settings.Filter, tags, Settings.TagsFilter, Settings.Sort, Settings.AfterDate);
+            var querySceneQuery = new QueryFavoriteSceneQuery(
+                1,
+                _pageSize,
+                (FavoriteFilter)Settings.Filter,
+                tags,
+                (FilterModifier)Settings.TagsFilter,
+                (SceneSort)Settings.Sort,
+                Settings.AfterDate);
 
             var requestBuilder = RequestBuilder
                                         .Create()

--- a/src/NzbDrone.Core/ImportLists/StashDB/Favorite/StashDBFavoriteSettings.cs
+++ b/src/NzbDrone.Core/ImportLists/StashDB/Favorite/StashDBFavoriteSettings.cs
@@ -19,12 +19,12 @@ namespace NzbDrone.Core.ImportLists.StashDB.Favorite
         protected override AbstractValidator<StashDBFavoriteSettings> Validator => new StashDBFavoriteSettingsValidator();
 
         [FieldDefinition(3, Label = "Favorite Filter", Type = FieldType.Select, SelectOptions = typeof(FavoriteFilter), HelpText = "Filter by favorited entity")]
-        public FavoriteFilter Filter { get; set; }
+        public int Filter { get; set; }
 
         [FieldDefinition(4, Label = "Tag StashIDs", HelpText = "Enter tag StashIDs, comma seperated  (Optional)")]
         public string Tags { get; set; }
 
         [FieldDefinition(5, Label = "Tags Filter", Type = FieldType.Select, SelectOptions = typeof(FilterModifier), HelpText = "Filter tags by")]
-        public FilterModifier TagsFilter { get; set; }
+        public int TagsFilter { get; set; }
     }
 }

--- a/src/NzbDrone.Core/ImportLists/StashDB/Performer/StashDBPerformerRequestGenerator.cs
+++ b/src/NzbDrone.Core/ImportLists/StashDB/Performer/StashDBPerformerRequestGenerator.cs
@@ -57,7 +57,17 @@ namespace NzbDrone.Core.ImportLists.StashDB.Performer
 
             Logger.Info($"Importing StashDB scenes for performers: {parameterLog}");
 
-            var querySceneQuery = new QueryPerformerSceneQuery(1, _pageSize, performers, studios, Settings.StudiosFilter, tags, Settings.TagsFilter, Settings.OnlyFavoriteStudios, Settings.Sort, Settings.AfterDate);
+            var querySceneQuery = new QueryPerformerSceneQuery(
+                1,
+                _pageSize,
+                performers,
+                studios,
+                (FilterModifier)Settings.StudiosFilter,
+                tags,
+                (FilterModifier)Settings.TagsFilter,
+                Settings.OnlyFavoriteStudios,
+                (SceneSort)Settings.Sort,
+                Settings.AfterDate);
 
             var requestBuilder = RequestBuilder
                                         .Create()

--- a/src/NzbDrone.Core/ImportLists/StashDB/Performer/StashDBPerformerSettings.cs
+++ b/src/NzbDrone.Core/ImportLists/StashDB/Performer/StashDBPerformerSettings.cs
@@ -22,22 +22,22 @@ namespace NzbDrone.Core.ImportLists.StashDB.Performer
     {
         protected override AbstractValidator<StashDBPerformerSettings> Validator => new StashDBPerformerSettingsValidator();
 
-        [FieldDefinition(3, Label = "Performers StashIDs",  HelpText = "Enter Performers StashIDs, comma seperated")]
+        [FieldDefinition(3, Label = "Performers StashIDs", HelpText = "Enter Performers StashIDs, comma seperated")]
         public string Performers { get; set; }
 
         [FieldDefinition(4, Label = "Studios StashIDs", HelpText = "Enter studios StashIDs, comma seperated (Optional)")]
         public string Studios { get; set; }
 
         [FieldDefinition(5, Label = "Studios Filter", Type = FieldType.Select, SelectOptions = typeof(FilterModifier), HelpText = "Filter studios by")]
-        public FilterModifier StudiosFilter { get; set; }
+        public int StudiosFilter { get; set; }
 
         [FieldDefinition(6, Label = "Tag StashIDs", HelpText = "Enter tag StashIDs, comma seperated  (Optional)")]
         public string Tags { get; set; }
 
         [FieldDefinition(7, Label = "Tags Filter", Type = FieldType.Select, SelectOptions = typeof(FilterModifier), HelpText = "Filter tags by")]
-        public FilterModifier TagsFilter { get; set; }
+        public int TagsFilter { get; set; }
 
-        [FieldDefinition(8, Label = "Only Favorite Studios", Type = FieldType.Checkbox,  HelpText = "Filter by favorite studios")]
+        [FieldDefinition(8, Label = "Only Favorite Studios", Type = FieldType.Checkbox, HelpText = "Filter by favorite studios")]
         public bool OnlyFavoriteStudios { get; set; }
     }
 }

--- a/src/NzbDrone.Core/ImportLists/StashDB/StashDBSettingsBase.cs
+++ b/src/NzbDrone.Core/ImportLists/StashDB/StashDBSettingsBase.cs
@@ -29,7 +29,7 @@ namespace NzbDrone.Core.ImportLists.StashDB
         public StashDBSettingsBase()
         {
             Limit = 100;
-            Sort = SceneSort.CREATED;
+            Sort = (int)SceneSort.CREATED;
             ApiKey = "";
             AfterDate = null;
         }
@@ -41,7 +41,7 @@ namespace NzbDrone.Core.ImportLists.StashDB
         public int Limit { get; set; }
 
         [FieldDefinition(2, Label = "Sort Date Descending", Type = FieldType.Select, SelectOptions = typeof(SceneSort), HelpText = "Descending sort by date style")]
-        public SceneSort Sort { get; set; }
+        public int Sort { get; set; }
 
         [FieldDefinition(2, Label = "Scenes Released after", Type = FieldType.Date, HelpText = "Scenes with the release date after")]
         public string AfterDate { get; set; }

--- a/src/NzbDrone.Core/ImportLists/StashDB/Studio/StashDBStudioRequestGenerator.cs
+++ b/src/NzbDrone.Core/ImportLists/StashDB/Studio/StashDBStudioRequestGenerator.cs
@@ -51,7 +51,15 @@ namespace NzbDrone.Core.ImportLists.StashDB.Studio
 
             Logger.Info($"Importing StashDB scenes for performers: {parameterLog}");
 
-            var querySceneQuery = new QueryStudioSceneQuery(1, _pageSize, studios, tags, Settings.TagsFilter, Settings.OnlyFavoritePerformers, Settings.Sort, Settings.AfterDate);
+            var querySceneQuery = new QueryStudioSceneQuery(
+                1,
+                _pageSize,
+                studios,
+                tags,
+                (FilterModifier)Settings.TagsFilter,
+                Settings.OnlyFavoritePerformers,
+                (SceneSort)Settings.Sort,
+                Settings.AfterDate);
 
             var requestBuilder = RequestBuilder
                                         .Create()

--- a/src/NzbDrone.Core/ImportLists/StashDB/Studio/StashDBStudioSettings.cs
+++ b/src/NzbDrone.Core/ImportLists/StashDB/Studio/StashDBStudioSettings.cs
@@ -29,9 +29,9 @@ namespace NzbDrone.Core.ImportLists.StashDB.Studio
         public string Tags { get; set; }
 
         [FieldDefinition(5, Label = "Tags Filter", Type = FieldType.Select, SelectOptions = typeof(FilterModifier), HelpText = "Filter tags by")]
-        public FilterModifier TagsFilter { get; set; }
+        public int TagsFilter { get; set; }
 
-        [FieldDefinition(6, Label = "Only Favorite Performers", Type = FieldType.Checkbox,  HelpText = "Filter by favorite performers")]
+        [FieldDefinition(6, Label = "Only Favorite Performers", Type = FieldType.Checkbox, HelpText = "Filter by favorite performers")]
         public bool OnlyFavoritePerformers { get; set; }
     }
 }

--- a/src/NzbDrone.Core/ImportLists/StashDB/Tags/StashDBTagsRequestGenerator.cs
+++ b/src/NzbDrone.Core/ImportLists/StashDB/Tags/StashDBTagsRequestGenerator.cs
@@ -43,7 +43,13 @@ namespace NzbDrone.Core.ImportLists.StashDB.Studio
 
             Logger.Info($"Importing StashDB scenes for performers: {parameterLog}");
 
-            var querySceneQuery = new QueryTagsSceneQuery(1, _pageSize, tags, Settings.TagsFilter, Settings.Sort, Settings.AfterDate);
+            var querySceneQuery = new QueryTagsSceneQuery(
+                1,
+                _pageSize,
+                tags,
+                (FilterModifier)Settings.TagsFilter,
+                (SceneSort)Settings.Sort,
+                Settings.AfterDate);
 
             var requestBuilder = RequestBuilder
                                         .Create()

--- a/src/NzbDrone.Core/ImportLists/StashDB/Tags/StashDBTagsSettings.cs
+++ b/src/NzbDrone.Core/ImportLists/StashDB/Tags/StashDBTagsSettings.cs
@@ -22,6 +22,6 @@ namespace NzbDrone.Core.ImportLists.StashDB.Studio
         public string Tags { get; set; }
 
         [FieldDefinition(5, Label = "Tags Filter", Type = FieldType.Select, SelectOptions = typeof(FilterModifier), HelpText = "Filter tags by")]
-        public FilterModifier TagsFilter { get; set; }
+        public int TagsFilter { get; set; }
     }
 }

--- a/src/NzbDrone.Core/Localization/Core/en.json
+++ b/src/NzbDrone.Core/Localization/Core/en.json
@@ -1726,6 +1726,7 @@
   "Refresh": "Refresh",
   "RefreshAndScan": "Refresh & Scan",
   "RefreshCollections": "Refresh Collections",
+  "Refreshed": "Refreshed",
   "RefreshInformationAndScanDisk": "Refresh information and scan disk",
   "RefreshLists": "Refresh Lists",
   "RefreshMonitoredIntervalHelpText": "How often to refresh monitored downloads from download clients, minimum 1 minute",


### PR DESCRIPTION
This is a byproduct of upstream refactoring of the SelectOptions definition (I believe).  The UI is expecting to work with enum int values, but this import list type is working with strings.  The strings were also stored in the DB that way.  This doesn't align with other import lists' settings.  In order to avoid a DB migration, I opted to fix the casting in the places these are used.

Going forward, the settings will be saved in line with *arr standards, but existing lists values already saved will be translated to avoid runtime errors.  If a user re-saves an existing list, it will be corrected to store the appropriate settings shape.

### To Test
- Back up DB
- Change docker tag to `ghcr.io/hotio/whisparr:v3-pr-fix-stashdb-import-list`
- Start container

Expected result
- UI should load normally
- Import lists should load when edited, fields like sort descening should show the existing values
- New lists should be add-able
- Re-saving an existing list should update the Settings column to store select list enums as int instead of string
- Saving a list should successfully trigger a refresh

#### Database Migration
NO

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes whisparr/whisparr#948