### PR TITLE
Fix: NullReferenceException on MapCoversToLocal

### DIFF
--- a/src/Whisparr.Api.V3/Movies/MovieController.cs
+++ b/src/Whisparr.Api.V3/Movies/MovieController.cs
@@ -365,6 +365,8 @@ namespace Whisparr.Api.V3.Movies
             var availDelay = _configService.AvailabilityDelay;
 
             var resource = movie.ToResource(availDelay, _qualityUpgradableSpecification);
+
+            // TODO: movie this to the movie updated event handler instead
             MapCoversToLocal(resource);
             FetchAndLinkMovieStatistics(resource);
 
@@ -423,11 +425,21 @@ namespace Whisparr.Api.V3.Movies
 
         private void MapCoversToLocal(MovieResource movie)
         {
+            if (movie == null)
+            {
+                return;
+            }
+
             _coverMapper.ConvertToLocalUrls(movie.Id, movie.Images);
         }
 
         private void MapCoversToLocal(IEnumerable<MovieResource> movies, Dictionary<string, FileInfo> coverFileInfos)
         {
+            if (movies == null || !movies.Any() || coverFileInfos == null || !coverFileInfos.Any())
+            {
+                return;
+            }
+
             _coverMapper.ConvertToLocalUrls(movies.Select(x => Tuple.Create(x.Id, x.Images.AsEnumerable())), coverFileInfos);
         }
 

--- a/src/Whisparr.Api.V3/Performers/PerformerController.cs
+++ b/src/Whisparr.Api.V3/Performers/PerformerController.cs
@@ -257,6 +257,11 @@ namespace Whisparr.Api.V3.Performers
 
         private void MapCoversToLocal(Performer performer)
         {
+            if (performer == null || !performer.Images.Any())
+            {
+                return;
+            }
+
             _coverMapper.ConvertToLocalPerformerUrls(performer.Id, performer.Images);
         }
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Added a null check on MapCoversToLocal to avoid issues preventing dependint /bulk API endpoint from loading.

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

- refs whisparr/whisparr#999