### PR TITLE
Fix: Scene screenshot not hidden on mobile

### DIFF
--- a/frontend/src/Movie/Details/MovieDetails.css
+++ b/frontend/src/Movie/Details/MovieDetails.css
@@ -53,7 +53,7 @@
   object-fit: cover;
 }
 
-.screenShot {
+.screenshot {
   z-index: 2;
   flex-shrink: 0;
   margin-top: 10px;
@@ -272,6 +272,7 @@
 
 @media only screen and (max-width: $breakpointLarge) {
   .poster,
+  .screenshot,
   .movieNavigationButtons {
     display: none;
   }

--- a/frontend/src/Movie/Details/MovieDetails.css.d.ts
+++ b/frontend/src/Movie/Details/MovieDetails.css.d.ts
@@ -31,7 +31,7 @@ interface CssExports {
   'releaseDate': string;
   'runtime': string;
   'sceneHeader': string;
-  'screenShot': string;
+  'screenshot': string;
   'selectedTab': string;
   'sizeOnDisk': string;
   'statusName': string;

--- a/frontend/src/Movie/Details/MovieDetails.tsx
+++ b/frontend/src/Movie/Details/MovieDetails.tsx
@@ -381,7 +381,7 @@ class MovieDetails extends Component<Props, State> {
               <MovieImage
                 safeForWorkMode={safeForWorkMode}
                 className={
-                  itemType === 'movie' ? styles.poster : styles.screenShot
+                  itemType === 'movie' ? styles.poster : styles.screenshot
                 }
                 coverType={itemType === 'movie' ? 'poster' : 'screenshot'}
                 images={images}


### PR DESCRIPTION
#### Database Migration
NO

#### Description
This was fine for movies, but since scenes uses a different CSS class, it wasn't hidden like movie posters were.

#### Screenshot (if UI related)
<details>
<img width="200" height="1311" alt="image" src="https://github.com/user-attachments/assets/4ab16691-b15d-464a-bbcf-d58bc05b3138" />

</details>
#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

- Fixes whisparr/whisparr#1003