### PR TITLE
Chore: Bump NLog to 6.1.0

### DIFF
--- a/src/NzbDrone.Common/Instrumentation/CleansingConsoleLogLayout.cs
+++ b/src/NzbDrone.Common/Instrumentation/CleansingConsoleLogLayout.cs
@@ -1,26 +1,28 @@
-using System.Text;
 using NLog;
 using NLog.Layouts;
 using NzbDrone.Common.EnvironmentInfo;
 
 namespace NzbDrone.Common.Instrumentation;
 
-public class CleansingConsoleLogLayout : SimpleLayout
+public class CleansingConsoleLogLayout : Layout
 {
+    private readonly string _format;
+
     public CleansingConsoleLogLayout(string format)
-        : base(format)
     {
+        _format = format;
     }
 
-    protected override void RenderFormattedMessage(LogEventInfo logEvent, StringBuilder target)
+    protected override string GetFormattedMessage(LogEventInfo logEvent)
     {
-        base.RenderFormattedMessage(logEvent, target);
+        var simpleLayout = new SimpleLayout(_format);
+        var result = simpleLayout.Render(logEvent);
 
         if (RuntimeInfo.IsProduction)
         {
-            var result = CleanseLogMessage.Cleanse(target.ToString());
-            target.Clear();
-            target.Append(result);
+            result = CleanseLogMessage.Cleanse(result);
         }
+
+        return result;
     }
 }

--- a/src/NzbDrone.Common/Instrumentation/NzbDroneLogger.cs
+++ b/src/NzbDrone.Common/Instrumentation/NzbDroneLogger.cs
@@ -143,13 +143,10 @@ namespace NzbDrone.Common.Instrumentation
             fileTarget.FileName = Path.Combine(appFolderInfo.GetLogFolder(), fileName);
             fileTarget.AutoFlush = true;
             fileTarget.KeepFileOpen = false;
-            fileTarget.ConcurrentWrites = false;
-            fileTarget.ConcurrentWriteAttemptDelay = 50;
-            fileTarget.ConcurrentWriteAttempts = 10;
             fileTarget.ArchiveAboveSize = 1.Megabytes();
             fileTarget.MaxArchiveFiles = maxArchiveFiles;
             fileTarget.EnableFileDelete = true;
-            fileTarget.ArchiveNumbering = ArchiveNumberingMode.Rolling;
+            fileTarget.ArchiveSuffixFormat = "{###}";
             fileTarget.Layout = FileLogLayout;
 
             var loggingRule = new LoggingRule("*", minLogLevel, fileTarget);
@@ -166,9 +163,6 @@ namespace NzbDrone.Common.Instrumentation
             fileTarget.FileName = Path.Combine(appFolderInfo.GetUpdateLogFolder(), DateTime.Now.ToString("yyyy.MM.dd-HH.mm") + ".txt");
             fileTarget.AutoFlush = true;
             fileTarget.KeepFileOpen = false;
-            fileTarget.ConcurrentWrites = false;
-            fileTarget.ConcurrentWriteAttemptDelay = 50;
-            fileTarget.ConcurrentWriteAttempts = 100;
             fileTarget.Layout = FileLogLayout;
 
             var loggingRule = new LoggingRule("*", LogLevel.Trace, fileTarget);

--- a/src/NzbDrone.Common/Whisparr.Common.csproj
+++ b/src/NzbDrone.Common/Whisparr.Common.csproj
@@ -6,12 +6,12 @@
   <ItemGroup>
     <PackageReference Include="DryIoc.dll" Version="5.4.3" />
     <PackageReference Include="IPAddressRange" Version="6.2.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.3" />
     <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="8.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="NLog" Version="5.4.0" />
-    <PackageReference Include="NLog.Layouts.ClefJsonLayout" Version="1.0.3" />
-    <PackageReference Include="NLog.Extensions.Logging" Version="5.4.0" />
+    <PackageReference Include="NLog" Version="6.1.0" />
+    <PackageReference Include="NLog.Layouts.ClefJsonLayout" Version="1.0.5" />
+    <PackageReference Include="NLog.Extensions.Logging" Version="6.1.1" />
     <PackageReference Include="Npgsql" Version="9.0.3" />
     <PackageReference Include="Sentry" Version="4.0.2" />
     <PackageReference Include="NLog.Targets.Syslog" Version="7.0.0" />

--- a/src/NzbDrone.Core.Test/Framework/MigrationTest.cs
+++ b/src/NzbDrone.Core.Test/Framework/MigrationTest.cs
@@ -2,7 +2,7 @@ using System;
 using System.Data;
 using FluentMigrator;
 using Microsoft.Extensions.Logging;
-using NLog.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using NUnit.Framework;
 using NzbDrone.Core.Datastore.Migration.Framework;
 
@@ -33,7 +33,7 @@ namespace NzbDrone.Core.Test.Framework
 
         protected override void SetupLogging()
         {
-            Mocker.SetConstant<ILoggerProvider>(Mocker.Resolve<NLogLoggerProvider>());
+            Mocker.SetConstant<ILoggerProvider>(NullLoggerProvider.Instance);
         }
 
         private ITestDatabase WithMigrationAction(Action<TMigration> beforeMigration = null)

--- a/src/NzbDrone.Core/Whisparr.Core.csproj
+++ b/src/NzbDrone.Core/Whisparr.Core.csproj
@@ -14,8 +14,8 @@
     <PackageReference Include="Polly" Version="8.6.0" />
     <PackageReference Include="Servarr.FFMpegCore" Version="4.7.0-26" />
     <PackageReference Include="Servarr.FFprobe" Version="5.1.4.112" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.3" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
     <PackageReference Include="FluentMigrator.Runner.Core" Version="6.2.0" />
     <PackageReference Include="FluentMigrator.Runner.SQLite" Version="6.2.0" />
@@ -23,7 +23,7 @@
     <PackageReference Include="FluentValidation" Version="9.5.4" />
     <PackageReference Include="SixLabors.ImageSharp" Version="3.1.11" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="NLog" Version="5.4.0" />
+    <PackageReference Include="NLog" Version="6.1.0" />
     <PackageReference Include="MonoTorrent" Version="3.0.2" />
     <PackageReference Include="System.Drawing.Common" Version="10.0.1" />
   </ItemGroup>

--- a/src/NzbDrone.Test.Common/LoggingTest.cs
+++ b/src/NzbDrone.Test.Common/LoggingTest.cs
@@ -60,9 +60,6 @@ namespace NzbDrone.Test.Common
             fileTarget.FileName = Path.Combine(TestContext.CurrentContext.WorkDirectory, "TestLog.txt");
             fileTarget.AutoFlush = false;
             fileTarget.KeepFileOpen = true;
-            fileTarget.ConcurrentWrites = true;
-            fileTarget.ConcurrentWriteAttemptDelay = 50;
-            fileTarget.ConcurrentWriteAttempts = 10;
             fileTarget.Layout = layout;
 
             LogManager.Configuration.AddTarget(fileTarget.GetType().Name, fileTarget);

--- a/src/NzbDrone.Test.Common/Whisparr.Test.Common.csproj
+++ b/src/NzbDrone.Test.Common/Whisparr.Test.Common.csproj
@@ -6,7 +6,7 @@
     <PackageReference Include="FluentAssertions" Version="6.12.1" />
     <PackageReference Include="FluentValidation" Version="9.5.4" />
     <PackageReference Include="Moq" Version="4.18.4" />
-    <PackageReference Include="NLog" Version="5.4.0" />
+    <PackageReference Include="NLog" Version="6.1.0" />
     <PackageReference Include="NUnit" Version="3.14.0" />
     <PackageReference Include="RestSharp" Version="106.15.0" />
   </ItemGroup>

--- a/src/NzbDrone.Update/Whisparr.Update.csproj
+++ b/src/NzbDrone.Update/Whisparr.Update.csproj
@@ -6,7 +6,7 @@
   <ItemGroup>
     <PackageReference Include="DryIoc.dll" Version="5.4.3" />
     <PackageReference Include="DryIoc.Microsoft.DependencyInjection" Version="6.2.0" />
-    <PackageReference Include="NLog" Version="5.4.0" />
+    <PackageReference Include="NLog" Version="6.1.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NzbDrone.Common\Whisparr.Common.csproj" />

--- a/src/NzbDrone.Windows/Whisparr.Windows.csproj
+++ b/src/NzbDrone.Windows/Whisparr.Windows.csproj
@@ -4,7 +4,7 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NLog" Version="5.4.0" />
+    <PackageReference Include="NLog" Version="6.1.0" />
     <PackageReference Include="System.IO.FileSystem.AccessControl" Version="5.0.0" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Whisparr.Api.V3/Whisparr.Api.V3.csproj
+++ b/src/Whisparr.Api.V3/Whisparr.Api.V3.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="FluentValidation" Version="9.5.4" />
     <PackageReference Include="Ical.Net" Version="4.3.1" />
-    <PackageReference Include="NLog" Version="5.4.0" />
+    <PackageReference Include="NLog" Version="6.1.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="8.1.4" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Whisparr.Http/Whisparr.Http.csproj
+++ b/src/Whisparr.Http/Whisparr.Http.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="FluentValidation" Version="9.5.4" />
     <PackageReference Include="ImpromptuInterface" Version="8.0.6" />
-    <PackageReference Include="NLog" Version="5.4.0" />
+    <PackageReference Include="NLog" Version="6.1.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NzbDrone.Core\Whisparr.Core.csproj" />


### PR DESCRIPTION
This had a dependency requirement to bump a couple instances of Microsoft.Logging.Extensions and Microsoft.Extensions.DependencyInjection (which I missed in the DryIoc bump).  Builds clean and all tests pass, app runs normally.  Fixed a couple build and test issues related to breaking changes in the 6.1 package.

#### Database Migration
NO

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Refs #59