### PR TITLE
Fix: Import Scenes fails to display unmapped files after scan completes

### DIFF
--- a/src/NzbDrone.Core/MediaFiles/MovieImport/ImportDecisionMaker.cs
+++ b/src/NzbDrone.Core/MediaFiles/MovieImport/ImportDecisionMaker.cs
@@ -162,7 +162,7 @@ namespace NzbDrone.Core.MediaFiles.MovieImport
                     SceneSource = sceneSource,
                 };
 
-                if (movie.ForeignId == null)
+                if (string.IsNullOrWhiteSpace(movie.ForeignId))
                 {
                     // Add the movieFile if no match to a movie
                     var unmappedFile = new MovieFile();
@@ -181,6 +181,7 @@ namespace NzbDrone.Core.MediaFiles.MovieImport
                     unmappedFile.Quality = localMovie.Quality;
 
                     unmappedFiles.Add(unmappedFile);
+                    _logger.Info("Added unmapped decision.  No matching movie found for file: {0}", file);
                     continue;
                 }
 


### PR DESCRIPTION
Issue was caused by recent metadata changes.  The import decision maker was explicitly checking for null, instead of null or whitespace.

#### Database Migration
NO

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes whisparr/whisparr#1000