### PR TITLE
Fix: Extract Scene Screenshots as Posters for Notifications and Consumers

### DIFF
--- a/src/NzbDrone.Core/Extras/Metadata/Consumers/Roksbox/RoksboxMetadata.cs
+++ b/src/NzbDrone.Core/Extras/Metadata/Consumers/Roksbox/RoksboxMetadata.cs
@@ -136,7 +136,7 @@ namespace NzbDrone.Core.Extras.Metadata.Consumers.Roksbox
                 return new List<ImageFileResult>();
             }
 
-            var image = movie.MovieMetadata.Value.Images.FirstOrDefault(c => c.CoverType == MediaCoverTypes.Poster) ?? movie.MovieMetadata.Value.Images.FirstOrDefault();
+            var image = movie.MovieMetadata.Value.Poster ?? movie.MovieMetadata.Value.Images.FirstOrDefault();
             if (image == null)
             {
                 _logger.Trace("Failed to find suitable Movie image for movie {0}.", movie.Title);

--- a/src/NzbDrone.Core/Extras/Metadata/Consumers/Wdtv/WdtvMetadata.cs
+++ b/src/NzbDrone.Core/Extras/Metadata/Consumers/Wdtv/WdtvMetadata.cs
@@ -132,7 +132,7 @@ namespace NzbDrone.Core.Extras.Metadata.Consumers.Wdtv
             }
 
             // Because we only support one image, attempt to get the Poster type, then if that fails grab the first
-            var image = movie.MovieMetadata.Value.Images.FirstOrDefault(c => c.CoverType == MediaCoverTypes.Poster) ?? movie.MovieMetadata.Value.Images.FirstOrDefault();
+            var image = movie.MovieMetadata.Value.Poster ?? movie.MovieMetadata.Value.Images.FirstOrDefault();
             if (image == null)
             {
                 _logger.Trace("Failed to find suitable Movie image for movie {0}.", movie.Title);

--- a/src/NzbDrone.Core/Movies/MovieMetadata.cs
+++ b/src/NzbDrone.Core/Movies/MovieMetadata.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Equ;
 using NzbDrone.Core.Languages;
+using NzbDrone.Core.MediaCover;
 using NzbDrone.Core.MetadataSource.SkyHook.Resource;
 using NzbDrone.Core.Movies.AlternativeTitles;
 using NzbDrone.Core.Movies.Credits;
@@ -72,6 +74,18 @@ namespace NzbDrone.Core.Movies
 
                 return false;
             }
+        }
+
+        public MediaCover.MediaCover Poster
+        {
+            // Return Poster if exists, otherwise return Screenshot (Don't return any Fanart)
+            get { return Images.FirstOrDefault(c => c.CoverType == MediaCoverTypes.Poster) ?? Images.FirstOrDefault(i => i.CoverType == MediaCoverTypes.Screenshot); }
+        }
+
+        public MediaCover.MediaCover Fanart
+        {
+            // Return Poster if exists, otherwise return Screenshot (Don't return any Fanart)
+            get { return Images.FirstOrDefault(c => c.CoverType == MediaCoverTypes.Fanart); }
         }
     }
 

--- a/src/NzbDrone.Core/Notifications/Discord/Discord.cs
+++ b/src/NzbDrone.Core/Notifications/Discord/Discord.cs
@@ -55,7 +55,7 @@ namespace NzbDrone.Core.Notifications.Discord
             {
                 embed.Thumbnail = new DiscordImage
                 {
-                    Url = message.Movie.MovieMetadata.Value.Images.FirstOrDefault(x => x.CoverType == MediaCoverTypes.Poster)?.RemoteUrl
+                    Url = message.Movie.MovieMetadata.Value.Poster?.RemoteUrl
                 };
             }
 
@@ -63,7 +63,7 @@ namespace NzbDrone.Core.Notifications.Discord
             {
                 embed.Image = new DiscordImage
                 {
-                    Url = message.Movie.MovieMetadata.Value.Images.FirstOrDefault(x => x.CoverType == MediaCoverTypes.Fanart)?.RemoteUrl
+                    Url = message.Movie.MovieMetadata.Value.Fanart?.RemoteUrl
                 };
             }
 
@@ -159,7 +159,7 @@ namespace NzbDrone.Core.Notifications.Discord
             {
                 embed.Thumbnail = new DiscordImage
                 {
-                    Url = message.Movie.MovieMetadata.Value.Images.FirstOrDefault(x => x.CoverType == MediaCoverTypes.Poster)?.RemoteUrl
+                    Url = message.Movie.MovieMetadata.Value.Poster?.RemoteUrl
                 };
             }
 
@@ -167,7 +167,7 @@ namespace NzbDrone.Core.Notifications.Discord
             {
                 embed.Image = new DiscordImage
                 {
-                    Url = message.Movie.MovieMetadata.Value.Images.FirstOrDefault(x => x.CoverType == MediaCoverTypes.Fanart)?.RemoteUrl
+                    Url = message.Movie.MovieMetadata.Value.Fanart?.RemoteUrl
                 };
             }
 
@@ -273,7 +273,7 @@ namespace NzbDrone.Core.Notifications.Discord
             {
                 embed.Thumbnail = new DiscordImage
                 {
-                    Url = movie.MovieMetadata.Value.Images.FirstOrDefault(x => x.CoverType == MediaCoverTypes.Poster)?.RemoteUrl
+                    Url = movie.MovieMetadata.Value.Poster?.RemoteUrl
                 };
             }
 
@@ -281,7 +281,7 @@ namespace NzbDrone.Core.Notifications.Discord
             {
                 embed.Image = new DiscordImage
                 {
-                    Url = movie.MovieMetadata.Value.Images.FirstOrDefault(x => x.CoverType == MediaCoverTypes.Fanart)?.RemoteUrl
+                    Url = movie.MovieMetadata.Value.Fanart?.RemoteUrl
                 };
             }
 
@@ -330,7 +330,7 @@ namespace NzbDrone.Core.Notifications.Discord
             {
                 embed.Thumbnail = new DiscordImage
                 {
-                    Url = movie.MovieMetadata.Value.Images.FirstOrDefault(x => x.CoverType == MediaCoverTypes.Poster)?.RemoteUrl
+                    Url = movie.MovieMetadata.Value.Poster?.RemoteUrl
                 };
             }
 
@@ -338,7 +338,7 @@ namespace NzbDrone.Core.Notifications.Discord
             {
                 embed.Image = new DiscordImage
                 {
-                    Url = movie.MovieMetadata.Value.Images.FirstOrDefault(x => x.CoverType == MediaCoverTypes.Fanart)?.RemoteUrl
+                    Url = movie.MovieMetadata.Value.Fanart?.RemoteUrl
                 };
             }
 

--- a/src/NzbDrone.Core/Notifications/Gotify/Gotify.cs
+++ b/src/NzbDrone.Core/Notifications/Gotify/Gotify.cs
@@ -6,7 +6,6 @@ using FluentValidation.Results;
 using NLog;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Localization;
-using NzbDrone.Core.MediaCover;
 using NzbDrone.Core.Movies;
 
 namespace NzbDrone.Core.Notifications.Gotify
@@ -140,7 +139,7 @@ namespace NzbDrone.Core.Notifications.Gotify
             {
                 if (Settings.IncludeMoviePoster)
                 {
-                    var poster = movie.MovieMetadata.Value.Images.FirstOrDefault(x => x.CoverType == MediaCoverTypes.Poster)?.RemoteUrl;
+                    var poster = movie.MovieMetadata.Value.Poster?.RemoteUrl;
 
                     if (poster != null)
                     {

--- a/src/NzbDrone.Core/Notifications/Pushcut/Pushcut.cs
+++ b/src/NzbDrone.Core/Notifications/Pushcut/Pushcut.cs
@@ -2,7 +2,6 @@ using System.Collections.Generic;
 using System.Linq;
 using FluentValidation.Results;
 using NzbDrone.Common.Extensions;
-using NzbDrone.Core.MediaCover;
 using NzbDrone.Core.Movies;
 
 namespace NzbDrone.Core.Notifications.Pushcut
@@ -76,7 +75,7 @@ namespace NzbDrone.Core.Notifications.Pushcut
 
         private string GetPosterUrl(Movie movie)
         {
-            return movie.MovieMetadata.Value.Images.FirstOrDefault(x => x.CoverType == MediaCoverTypes.Poster)?.RemoteUrl;
+            return movie.MovieMetadata.Value.Poster?.RemoteUrl;
         }
 
         private List<NotificationMetadataLink> GetLinks(Movie movie)

--- a/src/Whisparr.Api.V3/ImportLists/ImportListMoviesController.cs
+++ b/src/Whisparr.Api.V3/ImportLists/ImportListMoviesController.cs
@@ -5,7 +5,6 @@ using NzbDrone.Core.Configuration;
 using NzbDrone.Core.ImportLists;
 using NzbDrone.Core.ImportLists.ImportExclusions;
 using NzbDrone.Core.ImportLists.ImportListMovies;
-using NzbDrone.Core.MediaCover;
 using NzbDrone.Core.MetadataSource;
 using NzbDrone.Core.Movies;
 using NzbDrone.Core.Organizer;
@@ -94,7 +93,7 @@ namespace Whisparr.Api.V3.ImportLists
             {
                 var resource = currentMovie.ToResource();
 
-                var poster = currentMovie.MovieMetadata.Value.Images.FirstOrDefault(c => c.CoverType == MediaCoverTypes.Poster);
+                var poster = currentMovie.MovieMetadata.Value.Poster;
                 if (poster != null)
                 {
                     resource.RemotePoster = poster.RemoteUrl;
@@ -117,7 +116,7 @@ namespace Whisparr.Api.V3.ImportLists
             {
                 var resource = currentMovie.ToResource();
 
-                var poster = currentMovie.MovieMetadata.Value.Images.FirstOrDefault(c => c.CoverType == MediaCoverTypes.Poster);
+                var poster = currentMovie.MovieMetadata.Value.Poster;
                 if (poster != null)
                 {
                     resource.RemotePoster = poster.RemoteUrl;

--- a/src/Whisparr.Api.V3/Movies/MovieLookupController.cs
+++ b/src/Whisparr.Api.V3/Movies/MovieLookupController.cs
@@ -102,7 +102,7 @@ namespace Whisparr.Api.V3.Movies
 
                 _coverMapper.ConvertToLocalUrls(resource.Id, resource.Images);
 
-                var poster = currentMovie.MovieMetadata.Value.Images.FirstOrDefault(c => c.CoverType == MediaCoverTypes.Poster);
+                var poster = currentMovie.MovieMetadata.Value.Poster;
                 if (poster != null)
                 {
                     resource.RemotePoster = poster.RemoteUrl;

--- a/src/Whisparr.Api.V3/Search/SearchController.cs
+++ b/src/Whisparr.Api.V3/Search/SearchController.cs
@@ -89,7 +89,7 @@ namespace Whisparr.Api.V3.Search
 
                     _coverMapper.ConvertToLocalUrls(movieResource.Id, movieResource.Images);
 
-                    var poster = movie.MovieMetadata.Value.Images.FirstOrDefault(c => c.CoverType == MediaCoverTypes.Poster);
+                    var poster = movie.MovieMetadata.Value.Poster;
                     if (poster != null)
                     {
                         movieResource.RemotePoster = poster.RemoteUrl;


### PR DESCRIPTION
#### Database Migration
 NO

#### Description
Refactor the Images so that a Poster is known either a Poster or a Screenshot.

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes whisparr/whisparr#986