### PR TITLE
Fix: Correct the Credit naming on new items

### DIFF
--- a/src/NzbDrone.Core.Test/MovieTests/MovieServiceTests/FindByTitleFixture.cs
+++ b/src/NzbDrone.Core.Test/MovieTests/MovieServiceTests/FindByTitleFixture.cs
@@ -20,17 +20,17 @@ namespace NzbDrone.Core.Test.MovieTests.MovieServiceTests
         [SetUp]
         public void Setup()
         {
-            var credits = new List<Credit> { new Credit { Character = "Quinn", Performer = new CreditPerformer { Name = "Quinn Waters", Gender = Gender.Female } } };
-            var otherCredits = new List<Credit> { new Credit { Character = "Carrie", Performer = new CreditPerformer { Name = "Carrie Sage", Gender = Gender.Female } } };
-            var dualCredits = new List<Credit> { new Credit { Character = "Quinn", Performer = new CreditPerformer { Name = "Quinn Waters", Gender = Gender.Female } }, new Credit { Character = "Carrie", Performer = new CreditPerformer { Name = "Carrie Sage", Gender = Gender.Female } } };
-            var differentCredits = new List<Credit> { new Credit { Character = "Angie", Performer = new CreditPerformer { Name = "Angela White", Gender = Gender.Female } } };
-            var invalidCredits = new List<Credit> { new Credit { Character = "Invalid", Performer = new CreditPerformer { Name = "Invalid Name", Gender = Gender.Female } } };
-            var bellaCredits = new List<Credit> { new Credit { Character = "", Performer = new CreditPerformer { Name = "Violet Myers", Gender = Gender.Female } }, new Credit { Character = "", Performer = new CreditPerformer { Name = "Victor Ray", Gender = Gender.Male } } };
-            var evilCredits = new List<Credit> { new Credit { Character = "", Performer = new CreditPerformer { Name = "Whitney Wright", Gender = Gender.Female } }, new Credit { Character = "", Performer = new CreditPerformer { Name = "Mick Blue", Gender = Gender.Male } } };
-            var ariAlectra = new List<Credit> { new Credit { Character = "", Performer = new CreditPerformer { Name = "Ari Alectra", Gender = Gender.Female } } };
-            var amhyraShy = new List<Credit> { new Credit { Character = "", Performer = new CreditPerformer { Name = "Amhyra Shy", Gender = Gender.Female } } };
-            var cocoLovelock = new List<Credit> { new Credit { Character = "Coco Lovecock", Performer = new CreditPerformer { Name = "Coco Lovelock", Gender = Gender.Female } }  };
-            var vixenCredits = new List<Credit> { new Credit { Character = "", Performer = new CreditPerformer { Name = "Emma White", Gender = Gender.Female } } };
+            var credits = new List<Credit> { new Credit { Character = "Quinn", PersonName = "Quinn Waters", Performer = new CreditPerformer { Name = "Quinn Waters", Gender = Gender.Female } } };
+            var otherCredits = new List<Credit> { new Credit { Character = "Carrie", PersonName = "Carrie Sage", Performer = new CreditPerformer { Name = "Carrie Sage", Gender = Gender.Female } } };
+            var dualCredits = new List<Credit> { new Credit { Character = "Quinn", PersonName = "Quinn Waters", Performer = new CreditPerformer { Name = "Quinn Waters", Gender = Gender.Female } }, new Credit { Character = "Carrie", PersonName = "Carrie Sage", Performer = new CreditPerformer { Name = "Carrie Sage", Gender = Gender.Female } } };
+            var differentCredits = new List<Credit> { new Credit { Character = "Angie", PersonName = "Angela White", Performer = new CreditPerformer { Name = "Angela White", Gender = Gender.Female } } };
+            var invalidCredits = new List<Credit> { new Credit { Character = "Invalid", PersonName = "Invalid Name", Performer = new CreditPerformer { Name = "Invalid Name", Gender = Gender.Female } } };
+            var bellaCredits = new List<Credit> { new Credit { Character = "", PersonName = "Violet Myers", Performer = new CreditPerformer { Name = "Violet Myers", Gender = Gender.Female } }, new Credit { Character = "", PersonName = "Victor Ray",  Performer = new CreditPerformer { Name = "Victor Ray", Gender = Gender.Male } } };
+            var evilCredits = new List<Credit> { new Credit { Character = "", PersonName = "Whitney Wright", Performer = new CreditPerformer { Name = "Whitney Wright", Gender = Gender.Female } }, new Credit { Character = "", PersonName = "Mick Blue", Performer = new CreditPerformer { Name = "Mick Blue", Gender = Gender.Male } } };
+            var ariAlectra = new List<Credit> { new Credit { Character = "", PersonName = "Ari Alectra", Performer = new CreditPerformer { Name = "Ari Alectra", Gender = Gender.Female } } };
+            var amhyraShy = new List<Credit> { new Credit { Character = "", PersonName = "Amhyra Shy", Performer = new CreditPerformer { Name = "Amhyra Shy", Gender = Gender.Female } } };
+            var cocoLovelock = new List<Credit> { new Credit { Character = "Coco Lovecock", PersonName = "Coco Lovelock", Performer = new CreditPerformer { Name = "Coco Lovelock", Gender = Gender.Female } } };
+            var vixenCredits = new List<Credit> { new Credit { Character = "", PersonName = "Emma White", Performer = new CreditPerformer { Name = "Emma White", Gender = Gender.Female } } };
 
             Mocker.GetMock<ICreditService>()
                 .Setup(s => s.GetAllCreditsForMovieMetadata(It.Is<int>(s => s.Equals(1))))

--- a/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/FileNameBuilderFixture.cs
+++ b/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/FileNameBuilderFixture.cs
@@ -25,6 +25,7 @@ namespace NzbDrone.Core.Test.OrganizerTests.FileNameBuilderTests
     public class FileNameBuilderFixture : CoreTest<FileNameBuilder>
     {
         private Movie _movie;
+        private Movie _addScene;
         private Movie _scene;
         private Movie _sceneLongTitle;
         private MovieFile _movieFile;
@@ -36,12 +37,12 @@ namespace NzbDrone.Core.Test.OrganizerTests.FileNameBuilderTests
             var studio = new Core.MetadataSource.SkyHook.Resource.StudioResource { Title = "Pure Taboo", Network = "Adult Time Originals" };
             var credits = new List<Credit>
             {
-                new Credit { Character = "Rissa", Performer = new CreditPerformer { Name = "Rissa May", Gender = Gender.Female } },
-                new Credit { Character = null, Performer = new CreditPerformer { Name = "Maddy O'Reilly", Gender = Gender.Female } },
-                new Credit { Character = "Chuck", Performer = new CreditPerformer { Name = "Charles Dera", Gender = Gender.Male } },
-                new Credit { Character = "Reagan", Performer = new CreditPerformer { Name = "Reagan Foxx", Gender = Gender.Female } },
-                new Credit { Character = "Axel", Performer = new CreditPerformer { Name = "Axel Haze", Gender = Gender.Male } },
-                new Credit { Character = null, Performer = new CreditPerformer { Name = "Manuel Ferrara", Gender = Gender.Male } }
+                new Credit { Character = "Rissa", PersonName = "Rissa May", Performer = new CreditPerformer { Name = "Rissa May", Gender = Gender.Female } },
+                new Credit { Character = null, PersonName = "Maddy O'Reilly", Performer = new CreditPerformer { Name = "Maddy O'Reilly", Gender = Gender.Female } },
+                new Credit { Character = "Chuck", PersonName = "Charles Dera", Performer = new CreditPerformer { Name = "Charles Dera", Gender = Gender.Male } },
+                new Credit { Character = "Reagan", PersonName = "Reagan Foxx", Performer = new CreditPerformer { Name = "Reagan Foxx", Gender = Gender.Female } },
+                new Credit { Character = "Axel", PersonName = "Axel Haze", Performer = new CreditPerformer { Name = "Axel Haze", Gender = Gender.Male } },
+                new Credit { Character = null, PersonName = "Manuel Ferrara", Performer = new CreditPerformer { Name = "Manuel Ferrara", Gender = Gender.Male } }
             };
 
             Mocker.GetMock<ICreditService>()
@@ -74,6 +75,21 @@ namespace NzbDrone.Core.Test.OrganizerTests.FileNameBuilderTests
                     .With(x => x.MovieMetadata.Value.StashId = "019abb52-0557-7c5f-83df-94b828851fd1")
                     .With(x => x.MovieMetadata.Value.ReleaseDate = "2025-11-25")
                     .With(x => x.MovieMetadata.Value.Id = 1)
+                    .With(x => x.MovieMetadata.Value.Studio = studio)
+                    .With(x => x.MovieMetadata.Value.StudioTitle = studio.Title)
+                    .With(x => x.MovieMetadata.Value.ItemType = ItemType.Scene)
+                    .Build();
+
+            // Scene just Added but not refreshed (saved to the database)
+            _addScene = Builder<Movie>
+                    .CreateNew()
+                    .With(s => s.Title = "The Last Train Home")
+                    .With(x => x.ForeignId = "019abb52-0557-7c5f-83df-94b828851fd1")
+                    .With(x => x.MovieMetadata.Value.ForeignId = "019abb52-0557-7c5f-83df-94b828851fd1")
+                    .With(x => x.MovieMetadata.Value.StashId = "019abb52-0557-7c5f-83df-94b828851fd1")
+                    .With(x => x.MovieMetadata.Value.ReleaseDate = "2025-11-25")
+                    .With(x => x.MovieMetadata.Value.Id = 2)
+                    .With(x => x.MovieMetadata.Value.Credits = credits)
                     .With(x => x.MovieMetadata.Value.Studio = studio)
                     .With(x => x.MovieMetadata.Value.StudioTitle = studio.Title)
                     .With(x => x.MovieMetadata.Value.ItemType = ItemType.Scene)
@@ -115,6 +131,10 @@ namespace NzbDrone.Core.Test.OrganizerTests.FileNameBuilderTests
             // Aliases should be used if present, otherwise fallback to real name.
             Subject.BuildFileName(_scene, _movieFile)
                 .Should().Be("Pure Taboo - 2025-11-25 - The Last Train Home [Axel Chuck Maddy O'Reilly Manuel Ferrara]");
+
+            // Scene that is adding (not yet refreshed) should also work
+            Subject.BuildFileName(_addScene, _movieFile)
+                .Should().Be("Pure Taboo - 2025-11-25 - The Last Train Home [Axel Chuck Maddy O'Reilly Manuel Ferrara]");
         }
 
         [Test]
@@ -124,6 +144,10 @@ namespace NzbDrone.Core.Test.OrganizerTests.FileNameBuilderTests
 
             // Aliases should be used if present, otherwise fallback to real name.
             Subject.BuildFileName(_scene, _movieFile)
+                .Should().Be("Pure Taboo - 2025-11-25 - The Last Train Home [Axel Chuck Maddy OReilly Manuel Ferrara]");
+
+            // Scene that is adding (not yet refreshed) should also work
+            Subject.BuildFileName(_addScene, _movieFile)
                 .Should().Be("Pure Taboo - 2025-11-25 - The Last Train Home [Axel Chuck Maddy OReilly Manuel Ferrara]");
         }
 
@@ -135,6 +159,9 @@ namespace NzbDrone.Core.Test.OrganizerTests.FileNameBuilderTests
             // Only female aliases, fallback to real name if alias is not present
             Subject.BuildFileName(_scene, _movieFile)
                 .Should().Be("Pure Taboo - 2025-11-25 - The Last Train Home [Maddy O'Reilly Reagan Rissa]");
+
+            Subject.BuildFileName(_addScene, _movieFile)
+                .Should().Be("Pure Taboo - 2025-11-25 - The Last Train Home [Maddy O'Reilly Reagan Rissa]");
         }
 
         [Test]
@@ -144,6 +171,10 @@ namespace NzbDrone.Core.Test.OrganizerTests.FileNameBuilderTests
 
             // Only female aliases, fallback to real name if alias is not present
             Subject.BuildFileName(_scene, _movieFile)
+                .Should().Be("Pure Taboo - 2025-11-25 - The Last Train Home [Maddy OReilly Reagan Rissa]");
+
+            // Scene that is adding (not yet refreshed) should also work
+            Subject.BuildFileName(_addScene, _movieFile)
                 .Should().Be("Pure Taboo - 2025-11-25 - The Last Train Home [Maddy OReilly Reagan Rissa]");
         }
 

--- a/src/NzbDrone.Core.Test/OrganizerTests/GetMovieFolderFixture.cs
+++ b/src/NzbDrone.Core.Test/OrganizerTests/GetMovieFolderFixture.cs
@@ -18,6 +18,7 @@ namespace NzbDrone.Core.Test.OrganizerTests
     {
         private NamingConfig _namingConfig;
         private Movie _scene;
+        private Movie _addScene;
 
         [SetUp]
         public void Setup()
@@ -28,21 +29,39 @@ namespace NzbDrone.Core.Test.OrganizerTests
 
             var credits = new List<Credit>
             {
-                new Credit { Character = "Rissa", Performer = new CreditPerformer { Name = "Rissa May", Gender = Gender.Female } },
-                new Credit { Character = null, Performer = new CreditPerformer { Name = "Maddy O'Reilly", Gender = Gender.Female } },
-                new Credit { Character = "Chuck", Performer = new CreditPerformer { Name = "Charles Dera", Gender = Gender.Male } },
-                new Credit { Character = "Reagan", Performer = new CreditPerformer { Name = "Reagan Foxx", Gender = Gender.Female } },
-                new Credit { Character = "Axel", Performer = new CreditPerformer { Name = "Axel Haze", Gender = Gender.Male } },
-                new Credit { Character = null, Performer = new CreditPerformer { Name = "Manuel Ferrara", Gender = Gender.Male } }
+                new Credit { Character = "Rissa", PersonName = "Rissa May", Performer = new CreditPerformer { Name = "Rissa May", Gender = Gender.Female } },
+                new Credit { Character = null, PersonName = "Maddy O'Reilly", Performer = new CreditPerformer { Name = "Maddy O'Reilly", Gender = Gender.Female } },
+                new Credit { Character = "Chuck", PersonName = "Charles Dera", Performer = new CreditPerformer { Name = "Charles Dera", Gender = Gender.Male } },
+                new Credit { Character = "Reagan", PersonName = "Reagan Foxx", Performer = new CreditPerformer { Name = "Reagan Foxx", Gender = Gender.Female } },
+                new Credit { Character = "Axel", PersonName = "Axel Haze", Performer = new CreditPerformer { Name = "Axel Haze", Gender = Gender.Male } },
+                new Credit { Character = null, PersonName = "Manuel Ferrara", Performer = new CreditPerformer { Name = "Manuel Ferrara", Gender = Gender.Male } }
             };
 
+            Mocker.GetMock<ICreditService>()
+                .Setup(s => s.GetAllCreditsForMovieMetadata(It.Is<int>(s => s.Equals(1))))
+                .Returns(credits);
+
             _scene = Builder<Movie>
+                    .CreateNew()
+                    .With(s => s.Title = "The Last Train Home")
+                    .With(x => x.ForeignId = "019abb52-0557-7c5f-83df-94b828851fd1")
+                    .With(x => x.MovieMetadata.Value.Id = 1)
+                    .With(x => x.MovieMetadata.Value.ForeignId = "019abb52-0557-7c5f-83df-94b828851fd1")
+                    .With(x => x.MovieMetadata.Value.StashId = "019abb52-0557-7c5f-83df-94b828851fd1")
+                    .With(x => x.MovieMetadata.Value.ReleaseDate = "2025-11-25")
+                    .With(x => x.MovieMetadata.Value.StudioForeignId = studio.ForeignId)
+                    .With(x => x.MovieMetadata.Value.StudioTitle = studio.Title)
+                    .With(x => x.MovieMetadata.Value.ItemType = ItemType.Scene)
+                    .Build();
+
+            _addScene = Builder<Movie>
                     .CreateNew()
                     .With(s => s.Title = "The Last Train Home")
                     .With(x => x.ForeignId = "019abb52-0557-7c5f-83df-94b828851fd1")
                     .With(x => x.MovieMetadata.Value.ForeignId = "019abb52-0557-7c5f-83df-94b828851fd1")
                     .With(x => x.MovieMetadata.Value.StashId = "019abb52-0557-7c5f-83df-94b828851fd1")
                     .With(x => x.MovieMetadata.Value.ReleaseDate = "2025-11-25")
+                    .With(x => x.MovieMetadata.Value.Credits = credits)
                     .With(x => x.MovieMetadata.Value.StudioForeignId = studio.ForeignId)
                     .With(x => x.MovieMetadata.Value.StudioTitle = studio.Title)
                     .With(x => x.MovieMetadata.Value.ItemType = ItemType.Scene)
@@ -75,6 +94,9 @@ namespace NzbDrone.Core.Test.OrganizerTests
             _namingConfig.SceneFolderFormat = format;
 
             Subject.GetMovieFolder(_scene).Should().Be(expected);
+
+            // Also test with a new Scene from Skyhook
+            Subject.GetMovieFolder(_addScene).Should().Be(expected);
         }
     }
 }

--- a/src/NzbDrone.Core/Datastore/TableMapping.cs
+++ b/src/NzbDrone.Core/Datastore/TableMapping.cs
@@ -175,7 +175,7 @@ namespace NzbDrone.Core.Datastore
                   Mapper.Entity<UpdateHistory>("UpdateHistory").RegisterModel();
 
                   Mapper.Entity<MovieMetadata>("MovieMetadata").RegisterModel()
-                    .Ignore(i => i.SearchCredits)
+                    .Ignore(i => i.Credits)
                     .Ignore(i => i.TagIds);
 
                   Mapper.Entity<Performer>("Performers").RegisterModel()

--- a/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
+++ b/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
@@ -1284,7 +1284,7 @@ namespace NzbDrone.Core.MetadataSource.SkyHook
 
                 foreach (var performer in result.Credits)
                 {
-                    movie.MovieMetadata.Value.SearchCredits.Add(MapCast(performer));
+                    movie.MovieMetadata.Value.Credits.Add(MapCast(performer));
                 }
 
                 movie.MovieMetadata.Value.PerformerNames = result.Credits.Select(c => c.Performer.Name).ToList();

--- a/src/NzbDrone.Core/Movies/MovieMetadata.cs
+++ b/src/NzbDrone.Core/Movies/MovieMetadata.cs
@@ -15,7 +15,7 @@ namespace NzbDrone.Core.Movies
         public MovieMetadata()
         {
             AlternativeTitles = new List<AlternativeTitle>();
-            SearchCredits = new List<Credit>();
+            Credits = new List<Credit>();
             Images = new List<MediaCover.MediaCover>();
             Genres = new List<string>();
             OriginalLanguage = Language.English;
@@ -60,7 +60,7 @@ namespace NzbDrone.Core.Movies
         public MetadataSource MetadataSource { get; set; }
         public List<string> PerformerForeignIds { get; set; }
         public List<string> PerformerNames { get; set; }
-        public List<Credit> SearchCredits { get; set; } // Only Used for searching Movie/Scene to provide cast info gender
+        public List<Credit> Credits { get; set; } // Either Passed from SkyHook or Loaded from the database
 
         [MemberwiseEqualityIgnore]
         public bool IsRecentMovie
@@ -78,7 +78,7 @@ namespace NzbDrone.Core.Movies
 
         public MediaCover.MediaCover Poster
         {
-            // Return Poster if exists, otherwise return Screenshot (Don't return any Fanart)
+           // Return Poster if exists, otherwise return Screenshot (Don't return any Fanart)
             get { return Images.FirstOrDefault(c => c.CoverType == MediaCoverTypes.Poster) ?? Images.FirstOrDefault(i => i.CoverType == MediaCoverTypes.Screenshot); }
         }
 

--- a/src/NzbDrone.Core/Movies/MovieService.cs
+++ b/src/NzbDrone.Core/Movies/MovieService.cs
@@ -757,15 +757,15 @@ namespace NzbDrone.Core.Movies
                     }
                 }
 
-                var credits = _creditService.GetAllCreditsForMovieMetadata(movie.MovieMetadata.Value.Id);
-
-                if (credits == null || !credits.Any())
+                if (!movie.MovieMetadata.Value.Credits.Any())
                 {
-                    continue;
+                    // Load the Credits if not already loaded
+                    movie.MovieMetadata.Value.Credits = _creditService.GetAllCreditsForMovieMetadata(movie.MovieMetadata.Value.Id);
                 }
 
-                var cleanPerformers =  credits.Select(a => Parser.Parser.NormalizeEpisodeTitle(a.Performer.Name))
-                                                                       .Where(x => x.IsNotNullOrWhiteSpace());
+                var cleanPerformers = movie.MovieMetadata.Value.Credits
+                    .Select(a => Parser.Parser.NormalizeEpisodeTitle(a.Performer.Name ?? a.PersonName))
+                    .Where(n => n.IsNotNullOrWhiteSpace());
 
                 if (cleanPerformers == null || cleanPerformers.Empty())
                 {
@@ -780,8 +780,9 @@ namespace NzbDrone.Core.Movies
                     continue;
                 }
 
-                var cleanCharacters = credits.Select(a => Parser.Parser.NormalizeEpisodeTitle(a.Character))
-                                                                        .Where(x => x.IsNotNullOrWhiteSpace());
+                var cleanCharacters = movie.MovieMetadata.Value.Credits
+                    .Select(a => Parser.Parser.NormalizeEpisodeTitle(a.Character))
+                    .Where(x => x.IsNotNullOrWhiteSpace());
 
                 // If parsed title matches character, consider a match
                 if (cleanCharacters.Any() && cleanCharacters.Any(c => c.IsNotNullOrWhiteSpace() && parsedMovieTitle.Equals(c)))
@@ -791,7 +792,7 @@ namespace NzbDrone.Core.Movies
                     continue;
                 }
 
-                var cleanFemalePerformers = credits.Where(a => a.Performer.Gender == Gender.Female)
+                var cleanFemalePerformers = movie.MovieMetadata.Value.Credits.Where(a => a.Performer.Gender == Gender.Female)
                                                                              .Select(a => Parser.Parser.NormalizeEpisodeTitle(a.Performer.Name))
                                                                              .Where(x => x.IsNotNullOrWhiteSpace()).ToList();
 
@@ -803,7 +804,7 @@ namespace NzbDrone.Core.Movies
                     continue;
                 }
 
-                var cleanFemaleCharacters = credits.Where(a => a.Performer.Gender == Gender.Female)
+                var cleanFemaleCharacters = movie.MovieMetadata.Value.Credits.Where(a => a.Performer.Gender == Gender.Female)
                                                                              .Select(a => Parser.Parser.NormalizeEpisodeTitle(a.Character))
                                                                              .Where(x => x.IsNotNullOrWhiteSpace()).ToList();
 

--- a/src/NzbDrone.Core/Movies/RefreshMovieService.cs
+++ b/src/NzbDrone.Core/Movies/RefreshMovieService.cs
@@ -146,6 +146,7 @@ namespace NzbDrone.Core.Movies
             movieMetadata.Ratings = movieInfo.Ratings;
             movieMetadata.ItemType = movieInfo.ItemType;
             movieMetadata.MetadataSource = movieInfo.MetadataSource;
+            movieMetadata.Credits = creditInfo; // Store credits for so they can be used for the initial naming
             movieMetadata.Genres = movieInfo.Genres;
             movieMetadata.Website = movieInfo.Website;
 
@@ -219,8 +220,13 @@ namespace NzbDrone.Core.Movies
             var performerList = performerInfo.Where(p => !string.IsNullOrWhiteSpace(p.ForeignId)).ToList();
             _performerService.AddPerformers(performerList, true);
 
+            // Reset flattened performer lists before repopulating
+            movieMetadata.PerformerForeignIds = new List<string>();
+            movieMetadata.PerformerNames = new List<string>();
+
             // Update the flattened performer lists on the movie metadata
             performerList.ForEach(performer => movieMetadata.PerformerForeignIds.Add(performer.ForeignId));
+
             creditInfo.ForEach(credit => movieMetadata.PerformerNames.Add(credit.PersonName));
 
             _movieMetadataService.Upsert(movieMetadata);

--- a/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
@@ -402,10 +402,22 @@ namespace NzbDrone.Core.Organizer
                 tokenHandlers["{Release Date}"] = m => "Unknown";
             }
 
-            var credits = _creditService.GetAllCreditsForMovieMetadata(movie.MovieMetadataId);
-
-            if (credits != null)
+            if (!movie.MovieMetadata.Value.Credits.Any())
             {
+                // Load the Credits if not already loaded
+                movie.MovieMetadata.Value.Credits = _creditService.GetAllCreditsForMovieMetadata(movie.MovieMetadataId);
+
+                // Make sure that Credits is not null
+                if (movie.MovieMetadata.Value.Credits == null)
+                {
+                    movie.MovieMetadata.Value.Credits = new List<Credit>();
+                }
+            }
+
+            if (movie.MovieMetadata.Value.Credits.Any())
+            {
+                var credits = movie.MovieMetadata.Value.Credits;
+
                 tokenHandlers["{Scene Performers}"] = m => credits.OrderBy(p => p.Performer.Name)
                     .Select(p => p.Performer.Name)
                     .Take(4)

--- a/src/Whisparr.Api.V3/Movies/MovieResource.cs
+++ b/src/Whisparr.Api.V3/Movies/MovieResource.cs
@@ -160,7 +160,7 @@ namespace Whisparr.Api.V3.Movies
                 MovieFile = movieFile,
                 StudioTitle = model.MovieMetadata.Value.StudioTitle,
                 StudioForeignId = model.MovieMetadata.Value.StudioForeignId,
-                SearchCredits = model.MovieMetadata.Value.SearchCredits,
+                SearchCredits = model.MovieMetadata.Value.Credits,
                 PerformerForeignIds = model.MovieMetadata.Value.PerformerForeignIds,
                 PerformerNames = model.MovieMetadata.Value.PerformerNames,
                 ItemType = model.MovieMetadata.Value.ItemType,


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Pass the Credits from SkyHook to the FileBuilder and Matching.

movie.MovieMetadata.Value.Credit will be used and loaded from the Credits table if and when required.

Elegant solution would have been to used the _creditServie within the Credits prop in MovieMetadata, but the service can not be passed.

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes whisparr/whisparr#989