### PR TITLE
Fix: Command JSON serializer errors

### DIFF
--- a/src/NzbDrone.Core/Datastore/Converters/CommandConverter.cs
+++ b/src/NzbDrone.Core/Datastore/Converters/CommandConverter.cs
@@ -1,5 +1,6 @@
 using System.Data;
 using System.Text.Json;
+using NLog;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Common.Reflection;
 using NzbDrone.Core.Messaging.Commands;
@@ -8,6 +9,7 @@ namespace NzbDrone.Core.Datastore.Converters
 {
     public class CommandConverter : EmbeddedDocumentConverter<Command>
     {
+        private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
         public override Command Parse(object value)
         {
             var stringValue = (string)value;
@@ -17,24 +19,30 @@ namespace NzbDrone.Core.Datastore.Converters
                 return null;
             }
 
-            string contract;
-            using (var body = JsonDocument.Parse(stringValue))
+            try
             {
-                contract = body.RootElement.GetProperty("name").GetString();
+                string contract;
+                using (var body = JsonDocument.Parse(stringValue))
+                {
+                    contract = body.RootElement.GetProperty("name").GetString();
+                }
+
+                var impType = typeof(Command).Assembly.FindTypeByName(contract + "Command");
+
+                if (impType == null)
+                {
+                    var result = JsonSerializer.Deserialize<UnknownCommand>(stringValue, SerializerSettings);
+                    result.ContractName = contract;
+                    return result;
+                }
+
+                return (Command)JsonSerializer.Deserialize(stringValue, impType, SerializerSettings);
             }
-
-            var impType = typeof(Command).Assembly.FindTypeByName(contract + "Command");
-
-            if (impType == null)
+            catch (System.Exception ex)
             {
-                var result = JsonSerializer.Deserialize<UnknownCommand>(stringValue, SerializerSettings);
-
-                result.ContractName = contract;
-
-                return result;
+                Logger.Debug(ex, $"Failed to parse command body: {stringValue}");
+                return null;
             }
-
-            return (Command)JsonSerializer.Deserialize(stringValue, impType, SerializerSettings);
         }
 
         public override void SetValue(IDbDataParameter parameter, Command value)

--- a/src/Whisparr.Api.V3/Commands/CommandController.cs
+++ b/src/Whisparr.Api.V3/Commands/CommandController.cs
@@ -55,8 +55,13 @@ namespace Whisparr.Api.V3.Commands
         {
             var commandType =
                 _knownTypes.GetImplementations(typeof(Command))
-                               .Single(c => c.Name.Replace("Command", "")
-                                             .Equals(commandResource.Name, StringComparison.InvariantCultureIgnoreCase));
+                    .SingleOrDefault(c => c.Name.Replace("Command", "")
+                        .Equals(commandResource.Name, StringComparison.InvariantCultureIgnoreCase));
+
+            if (commandType == null)
+            {
+                return BadRequest($"Unknown command type: {commandResource.Name}");
+            }
 
             Request.Body.Seek(0, SeekOrigin.Begin);
             using (var reader = new StreamReader(Request.Body))


### PR DESCRIPTION
Adds a try...catch around the JSON deserializer part of this, so if bad JSON ends up in the command queue, it should not cause an app crash.

#### Database Migration
NO


#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

- ref: whisparr/whisparr#999