### PR TITLE
Fix: NullReferenceException on LinkMovieStatistics

### DIFF
--- a/src/Whisparr.Api.V3/Movies/MovieController.cs
+++ b/src/Whisparr.Api.V3/Movies/MovieController.cs
@@ -438,9 +438,19 @@ namespace Whisparr.Api.V3.Movies
 
         private void LinkMovieStatistics(List<MovieResource> resources, Dictionary<int, MovieStatistics> sDict)
         {
+            if (resources == null || sDict == null)
+            {
+                return;
+            }
+
             foreach (var movie in resources)
             {
-                if (sDict.TryGetValue(movie.Id, out var stats))
+                if (movie == null)
+                {
+                    continue;
+                }
+
+                if (sDict.TryGetValue(movie.Id, out var stats) && stats != null)
                 {
                     LinkMovieStatistics(movie, stats);
                 }
@@ -449,6 +459,11 @@ namespace Whisparr.Api.V3.Movies
 
         private void LinkMovieStatistics(MovieResource resource, MovieStatistics movieStatistics)
         {
+            if (resource == null || movieStatistics == null)
+            {
+                return;
+            }
+
             resource.Statistics = movieStatistics.ToResource();
             resource.HasFile = movieStatistics.MovieFileCount > 0;
             resource.SizeOnDisk = movieStatistics.SizeOnDisk;


### PR DESCRIPTION
#### Database Migration
NO

#### Description
If LinkMovieStatistics fails, it blocks `/api/v3/movie/bulk` from loading at all, which is effectively an app crash.  Since this is only a filler method for stats, it can fail silently.

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

- refs: whisparr/whisparr#999