### PR TITLE
Fix: Media cover handling for Performers, Studios

### DIFF
--- a/src/NzbDrone.Core/MediaCover/MediaCoverService.cs
+++ b/src/NzbDrone.Core/MediaCover/MediaCoverService.cs
@@ -42,6 +42,8 @@ namespace NzbDrone.Core.MediaCover
         IHandleAsync<PerformerUpdatedEvent>,
         IHandleAsync<StudioUpdatedEvent>,
         IHandleAsync<MoviesDeletedEvent>,
+        IHandleAsync<PerformersDeletedEvent>,
+        IHandleAsync<StudiosDeletedEvent>,
         IMapCoversToLocal
     {
         private readonly IMediaCoverProxy _mediaCoverProxy;
@@ -713,6 +715,30 @@ namespace NzbDrone.Core.MediaCover
             foreach (var movie in message.Movies)
             {
                 var path = GetMovieCoverPath(movie.Id);
+                if (_diskProvider.FolderExists(path))
+                {
+                    _diskProvider.DeleteFolder(path, true);
+                }
+            }
+        }
+
+        public void HandleAsync(PerformersDeletedEvent message)
+        {
+            foreach (var performer in message.Performers)
+            {
+                var path = GetPerformerCoverPath(performer.Id);
+                if (_diskProvider.FolderExists(path))
+                {
+                    _diskProvider.DeleteFolder(path, true);
+                }
+            }
+        }
+
+        public void HandleAsync(StudiosDeletedEvent message)
+        {
+            foreach (var studio in message.Studios)
+            {
+                var path = GetStudioCoverPath(studio.Id);
                 if (_diskProvider.FolderExists(path))
                 {
                     _diskProvider.DeleteFolder(path, true);

--- a/src/NzbDrone.Core/Movies/Performers/Events/PerformersDeletedEvent.cs
+++ b/src/NzbDrone.Core/Movies/Performers/Events/PerformersDeletedEvent.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+using NzbDrone.Common.Messaging;
+
+namespace NzbDrone.Core.Movies.Performers.Events
+{
+    public class PerformersDeletedEvent : IEvent
+    {
+        public List<Performer> Performers { get; private set; }
+
+        public PerformersDeletedEvent(List<Performer> performers)
+        {
+            Performers = performers;
+        }
+    }
+}

--- a/src/NzbDrone.Core/Movies/Performers/PerformerService.cs
+++ b/src/NzbDrone.Core/Movies/Performers/PerformerService.cs
@@ -128,6 +128,7 @@ namespace NzbDrone.Core.Movies.Performers
         public void RemovePerformer(Performer performer)
         {
             _performerRepo.Delete(performer);
+            _eventAggregator.PublishEvent(new PerformersDeletedEvent(new List<Performer> { performer }));
             RemovePerformerResourcesCache(performer.ForeignId);
         }
 

--- a/src/NzbDrone.Core/Movies/Studios/Events/StudiosDeletedEvent.cs
+++ b/src/NzbDrone.Core/Movies/Studios/Events/StudiosDeletedEvent.cs
@@ -1,0 +1,14 @@
+using System.Collections.Generic;
+using NzbDrone.Common.Messaging;
+namespace NzbDrone.Core.Movies.Studios.Events
+{
+    public class StudiosDeletedEvent : IEvent
+    {
+        public List<Studio> Studios { get; private set; }
+
+        public StudiosDeletedEvent(List<Studio> studios)
+        {
+            Studios = studios;
+        }
+    }
+}

--- a/src/NzbDrone.Core/Movies/Studios/StudioService.cs
+++ b/src/NzbDrone.Core/Movies/Studios/StudioService.cs
@@ -95,7 +95,7 @@ namespace NzbDrone.Core.Movies.Studios
         public void RemoveStudio(Studio studio)
         {
             _studioRepo.Delete(studio);
-
+            _eventAggregator.PublishEvent(new StudiosDeletedEvent(new List<Studio> { studio }));
             RemoveStudioResourcesCache(studio.ForeignId);
         }
 

--- a/src/Whisparr.Api.V3/Performers/PerformerController.cs
+++ b/src/Whisparr.Api.V3/Performers/PerformerController.cs
@@ -78,6 +78,24 @@ namespace Whisparr.Api.V3.Performers
             }
         }
 
+        protected PerformerResource MapToResource(Performer performer)
+        {
+            if (performer == null)
+            {
+                return null;
+            }
+
+            var resource = performer.ToResource();
+            MapCoversToLocal(performer);
+
+            if (_useCache)
+            {
+                _performerResourceCache.Set(resource.Id.ToString(), resource);
+            }
+
+            return resource;
+        }
+
         /// <summary>Retrieves a performer by their Whisparr (local)internal ID</summary>
         /// <param name="id">The internal ID of the performer</param>
         /// <returns>Performer details with associated movies and local cover URLs</returns>
@@ -87,9 +105,7 @@ namespace Whisparr.Api.V3.Performers
         [Produces("application/json")]
         protected override PerformerResource GetResourceById(int id)
         {
-            var resource = _performerService.GetById(id).ToResource();
-
-            _coverMapper.ConvertToLocalPerformerUrls(resource.Id, resource.Images);
+            var resource = MapToResource(_performerService.GetById(id));
 
             FetchAndLinkMovies(resource);
 
@@ -197,13 +213,10 @@ namespace Whisparr.Api.V3.Performers
 
             var updatedPerformer = _performerService.Update(resource.ToModel(performer));
             _performerResourceCache.Remove(updatedPerformer.ForeignId);
-            var performerResource = updatedPerformer.ToResource();
+            var performerResource = MapToResource(updatedPerformer);
 
             // Added to allow for React-Query cache updates
             FetchAndLinkMovies(performerResource);
-
-            // Broadcasts to both SignalR and React-Query clients
-            BroadcastResourceChange(ModelAction.Updated, performerResource);
 
             return Accepted(performerResource);
         }
@@ -242,11 +255,16 @@ namespace Whisparr.Api.V3.Performers
             _performerService.RemovePerformer(performer);
         }
 
+        private void MapCoversToLocal(Performer performer)
+        {
+            _coverMapper.ConvertToLocalPerformerUrls(performer.Id, performer.Images);
+        }
+
         /// <summary>Handles performer updated events to update the performer cache and broadcast changes via SignalR</summary>
         [NonAction]
         public void Handle(PerformerUpdatedEvent message)
         {
-            var resource = message.Performer.ToResource();
+            var resource = MapToResource(message.Performer);
 
             FetchAndLinkMovies(resource);
             _performerResourceCache.Remove(resource.ForeignId);
@@ -329,7 +347,7 @@ namespace Whisparr.Api.V3.Performers
             var performerResource = _performerResourceCache.Find(performerForeignId);
             if (performerResource == null)
             {
-                performerResource = _performerService.FindByForeignId(performerForeignId).ToResource();
+                performerResource = MapToResource(_performerService.FindByForeignId(performerForeignId));
             }
 
             return performerResource;
@@ -436,32 +454,6 @@ namespace Whisparr.Api.V3.Performers
             }
 
             return performerResources;
-        }
-
-        private void HydratePerformerResourceWithMovies(PerformerResource resource)
-        {
-            var movies = _moviesService.GetByPerformerForeignId(resource.ForeignId);
-            var movieResources = movies
-                .Select(m => MovieResourceMapper.ToResource(m, 0))
-                .Where(r => r != null)
-                .ToList();
-
-            if (resource.Studios == null || resource.Studios.Count == 0)
-            {
-                var hydrated = GetCachedPerformerResource(resource.ForeignId);
-                if (hydrated != null)
-                {
-                    resource.Studios = hydrated.Studios;
-                }
-            }
-
-            foreach (var studio in resource.Studios)
-            {
-                var studioMovies = movieResources
-                    .Where(movie => movie.StudioForeignId == studio.ForeignId)
-                    .ToList();
-                studio.Movies = studioMovies;
-            }
         }
     }
 }

--- a/src/Whisparr.Api.V3/Studios/StudioController.cs
+++ b/src/Whisparr.Api.V3/Studios/StudioController.cs
@@ -74,11 +74,18 @@ namespace Whisparr.Api.V3.Studios
             }
         }
 
+        protected StudioResource MapToResource(Studio studio)
+        {
+            var resource = studio.ToResource();
+
+            MapCoversToLocal(studio);
+
+            return resource;
+        }
+
         protected override StudioResource GetResourceById(int id)
         {
-            var resource = _studioService.GetById(id).ToResource();
-
-            _coverMapper.ConvertToLocalStudioUrls(resource.Id, resource.Images);
+            var resource = MapToResource(_studioService.GetById(id));
 
             FetchAndLinkMovies(resource);
 
@@ -109,7 +116,7 @@ namespace Whisparr.Api.V3.Studios
 
                     if (studio != null)
                     {
-                        studioResources.AddIfNotNull(studio.ToResource());
+                        studioResources.AddIfNotNull(MapToResource(studio));
                     }
                 }
                 else
@@ -147,7 +154,6 @@ namespace Whisparr.Api.V3.Studios
             var updatedStudio = _studioService.Update(resource.ToModel(studio));
 
             _studioResourceCache.Remove(updatedStudio.ForeignId);
-            BroadcastResourceChange(ModelAction.Updated, updatedStudio.ToResource());
 
             return Accepted(updatedStudio);
         }
@@ -183,14 +189,19 @@ namespace Whisparr.Api.V3.Studios
             _studioService.RemoveStudio(studio);
         }
 
+        private void MapCoversToLocal(Studio studio)
+        {
+            _coverMapper.ConvertToLocalStudioUrls(studio.Id, studio.Images);
+        }
+
         [NonAction]
         public void Handle(StudioUpdatedEvent message)
         {
-            var resource = message.Studio.ToResource();
+            var resource = MapToResource(message.Studio);
 
             _studioResourceCache.Remove(resource.ForeignId);
             FetchAndLinkMovies(resource);
-            BroadcastResourceChange(ModelAction.Updated, message.Studio.ToResource());
+            BroadcastResourceChange(ModelAction.Updated, resource);
         }
 
         private void FetchAndLinkMovies(StudioResource resource)
@@ -302,7 +313,7 @@ namespace Whisparr.Api.V3.Studios
 
                         foreach (var studio in studios)
                         {
-                            studioResources.AddIfNotNull(studio.ToResource());
+                            studioResources.AddIfNotNull(MapToResource(studio));
                         }
 
                         var coverFileInfos = _coverMapper.GetStudioCoverFileInfos();


### PR DESCRIPTION
#### Database Migration
NO

#### Description

- Fixed a bug where failed image downloads are never fully resolved
- Fixed a bug where deleting performers and studios leaves their images behind in the config/MediaCover folder

When metadata sources have image delivery issues and can’t be retrieved upon new item creation, they remain unresolved.  This change ensures that the cover download pipeline mimics how movie/scene covers work.

Also fixed orphaned media covers.  Previously, when deleting a performer or studio, their media covers would be left behind on disk.  We were missing event handler actions for deletions.

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX