### PR TITLE
Fix: Fallback test when adding indexers with empty results

### DIFF
--- a/src/NzbDrone.Core/Indexers/HttpIndexerBase.cs
+++ b/src/NzbDrone.Core/Indexers/HttpIndexerBase.cs
@@ -370,7 +370,21 @@ namespace NzbDrone.Core.Indexers
 
                 if (releases.Empty())
                 {
-                    return new ValidationFailure(string.Empty, "Query successful, but no results in the configured categories were returned from your indexer. This may be an issue with the indexer or your indexer category settings.");
+                    // Test with a fake scene search
+                    var movieSearchCriteria = new SceneSearchCriteria() { Movie = new Movies.Movie() { Title = "xxx" }, SceneTitles = new List<string>() { "xxx" } };
+                    var backupRequest = generator.GetSearchRequests(movieSearchCriteria).GetAllTiers().FirstOrDefault()?.FirstOrDefault();
+
+                    if (backupRequest == null)
+                    {
+                        return new ValidationFailure(string.Empty, "No rss feed query available. This may be an issue with the indexer or your indexer category settings.");
+                    }
+
+                    releases = await FetchPage(backupRequest, parser);
+
+                    if (releases.Empty())
+                    {
+                        return new ValidationFailure(string.Empty, "Query successful, but no results in the configured categories were returned from your indexer. This may be an issue with the indexer or your indexer category settings.");
+                    }
                 }
             }
             catch (ApiKeyException ex)


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Indexers can fail if there is no query sent, as they will return no results.

Create a dummy search for "xxx" should return a result.

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX