### PR TITLE
Fix: Read the Gender value for Credit Performer to correct naming

### DIFF
--- a/frontend/src/Settings/Profiles/Quality/EditQualityProfileModalContent.js
+++ b/frontend/src/Settings/Profiles/Quality/EditQualityProfileModalContent.js
@@ -122,6 +122,7 @@ class EditQualityProfileModalContent extends Component {
     const {
       id,
       name,
+      fallback,
       upgradeAllowed,
       cutoff,
       minFormatScore,
@@ -180,6 +181,20 @@ class EditQualityProfileModalContent extends Component {
                             type={inputTypes.TEXT}
                             name="name"
                             {...name}
+                            onChange={onInputChange}
+                          />
+                        </FormGroup>
+
+                        <FormGroup size={sizes.EXTRA_SMALL}>
+                          <FormLabel size={sizes.SMALL}>
+                            {translate('FallbackQualityProfile')}
+                          </FormLabel>
+
+                          <FormInputGroup
+                            type={inputTypes.CHECK}
+                            name="fallback"
+                            {...fallback}
+                            helpText={translate('FallbackQualityProfileHelpText')}
                             onChange={onInputChange}
                           />
                         </FormGroup>

--- a/frontend/src/Settings/Profiles/Quality/QualityProfile.css
+++ b/frontend/src/Settings/Profiles/Quality/QualityProfile.css
@@ -36,3 +36,17 @@
   margin: 0;
   border: none;
 }
+
+.fallback
+{
+  position: absolute;   /* Stays in place even when scrolling */
+  right: 0;          /* Distance from right */
+  bottom: 0;         /* Distance from bottom */
+}
+
+.fallback span
+{
+  border-color: transparent;
+  background-color: transparent;
+  font-size: 14px;
+}

--- a/frontend/src/Settings/Profiles/Quality/QualityProfile.css.d.ts
+++ b/frontend/src/Settings/Profiles/Quality/QualityProfile.css.d.ts
@@ -2,6 +2,7 @@
 // Please do not change this file!
 interface CssExports {
   'cloneButton': string;
+  'fallback': string;
   'name': string;
   'nameContainer': string;
   'qualities': string;

--- a/frontend/src/Settings/Profiles/Quality/QualityProfile.js
+++ b/frontend/src/Settings/Profiles/Quality/QualityProfile.js
@@ -67,6 +67,7 @@ class QualityProfile extends Component {
       id,
       name,
       upgradeAllowed,
+      fallback,
       cutoff,
       items,
       isDeleting
@@ -151,6 +152,14 @@ class QualityProfile extends Component {
           }
         </div>
 
+        {fallback && (
+          <div className={styles.fallback}>
+            <Label>
+              {translate('Fallback')}
+            </Label>
+          </div>
+        )}
+
         <EditQualityProfileModalConnector
           id={id}
           isOpen={this.state.isEditQualityProfileModalOpen}
@@ -177,6 +186,7 @@ QualityProfile.propTypes = {
   id: PropTypes.number.isRequired,
   name: PropTypes.string.isRequired,
   upgradeAllowed: PropTypes.bool.isRequired,
+  fallback: PropTypes.bool.isRequired,
   cutoff: PropTypes.number.isRequired,
   items: PropTypes.arrayOf(PropTypes.object).isRequired,
   isDeleting: PropTypes.bool.isRequired,

--- a/src/NzbDrone.Core/Datastore/Migration/021_qualityprofile_fallback.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/021_qualityprofile_fallback.cs
@@ -1,0 +1,15 @@
+using FluentMigrator;
+using NzbDrone.Core.Datastore.Migration.Framework;
+
+namespace NzbDrone.Core.Datastore.Migration
+{
+    [Migration(021)]
+    public class qualityprofile_fallback : NzbDroneMigrationBase
+    {
+        protected override void MainDbUpgrade()
+        {
+            Alter.Table("QualityProfiles")
+                .AddColumn("Fallback").AsBoolean().WithDefaultValue(false);
+        }
+    }
+}

--- a/src/NzbDrone.Core/Localization/Core/en.json
+++ b/src/NzbDrone.Core/Localization/Core/en.json
@@ -739,6 +739,8 @@
   "FailedToLoadMovieFromAPI": "Failed to load movie from API",
   "FailedToUpdateSettings": "Failed to update settings",
   "Fallback": "Fallback",
+  "FallbackQualityProfile": "Fallback",
+  "FallbackQualityProfileHelpText": "Used as a Fallback Quality Profile if an invalid Profile is used",
   "False": "False",
   "FavoriteFolderAdd": "Add Favorite Folder",
   "FavoriteFolderRemove": "Remove Favorite Folder",

--- a/src/NzbDrone.Core/MediaFiles/MovieImport/Identification/IdentificationService.cs
+++ b/src/NzbDrone.Core/MediaFiles/MovieImport/Identification/IdentificationService.cs
@@ -13,6 +13,7 @@ using NzbDrone.Core.MetadataSource;
 using NzbDrone.Core.Movies;
 using NzbDrone.Core.Organizer;
 using NzbDrone.Core.Parser.Model;
+using NzbDrone.Core.Profiles.Qualities;
 using NzbDrone.Core.RootFolders;
 
 namespace NzbDrone.Core.MediaFiles.MovieImport
@@ -36,6 +37,7 @@ namespace NzbDrone.Core.MediaFiles.MovieImport
         private readonly INamingConfigService _namingConfigService;
         private readonly IConfigService _configService;
         private readonly IRootFolderService _rootFolderService;
+        private readonly IQualityProfileRepository _profileRepository;
         private readonly Logger _logger;
 
         public SceneIdentificationService(ISearchForNewMovie searchProxy,
@@ -50,6 +52,7 @@ namespace NzbDrone.Core.MediaFiles.MovieImport
                                           INamingConfigService namingConfigService,
                                           IConfigService configService,
                                           IRootFolderService rootFolderService,
+                                          IQualityProfileRepository profileRepository,
                                           Logger logger)
         {
             _searchProxy = searchProxy;
@@ -64,6 +67,7 @@ namespace NzbDrone.Core.MediaFiles.MovieImport
             _namingConfigService = namingConfigService;
             _configService = configService;
             _rootFolderService = rootFolderService;
+            _profileRepository = profileRepository;
             _logger = logger;
         }
 
@@ -213,7 +217,10 @@ namespace NzbDrone.Core.MediaFiles.MovieImport
                     }
                 }
 
-                movie.QualityProfileId = 1;
+                var qualityProfiles = _profileRepository.All();
+                var defaultProfile = qualityProfiles.FirstOrDefault(x => x.Fallback) ?? qualityProfiles.First();
+
+                movie.QualityProfileId = defaultProfile.Id;
                 movie.RootFolderPath = rootFolder;
                 movie.AddOptions = new AddMovieOptions
                 {

--- a/src/NzbDrone.Core/MediaFiles/MovieImport/Identification/IdentificationService.cs
+++ b/src/NzbDrone.Core/MediaFiles/MovieImport/Identification/IdentificationService.cs
@@ -141,7 +141,7 @@ namespace NzbDrone.Core.MediaFiles.MovieImport
 
             var movie = new Movie();
 
-            if (result.Title.IsNotNullOrWhiteSpace())
+            if (result?.Id != null && result.Title.IsNotNullOrWhiteSpace())
             {
                 movie = result;
                 var sourcePath = file.ToString();

--- a/src/NzbDrone.Core/MediaFiles/SceneDiskScanService.cs
+++ b/src/NzbDrone.Core/MediaFiles/SceneDiskScanService.cs
@@ -92,6 +92,11 @@ namespace NzbDrone.Core.MediaFiles
             if (folders == null)
             {
                 folders = _rootFolderService.All().Select(x => x.Path).ToList();
+                if (folders == null)
+                {
+                    _logger.Error("No Root Folders Defined.");
+                    return;
+                }
             }
 
             var movieIds = new List<int>();

--- a/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
+++ b/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
@@ -1569,9 +1569,17 @@ namespace NzbDrone.Core.MetadataSource.SkyHook
                 throw new ArgumentNullException(nameof(castResource));
             }
 
+            // Extract the person name from older skyhook data
+            var personName = castResource.PersonName.IsNotNullOrWhiteSpace() ? castResource.PersonName : castResource.Performer.Name;
+
+            if (personName == null)
+            {
+                personName = "";
+            }
+
             var newActor = new Credit
             {
-                PersonName = castResource.Performer.Name,
+                PersonName = personName,
                 Character = castResource.Character,
                 Order = castResource.Order,
                 Type = CreditType.Cast,

--- a/src/NzbDrone.Core/Movies/Credits/CreditRepository.cs
+++ b/src/NzbDrone.Core/Movies/Credits/CreditRepository.cs
@@ -45,9 +45,11 @@ namespace NzbDrone.Core.Movies.Credits
                     var creditPerformer = new CreditPerformer();
 
                     creditPerformer.Id = performer?.Id ?? 0;
+                    creditPerformer.Name = performer?.Name ?? string.Empty;
                     creditPerformer.ForeignId = performer?.ForeignId;
                     creditPerformer.TpdbId = performer?.TpdbId;
                     creditPerformer.TmdbId = performer?.TmdbId ?? 0;
+                    creditPerformer.Gender = performer?.Gender ?? Gender.Female;
                     creditPerformer.Monitored = performer?.Monitored == true;
                     creditPerformer.MoviesMonitored = performer?.MoviesMonitored == true;
 

--- a/src/NzbDrone.Core/Movies/MovieRepository.cs
+++ b/src/NzbDrone.Core/Movies/MovieRepository.cs
@@ -156,7 +156,12 @@ namespace NzbDrone.Core.Movies
                 {
                     movie.MovieMetadata = metadata;
                     movie.MovieFile = file;
-                    movie.QualityProfile = qualityProfiles[movie.QualityProfileId];
+
+                    // Check Quality Key exists
+                    if (qualityProfiles.ContainsKey(movie.QualityProfileId))
+                    {
+                        movie.QualityProfile = qualityProfiles[movie.QualityProfileId];
+                    }
 
                     if (alternativeTitles.TryGetValue(movie.MovieMetadataId, out var altTitles))
                     {

--- a/src/NzbDrone.Core/Movies/MovieRepository.cs
+++ b/src/NzbDrone.Core/Movies/MovieRepository.cs
@@ -158,10 +158,14 @@ namespace NzbDrone.Core.Movies
                     movie.MovieFile = file;
 
                     // Check Quality Key exists
-                    if (qualityProfiles.ContainsKey(movie.QualityProfileId))
+                    if (!qualityProfiles.ContainsKey(movie.QualityProfileId))
                     {
-                        movie.QualityProfile = qualityProfiles[movie.QualityProfileId];
+                        // Correct any bad Quality Profiles
+                        var defaultProfile = qualityProfiles.FirstOrDefault(x => x.Value.Fallback).Value ?? qualityProfiles.First().Value;
+                        movie.QualityProfileId = defaultProfile.Id;
                     }
+
+                    movie.QualityProfile = qualityProfiles[movie.QualityProfileId];
 
                     if (alternativeTitles.TryGetValue(movie.MovieMetadataId, out var altTitles))
                     {

--- a/src/NzbDrone.Core/Profiles/Qualities/QualityProfile.cs
+++ b/src/NzbDrone.Core/Profiles/Qualities/QualityProfile.cs
@@ -23,6 +23,7 @@ namespace NzbDrone.Core.Profiles.Qualities
         public List<ProfileFormatItem> FormatItems { get; set; }
         public Language Language { get; set; }
         public bool UpgradeAllowed { get; set; }
+        public bool Fallback { get; set; }
         public Quality FirststAllowedQuality()
         {
             var firstAllowed = Items.First(q => q.Allowed);

--- a/src/NzbDrone.Core/Profiles/Qualities/QualityProfileService.cs
+++ b/src/NzbDrone.Core/Profiles/Qualities/QualityProfileService.cs
@@ -69,7 +69,7 @@ namespace NzbDrone.Core.Profiles.Qualities
         public void Delete(int id)
         {
             if (_movieService.GetAllMovies().Any(c => c.QualityProfileId == id) || _importListFactory.All().Any(c => c.QualityProfileId == id) ||
-                _performerService.GetAllPerformers().Any(c => c.QualityProfileId == id) || _studioService.GetAllStudios().Any(c => c.QualityProfileId == id))
+                _performerService.GetAllPerformers().Any(c => c.QualityProfileId == id) || _studioService.GetAllStudios().Any(c => c.QualityProfileId == id) || _profileRepository.Get(id)?.Fallback == true)
             {
                 throw new QualityProfileInUseException(id);
             }

--- a/src/Whisparr.Api.V3/Profiles/Quality/QualityProfileController.cs
+++ b/src/Whisparr.Api.V3/Profiles/Quality/QualityProfileController.cs
@@ -52,6 +52,18 @@ namespace Whisparr.Api.V3.Profiles.Quality
         {
             var model = resource.ToModel();
             model = _qualityProfileService.Add(model);
+
+            if (model.Fallback)
+            {
+                // Uncheck all other profiles as Fallback if this is set to Fallback
+                var all = _qualityProfileService.All();
+                foreach (var profile in all.Where(p => p.Id != model.Id && p.Fallback))
+                {
+                    profile.Fallback = false;
+                    _qualityProfileService.Update(profile);
+                }
+            }
+
             return Created(model.Id);
         }
 
@@ -68,6 +80,17 @@ namespace Whisparr.Api.V3.Profiles.Quality
             var model = resource.ToModel();
 
             _qualityProfileService.Update(model);
+
+            if (model.Fallback)
+            {
+                // Uncheck all other profiles as Fallback if this is set to Fallback
+                var all = _qualityProfileService.All();
+                foreach (var profile in all.Where(p => p.Id != model.Id && p.Fallback))
+                {
+                    profile.Fallback = false;
+                    _qualityProfileService.Update(profile);
+                }
+            }
 
             return Accepted(model.Id);
         }

--- a/src/Whisparr.Api.V3/Profiles/Quality/QualityProfileResource.cs
+++ b/src/Whisparr.Api.V3/Profiles/Quality/QualityProfileResource.cs
@@ -12,6 +12,7 @@ namespace Whisparr.Api.V3.Profiles.Quality
     {
         public string Name { get; set; }
         public bool UpgradeAllowed { get; set; }
+        public bool Fallback { get; set; }
         public int Cutoff { get; set; }
         public List<QualityProfileQualityItemResource> Items { get; set; }
         public int MinFormatScore { get; set; }
@@ -55,6 +56,7 @@ namespace Whisparr.Api.V3.Profiles.Quality
                 Id = model.Id,
                 Name = model.Name,
                 UpgradeAllowed = model.UpgradeAllowed,
+                Fallback = model.Fallback,
                 Cutoff = model.Cutoff,
                 Items = model.Items.ConvertAll(ToResource),
                 MinFormatScore = model.MinFormatScore,
@@ -104,6 +106,7 @@ namespace Whisparr.Api.V3.Profiles.Quality
                 Id = resource.Id,
                 Name = resource.Name,
                 UpgradeAllowed = resource.UpgradeAllowed,
+                Fallback = resource.Fallback,
                 Cutoff = resource.Cutoff,
                 Items = resource.Items.ConvertAll(ToModel),
                 MinFormatScore = resource.MinFormatScore,


### PR DESCRIPTION
#### Database Migration
YES - 021

#### Description
Read all the credit data, for naming tokens. 
Handle old data for the credit personname

Second Commit Checks information for Scene Impot
Handle when there are no root folders for a scene Import
Checks that the Identification has a Movie with a movie ID.

Third
Check the profileID, so it does not throw and exception, the first will then be used.

Fourth
Set a Fallback Quality Profile, so that it can correct issues with Quality Profiles.


#### Screenshot (if UI related)
<img width="1275" height="479" alt="image" src="https://github.com/user-attachments/assets/18649239-9c1e-4f4b-91a5-4651677fc5e6" />

<img width="779" height="245" alt="image" src="https://github.com/user-attachments/assets/65ad2827-1591-4f79-859c-20a10b6a9009" />

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX
* refs https://github.com/Whisparr/Whisparr-Eros/issues/781