### PR TITLE
New: Batch background processing for movie updates in browser

### DIFF
--- a/frontend/src/Components/SignalRConnector.js
+++ b/frontend/src/Components/SignalRConnector.js
@@ -5,7 +5,7 @@ import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
 import { queryClient } from 'App/queryClient';
 import { setAppValue, setVersion } from 'Store/Actions/appActions';
-import { removeItem, update, updateItem } from 'Store/Actions/baseActions';
+import { removeItem, update, updateItem, updateItemsBatch } from 'Store/Actions/baseActions';
 import { fetchCommands, finishCommand, updateCommand } from 'Store/Actions/commandActions';
 import { fetchMovies } from 'Store/Actions/movieActions';
 import { fetchQueue, fetchQueueDetails } from 'Store/Actions/queueActions';
@@ -46,6 +46,7 @@ const mapDispatchToProps = {
   dispatchSetVersion: setVersion,
   dispatchUpdate: update,
   dispatchUpdateItem: updateItem,
+  dispatchUpdateItemsBatch: updateItemsBatch,
   dispatchRemoveItem: removeItem,
   dispatchFetchHealth: fetchHealth,
   dispatchFetchQualityDefinitions: fetchQualityDefinitions,
@@ -266,13 +267,28 @@ class SignalRConnector extends Component {
   };
 
   handleMovie = (body) => {
-    const action = body.action;
     const section = 'movies';
 
+    // Support batch payloads (Resources) and single (resource)
+    if (Array.isArray(body.resources) && body.resources.length > 0) {
+      // Batched update
+      if (body.action === 'updated') {
+        this.props.dispatchUpdateItemsBatch(body.resources.map((resource) => ({ section, ...resource })));
+        body.resources.forEach(updateMovieInPerformerWorksQueryCache);
+        repopulatePage('movieUpdated');
+      } else if (body.action === 'deleted') {
+        body.resources.forEach((resource) => {
+          this.props.dispatchRemoveItem({ section, id: resource.id });
+        });
+      }
+      repopulatePage('movieUpdated');
+      return;
+    }
+
+    // Fallback: single resource
+    const action = body.action;
     if (action === 'updated') {
       this.props.dispatchUpdateItem({ section, ...body.resource });
-
-      // TODO: temp shim for react-query until Movie is moved to React-Query
       updateMovieInPerformerWorksQueryCache(body.resource);
       repopulatePage('movieUpdated');
     } else if (action === 'deleted') {
@@ -466,6 +482,7 @@ SignalRConnector.propTypes = {
   dispatchSetAppValue: PropTypes.func.isRequired,
   dispatchSetVersion: PropTypes.func.isRequired,
   dispatchUpdate: PropTypes.func.isRequired,
+  dispatchUpdateItemsBatch: PropTypes.func.isRequired,
   dispatchUpdateItem: PropTypes.func.isRequired,
   dispatchRemoveItem: PropTypes.func.isRequired,
   dispatchFetchHealth: PropTypes.func.isRequired,

--- a/frontend/src/Store/Actions/baseActions.js
+++ b/frontend/src/Store/Actions/baseActions.js
@@ -7,6 +7,7 @@ export const SET = 'base/set';
 
 export const UPDATE = 'base/update';
 export const UPDATE_ITEM = 'base/updateItem';
+export const UPDATE_ITEMS_BATCH = 'base/updateItemsBatch';
 export const UPDATE_SERVER_SIDE_COLLECTION = 'base/updateServerSideCollection';
 
 export const SET_SETTING_VALUE = 'base/setSettingValue';
@@ -21,6 +22,7 @@ export const set = createAction(SET);
 
 export const update = createAction(UPDATE);
 export const updateItem = createAction(UPDATE_ITEM);
+export const updateItemsBatch = createAction(UPDATE_ITEMS_BATCH);
 export const updateServerSideCollection = createAction(UPDATE_SERVER_SIDE_COLLECTION);
 
 export const setSettingValue = createAction(SET_SETTING_VALUE);

--- a/frontend/src/Store/Actions/movieActions.js
+++ b/frontend/src/Store/Actions/movieActions.js
@@ -655,6 +655,20 @@ export const reducers = createHandleActions({
         ...payload
       }
     };
+  },
+  // Batch update handler: efficiently updates multiple items in one state edit
+  UPDATE_ITEMS_BATCH: (state, { payload }) => {
+    // payload: array of updated movie objects, each with an id
+    const updatedMap = {};
+    payload.forEach((item) => {
+      updatedMap[item.id] = item;
+    });
+    return {
+      ...state,
+      items: state.items.map((item) =>
+        (updatedMap[item.id] ? { ...item, ...updatedMap[item.id] } : item)
+      )
+    };
   }
 
 }, defaultState, section);

--- a/src/Whisparr.Api.V3/Movies/MovieController.cs
+++ b/src/Whisparr.Api.V3/Movies/MovieController.cs
@@ -294,8 +294,9 @@ namespace Whisparr.Api.V3.Movies
             foreach (var movie in updated)
             {
                 _movieResourcesCache.Remove(movie.Id.ToString());
-                BroadcastResourceChange(ModelAction.Updated, MapToResource(movie));
             }
+
+            BroadcastResourceChangeBatch(ModelAction.Updated, updated.Select(MapToResource));
 
             return Ok();
         }
@@ -370,7 +371,7 @@ namespace Whisparr.Api.V3.Movies
             resource.RootFolderPath = _rootFolderService.GetBestRootFolderPath(resource.Path);
 
             if (_useCache)
-        {
+            {
                 _movieResourcesCache.Set(resource.Id.ToString(), resource);
             }
 
@@ -507,17 +508,7 @@ namespace Whisparr.Api.V3.Movies
         [NonAction]
         public void Handle(MoviesDeletedEvent message)
         {
-            foreach (var movie in message.Movies)
-            {
-                _movieResourcesCache.Remove(movie.Id.ToString());
-                BroadcastResourceChange(ModelAction.Deleted, movie.Id);
-            }
-        }
-
-        [NonAction]
-        public void Handle(MoviesBulkEditedEvent message)
-        {
-            if (message?.Movies == null)
+            if (message?.Movies == null || !message.Movies.Any())
             {
                 return;
             }
@@ -525,8 +516,26 @@ namespace Whisparr.Api.V3.Movies
             foreach (var movie in message.Movies)
             {
                 _movieResourcesCache.Remove(movie.Id.ToString());
-                BroadcastResourceChange(ModelAction.Updated, MapToResource(movie));
             }
+
+            BroadcastResourceChangeBatch(ModelAction.Deleted, message.Movies.Select(m => new MovieResource { Id = m.Id }));
+        }
+
+        [NonAction]
+        public void Handle(MoviesBulkEditedEvent message)
+        {
+            if (message?.Movies == null || !message.Movies.Any())
+            {
+                return;
+            }
+
+            foreach (var movie in message.Movies)
+            {
+                _movieResourcesCache.Remove(movie.Id.ToString());
+            }
+
+            // Batch broadcast with mapped resources
+            BroadcastResourceChangeBatch(ModelAction.Updated, message.Movies.Select(MapToResource));
         }
 
         [NonAction]
@@ -599,7 +608,7 @@ namespace Whisparr.Api.V3.Movies
             {
                 var movieResource = _movieResourcesCache.Find(id.ToString());
                 if (movieResource == null)
-        {
+                {
                     missingIds.Add(id);
                 }
                 else
@@ -623,7 +632,7 @@ namespace Whisparr.Api.V3.Movies
                         _movieResourcesCache.Lock.Wait();
                         releaseLock = true;
                         if (stopwatch.Elapsed.TotalSeconds > 2)
-            {
+                        {
                             _logger.Warn($"Locked movie cache for {stopwatch.Elapsed.TotalSeconds} seconds");
                         }
 
@@ -679,7 +688,7 @@ namespace Whisparr.Api.V3.Movies
                             foreach (var moviesResource in moviesResources)
                             {
                                 _movieResourcesCache.Set(moviesResource.Id.ToString(), moviesResource);
-            }
+                            }
                         }
                     }
                 }

--- a/src/Whisparr.Http/REST/RestControllerWithSignalR.cs
+++ b/src/Whisparr.Http/REST/RestControllerWithSignalR.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using Microsoft.AspNetCore.Mvc;
 using NzbDrone.Core.Datastore;
@@ -11,6 +13,8 @@ namespace Whisparr.Http.REST
         where TResource : RestResource, new()
         where TModel : ModelBase, new()
     {
+        private const int DefaultBatchChunkSize = 50;
+
         protected string Resource { get; }
         private readonly IBroadcastSignalRMessage _signalRBroadcaster;
 
@@ -81,6 +85,56 @@ namespace Whisparr.Http.REST
 
                 _signalRBroadcaster.BroadcastMessage(signalRMessage);
             }
+        }
+
+        // New: Batch broadcast method with chunking
+        protected void BroadcastResourceChangeBatch(ModelAction action, IEnumerable<TResource> resources, int chunkSize = DefaultBatchChunkSize)
+        {
+            if (!_signalRBroadcaster.IsConnected)
+            {
+                return;
+            }
+
+            if (!GetType().Namespace.Contains("V3"))
+            {
+                return;
+            }
+
+            foreach (var chunk in Chunk(resources, chunkSize))
+            {
+                var signalRMessage = new SignalRMessage
+                {
+                    Name = Resource,
+                    Body = new ResourceChangeMessage<TResource>(chunk.ToList(), action),
+                    Action = action
+                };
+                _signalRBroadcaster.BroadcastMessage(signalRMessage);
+            }
+        }
+
+        // Helper: Chunk an IEnumerable<T> into batches
+        private static IEnumerable<IEnumerable<T>> Chunk<T>(IEnumerable<T> source, int size)
+        {
+            if (source == null)
+            {
+                yield break;
+            }
+
+            var enumerator = source.GetEnumerator();
+            while (enumerator.MoveNext())
+            {
+                yield return YieldChunkElements(enumerator, size);
+            }
+        }
+
+        private static IEnumerable<T> YieldChunkElements<T>(IEnumerator<T> source, int size)
+        {
+            var i = 0;
+            do
+            {
+                yield return source.Current;
+            }
+            while (++i < size && source.MoveNext());
         }
 
         protected void BroadcastResourceChange(ModelAction action)

--- a/src/Whisparr.Http/ResourceChangeMessage.cs
+++ b/src/Whisparr.Http/ResourceChangeMessage.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using NzbDrone.Core.Datastore.Events;
 using Whisparr.Http.REST;
 
@@ -8,6 +9,7 @@ namespace Whisparr.Http
         where TResource : RestResource
     {
         public TResource Resource { get; private set; }
+        public IReadOnlyList<TResource> Resources { get; private set; }
         public ModelAction Action { get; private set; }
 
         public ResourceChangeMessage(ModelAction action)
@@ -23,6 +25,17 @@ namespace Whisparr.Http
         public ResourceChangeMessage(TResource resource, ModelAction action)
         {
             Resource = resource;
+            Action = action;
+        }
+
+        public ResourceChangeMessage(IEnumerable<TResource> resources, ModelAction action)
+        {
+            if (resources == null)
+            {
+                throw new ArgumentNullException(nameof(resources));
+            }
+
+            Resources = new List<TResource>(resources);
             Action = action;
         }
     }


### PR DESCRIPTION
Moves some of the bulk update commands for Movie in SIgnalR to batch instead of one at a  time.  Should reduce hcurn and re-runders on bulk updates to Movies.

Test this in dev, this is a POC, specific to Movies, and within those, only items that previously iteracted a SignalR broadcast in a ForEach loop.  That includes bulk monitoring and the Scene/Movie index bulk edits.  The browser console will show SignalR events with 50-item payloads instead of one per movie/scene edit.

#### Database Migration
NO

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX