### PR TITLE
Fix: Harden Metadata API response handling

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -52,6 +52,9 @@ dotnet_diagnostic.IDE0005.severity = error
 dotnet_diagnostic.IDE0007.severity = error
 # Inline variable declaration
 dotnet_diagnostic.IDE0018.severity = error
+# Remove unused private members
+dotnet_code_quality_unused_parameters = non_public
+dotnet_diagnostic.IDE0060.severity = suggestion
 
 # Stylecop Rules
 dotnet_diagnostic.SA0001.severity = none

--- a/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
+++ b/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
@@ -506,7 +506,7 @@ namespace NzbDrone.Core.MetadataSource.SkyHook
             var tpdbIds = httpResponse.Resource.TpdbMovies;
             var tmpdIds = new List<int>();
 
-         // Check while Skyhook is transitioning to return TMDB company movies.
+            // Check while Skyhook is transitioning to return TMDB company movies.
             if (httpResponse.Resource.Movies != null)
             {
                 tmpdIds = httpResponse.Resource.Movies.ConvertAll(int.Parse);
@@ -529,6 +529,11 @@ namespace NzbDrone.Core.MetadataSource.SkyHook
 
         public MovieMetadata MapMovie(MovieResource resource)
         {
+            if (resource == null)
+            {
+                throw new ArgumentNullException(nameof(resource));
+            }
+
             var movie = new MovieMetadata();
             var altTitles = new List<AlternativeTitle>();
             var metadataSource = MapMetadataSource(resource.ItemType, resource.ForeignIds);
@@ -632,6 +637,11 @@ namespace NzbDrone.Core.MetadataSource.SkyHook
 
         public MovieMetadata MapMovieToTmdbMovie(MovieMetadata movie)
         {
+            if (movie == null)
+            {
+                throw new ArgumentNullException(nameof(movie));
+            }
+
             try
             {
                 var newMovie = movie;
@@ -876,7 +886,21 @@ namespace NzbDrone.Core.MetadataSource.SkyHook
 
                 var httpResponse = _httpClient.Get<List<MovieResource>>(request);
 
-                return httpResponse.Resource.SelectList(MapSearchResult);
+                return httpResponse.Resource
+                    .Select(resource =>
+                    {
+                        try
+                        {
+                            return MapSearchResult(resource);
+                        }
+                        catch (Exception ex)
+                        {
+                            _logger.Trace(ex, $"Failed to map search result for resource: {resource?.ToJson(Formatting.None)}");
+                            return null;
+                        }
+                    })
+                    .Where(x => x != null)
+                    .ToList();
             }
             catch (HttpException ex)
             {
@@ -967,7 +991,21 @@ namespace NzbDrone.Core.MetadataSource.SkyHook
 
                 var httpResponse = _httpClient.Get<List<MovieResource>>(request);
 
-                return httpResponse.Resource.SelectList(MapSearchResult);
+                return httpResponse.Resource
+                    .Select(resource =>
+                    {
+                        try
+                        {
+                            return MapSearchResult(resource);
+                        }
+                        catch (Exception ex)
+                        {
+                            _logger.Trace(ex, $"Failed to map TPDB search result for resource: {resource?.ToJson(Formatting.None)}");
+                            return null;
+                        }
+                    })
+                    .Where(x => x != null)
+                    .ToList();
             }
             catch (HttpException ex)
             {
@@ -1039,7 +1077,21 @@ namespace NzbDrone.Core.MetadataSource.SkyHook
 
                 var httpResponse = _httpClient.Get<List<MovieResource>>(request);
 
-                return httpResponse.Resource.SelectList(MapSearchResult);
+                return httpResponse.Resource
+                    .Select(resource =>
+                    {
+                        try
+                        {
+                            return MapSearchResult(resource);
+                        }
+                        catch (Exception ex)
+                        {
+                            _logger.Trace(ex, $"Failed to map Scene search result for resource: {resource?.ToJson(Formatting.None)}");
+                            return null;
+                        }
+                    })
+                    .Where(x => x != null)
+                    .ToList();
             }
             catch (UnexpectedHtmlContentException ex)
             {
@@ -1240,25 +1292,27 @@ namespace NzbDrone.Core.MetadataSource.SkyHook
 
         public Movies.MetadataSource MapMetadataSource(ItemType itemType, ExternalIdResource externalIdResource)
         {
-            if (itemType == ItemType.Movie)
+            if (externalIdResource == null)
             {
-                if (externalIdResource.TpdbId.IsNotNullOrWhiteSpace())
-                {
-                    return Movies.MetadataSource.TpdbMovie;
-                }
-                else
-                {
-                    return Movies.MetadataSource.Tmdb;
-                }
+                return itemType == ItemType.Movie ? Movies.MetadataSource.Tmdb : Movies.MetadataSource.Stash;
             }
-            else
+
+            return itemType switch
             {
-                return Movies.MetadataSource.Stash;
-            }
+                ItemType.Movie => !string.IsNullOrWhiteSpace(externalIdResource.TpdbId)
+                    ? Movies.MetadataSource.TpdbMovie
+                    : Movies.MetadataSource.Tmdb,
+                _ => Movies.MetadataSource.Stash
+            };
         }
 
         public static string MapForeignId(Movies.MetadataSource metadataSource, ExternalIdResource externalIdResource)
         {
+            if (externalIdResource == null)
+            {
+                throw new ArgumentNullException(nameof(externalIdResource));
+            }
+
             if (metadataSource == Movies.MetadataSource.Tmdb)
             {
                 return externalIdResource.TmdbId.ToString();
@@ -1275,6 +1329,11 @@ namespace NzbDrone.Core.MetadataSource.SkyHook
 
         private Movie MapSearchResult(MovieResource result)
         {
+            if (result == null)
+            {
+                throw new ArgumentNullException(nameof(result));
+            }
+
             var foreignId = MapForeignId(MapMetadataSource(result.ItemType, result.ForeignIds), result.ForeignIds);
             var movie = _movieService.FindByForeignId(foreignId);
 
@@ -1294,40 +1353,50 @@ namespace NzbDrone.Core.MetadataSource.SkyHook
             return movie;
         }
 
-        private MovieCollection MapCollection(CollectionResource arg)
+        private MovieCollection MapCollection(CollectionResource collectionResource)
         {
+            if (collectionResource == null)
+            {
+                throw new ArgumentNullException(nameof(collectionResource));
+            }
+
             var collection = new MovieCollection
             {
-                TmdbId = arg.ForeignIds.TmdbId,
-                Title = arg.Name,
-                Overview = arg.Overview,
-                CleanTitle = arg.Name.CleanMovieTitle(),
-                SortTitle = Parser.Parser.NormalizeTitle(arg.Name),
-                Images = arg.Images?.Select(MapImage).ToList() ?? new List<MediaCover.MediaCover>(),
-                Movies = arg.Parts?.Select(x => MapMovie(x)).ToList() ?? new List<MovieMetadata>()
+                TmdbId = collectionResource.ForeignIds.TmdbId,
+                Title = collectionResource.Name,
+                Overview = collectionResource.Overview,
+                CleanTitle = collectionResource.Name.CleanMovieTitle(),
+                SortTitle = Parser.Parser.NormalizeTitle(collectionResource.Name),
+                Images = collectionResource.Images?.Select(MapImage).ToList() ?? new List<MediaCover.MediaCover>(),
+                Movies = collectionResource.Parts?.Select(x => MapMovie(x)).ToList() ?? new List<MovieMetadata>()
             };
 
             return collection;
         }
 
-        private static Credit MapCast(CastResource arg)
+        private static Credit MapCast(CastResource castResource)
         {
+            if (castResource == null)
+            {
+                throw new ArgumentNullException(nameof(castResource));
+            }
+
             var newActor = new Credit
             {
-                PersonName = arg.PersonName.IsNotNullOrWhiteSpace() ? arg.PersonName : arg.Performer.Name,
-                Character = arg.Character,
-                Order = arg.Order,
+                PersonName = castResource.PersonName.IsNotNullOrWhiteSpace() ? castResource.PersonName : castResource.Performer.Name,
+                Character = castResource.Character,
+                Order = castResource.Order,
                 Type = CreditType.Cast,
-                Images = arg.Performer.Images.Select(MapImage).ToList(),
-                PerformerForeignId = arg.Performer.ForeignIds.StashId,
+                Images = castResource.Performer.Images.Select(MapImage).ToList(),
+                PerformerForeignId = castResource.Performer.ForeignIds.StashId,
 
                 // To Remove once client uses the Credit Controller
                 Performer = new CreditPerformer
                 {
-                    Name = arg.Performer.Name,
-                    ForeignId = arg.Performer.ForeignIds.StashId.ToString(),
-                    Images = arg.Performer.Images.Select(MapImage).ToList(),
-                    Gender = MapGender(arg.Performer.Gender)
+                    Name = castResource.Performer.Name,
+                    ForeignId = castResource.Performer.ForeignIds.StashId.ToString(),
+                    Images = castResource.Performer.Images.Select(MapImage).ToList(),
+                    Gender = MapGender(castResource.Performer.Gender)
                 }
             };
 
@@ -1336,6 +1405,11 @@ namespace NzbDrone.Core.MetadataSource.SkyHook
 
         private Performer MapPerformer(PerformerResource performer)
         {
+            if (performer == null)
+            {
+                throw new ArgumentNullException(nameof(performer));
+            }
+
             var newPerformer = new Performer
             {
                 Name = performer.Name,
@@ -1438,62 +1512,79 @@ namespace NzbDrone.Core.MetadataSource.SkyHook
             }
         }
 
-        private static AlternativeTitle MapAlternativeTitle(AlternativeTitleResource arg)
+        private static AlternativeTitle MapAlternativeTitle(AlternativeTitleResource altTitleResource)
         {
+            if (altTitleResource == null)
+            {
+                throw new ArgumentNullException(nameof(altTitleResource));
+            }
+
             var newAlternativeTitle = new AlternativeTitle
             {
-                Title = arg.Title,
-                SourceType = arg.Type,
-                CleanTitle = arg.Title.CleanMovieTitle()
+                Title = altTitleResource.Title,
+                SourceType = altTitleResource.Type,
+                CleanTitle = altTitleResource.Title.CleanMovieTitle()
             };
 
             return newAlternativeTitle;
         }
 
-        private Studio MapStudio(StudioResource studio)
+        private Studio MapStudio(StudioResource studioResource)
         {
+            if (studioResource == null)
+            {
+                throw new ArgumentNullException(nameof(studioResource));
+            }
+
             // Do not Map the Studio if it has not mapped to a StashDB studio. For Movies as the name is stored in the movie Metadata.
-            if (string.IsNullOrEmpty(studio?.ForeignIds?.StashId))
+            if (string.IsNullOrEmpty(studioResource?.ForeignIds?.StashId))
             {
                 return null;
             }
 
             var newStudio = new Studio
             {
-                Title = studio.Title,
-                CleanTitle = studio.Title.CleanStudioTitle(),
-                SortTitle = Parser.Parser.NormalizeTitle(studio.Title),
-                Aliases = studio.Aliases,
-                Website = studio.Homepage,
-                ForeignId = studio.ForeignIds.StashId,
-                TpdbId = studio.ForeignIds.TpdbId,
-                TmdbId = studio.ForeignIds.TmdbId,
-                Network = studio.Network,
-                Images = studio.Images?.Select(MapImage).ToList() ?? new List<MediaCover.MediaCover>(),
-                Status = studio.Status
+                Title = studioResource.Title,
+                CleanTitle = studioResource.Title.CleanStudioTitle(),
+                SortTitle = Parser.Parser.NormalizeTitle(studioResource.Title),
+                Aliases = studioResource.Aliases,
+                Website = studioResource.Homepage,
+                ForeignId = studioResource.ForeignIds.StashId,
+                TpdbId = studioResource.ForeignIds.TpdbId,
+                TmdbId = studioResource.ForeignIds.TmdbId,
+                Network = studioResource.Network,
+                Images = studioResource.Images?.Select(MapImage).ToList() ?? new List<MediaCover.MediaCover>(),
+                Status = studioResource.Status
             };
 
             return newStudio;
         }
 
-        private static Credit MapSceneCast(CastResource arg, string sceneForeignId)
+        private static Credit MapSceneCast(CastResource castResource, string sceneForeignId)
         {
+            // TODO: Remove sceneForeignId?  Not in use
+
+            if (castResource == null)
+            {
+                throw new ArgumentNullException(nameof(castResource));
+            }
+
             var newActor = new Credit
             {
-                PersonName = arg.Performer.Name,
-                Character = arg.Character,
-                Order = arg.Order,
+                PersonName = castResource.Performer.Name,
+                Character = castResource.Character,
+                Order = castResource.Order,
                 Type = CreditType.Cast,
-                Images = arg.Performer.Images.Select(MapImage).ToList(),
-                PerformerForeignId = arg.Performer.ForeignIds.StashId,
+                Images = castResource.Performer.Images.Select(MapImage).ToList(),
+                PerformerForeignId = castResource.Performer.ForeignIds.StashId,
 
                 // To Remove once client uses the Credit Controller
                 Performer = new CreditPerformer
                 {
-                    Name = arg.Performer.Name,
-                    ForeignId = arg.Performer.ForeignIds.StashId,
-                    Images = arg.Performer.Images?.Select(MapImage).ToList() ?? new List<MediaCover.MediaCover>(),
-                    Gender = MapGender(arg.Performer.Gender)
+                    Name = castResource.Performer.Name,
+                    ForeignId = castResource.Performer.ForeignIds.StashId,
+                    Images = castResource.Performer.Images?.Select(MapImage).ToList() ?? new List<MediaCover.MediaCover>(),
+                    Gender = MapGender(castResource.Performer.Gender)
                 }
             };
 
@@ -1522,12 +1613,17 @@ namespace NzbDrone.Core.MetadataSource.SkyHook
             return mappedRatings;
         }
 
-        private static MediaCover.MediaCover MapImage(ImageResource arg)
+        private static MediaCover.MediaCover MapImage(ImageResource imageResource)
         {
+            if (imageResource == null)
+            {
+                throw new ArgumentNullException(nameof(imageResource));
+            }
+
             return new MediaCover.MediaCover
             {
-                RemoteUrl = arg.Url,
-                CoverType = MapCoverType(arg.CoverType)
+                RemoteUrl = imageResource.Url,
+                CoverType = MapCoverType(imageResource.CoverType)
             };
         }
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
SkyHook’s API response processing mapping methods assumed perfect responses, suitable for single-item queries but inadequate for lists.  If any item fails to map, the whole thing fails. To address this, SkyHookProxy now employs a dual approach:

- Added explicit null-checks for mapping methods that use classes as input parameters.  This solves any potential NRE's when binding properties from the input param.
- Moved away from LINQ `SelectList` iterators in favor of per-item `try...catch `when iterating a list.  This combined with the null-check throws should result in both more predictable results and better exception logging.

Also added a suggestion in .editorconfig to surface unused method params.  It them appear "dim" and they show a tooltip on hover.  See screenshot on PR.

#### Screenshot
<img width="797" height="204" alt="image" src="https://github.com/user-attachments/assets/d40c0629-c3e3-4b24-88e8-72bc68efe83f" />

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

- Fixes whisparr/whisparr#994
- Fixes whisparr/whisparr#995