### PR TITLE
Fix: Blacklist the URL for Whisparr V2 Metadata

### DIFF
--- a/src/NzbDrone.Core/Configuration/ConfigFileProvider.cs
+++ b/src/NzbDrone.Core/Configuration/ConfigFileProvider.cs
@@ -182,7 +182,9 @@ namespace NzbDrone.Core.Configuration
             {
                 const string defaultValue = "https://api.whisparr.com/v4/{route}";
                 var whisparrMetadata = GetValue("WhisparrMetadata", defaultValue);
-                if (string.IsNullOrWhiteSpace(whisparrMetadata))
+
+                // Do not allow the old v3 URL for Whisparr V2 Metadata
+                if (string.IsNullOrWhiteSpace(whisparrMetadata) || whisparrMetadata.Equals("https://api.whisparr.com/v3/{route}", StringComparison.InvariantCultureIgnoreCase))
                 {
                     return defaultValue;
                 }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Within V3 the "https://api.whisparr.com/v3/{route}" will be blacklisted, so that it is automatically set to the current default.

The Setting is still there to cover if the domain name goes down, and an alternate is used, eg. https://api.whisparr.porn/v4/{route}, and also local development of SkyHook.

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX