### PR TITLE
Chore: Bump additional test packages and update deps

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -135,8 +135,8 @@
   <!-- Standard testing packages -->
   <ItemGroup Condition="'$(TestProject)'=='true'">
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
-    <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="GitHubActionsTestLogger" Version="3.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="NUnit" Version="4.4.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="6.1.0" />
     <PackageReference Include="NunitXml.TestLogger" Version="8.0.0" />

--- a/src/NuGet.config
+++ b/src/NuGet.config
@@ -5,6 +5,5 @@
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
     <add key="dotnet-bsd-crossbuild" value="https://pkgs.dev.azure.com/Servarr/Servarr/_packaging/dotnet-bsd-crossbuild/nuget/v3/index.json" />
     <add key="Mono.Posix.NETStandard" value="https://pkgs.dev.azure.com/Servarr/Servarr/_packaging/Mono.Posix.NETStandard/nuget/v3/index.json" />
-    <add key="FFMpegCore" value="https://pkgs.dev.azure.com/Servarr/Servarr/_packaging/FFMpegCore/nuget/v3/index.json" />
   </packageSources>
 </configuration>

--- a/src/NzbDrone.Common.Test/TPLTests/RateLimitServiceFixture.cs
+++ b/src/NzbDrone.Common.Test/TPLTests/RateLimitServiceFixture.cs
@@ -79,7 +79,7 @@ namespace NzbDrone.Common.Test.TPLTests
 
             Subject.WaitAndPulse("me", TimeSpan.FromMilliseconds(100));
 
-            (GetRateLimitStore()["me"] - _epoch).Should().BeGreaterOrEqualTo(TimeSpan.FromMilliseconds(300));
+            (GetRateLimitStore()["me"] - _epoch).Should().BeGreaterThanOrEqualTo(TimeSpan.FromMilliseconds(300));
         }
 
         [Test]
@@ -87,7 +87,7 @@ namespace NzbDrone.Common.Test.TPLTests
         {
             Subject.WaitAndPulse("me", TimeSpan.FromMilliseconds(100));
 
-            (GetRateLimitStore()["me"] - _epoch).Should().BeGreaterOrEqualTo(TimeSpan.FromMilliseconds(100));
+            (GetRateLimitStore()["me"] - _epoch).Should().BeGreaterThanOrEqualTo(TimeSpan.FromMilliseconds(100));
         }
 
         [Test]
@@ -98,7 +98,7 @@ namespace NzbDrone.Common.Test.TPLTests
 
             Subject.WaitAndPulse("me", "sub", TimeSpan.FromMilliseconds(100));
 
-            (GetRateLimitStore()["me-sub"] - _epoch).Should().BeGreaterOrEqualTo(TimeSpan.FromMilliseconds(400));
+            (GetRateLimitStore()["me-sub"] - _epoch).Should().BeGreaterThanOrEqualTo(TimeSpan.FromMilliseconds(400));
         }
 
         [Test]
@@ -109,7 +109,7 @@ namespace NzbDrone.Common.Test.TPLTests
 
             Subject.WaitAndPulse("me", "sub", TimeSpan.FromMilliseconds(100));
 
-            (GetRateLimitStore()["me-sub"] - _epoch).Should().BeGreaterOrEqualTo(TimeSpan.FromMilliseconds(200));
+            (GetRateLimitStore()["me-sub"] - _epoch).Should().BeGreaterThanOrEqualTo(TimeSpan.FromMilliseconds(200));
         }
 
         [Test]

--- a/src/NzbDrone.Core.Test/Datastore/BasicRepositoryFixture.cs
+++ b/src/NzbDrone.Core.Test/Datastore/BasicRepositoryFixture.cs
@@ -19,11 +19,10 @@ namespace NzbDrone.Core.Test.Datastore
         [SetUp]
         public void Setup()
         {
-            AssertionOptions.AssertEquivalencyUsing(options =>
-            {
-                options.Using<DateTime>(ctx => ctx.Subject.Should().BeCloseTo(ctx.Expectation.ToUniversalTime(), _dateTimePrecision)).WhenTypeIs<DateTime>();
-                return options;
-            });
+            AssertionConfiguration.Current.Equivalency.Modify(options =>
+                options.Using<DateTime>(ctx =>
+                        ctx.Subject.Should().BeCloseTo(ctx.Expectation.ToUniversalTime(), _dateTimePrecision))
+                    .WhenTypeIs<DateTime>());
 
             _basicList = Builder<ScheduledTask>
                 .CreateListOfSize(5)

--- a/src/NzbDrone.Core.Test/Download/DownloadClientTests/TransmissionTests/TransmissionFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientTests/TransmissionTests/TransmissionFixture.cs
@@ -298,8 +298,8 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.TransmissionTests
         }
 
         [TestCase(2147483648)] // 2038-01-19T03:14:08Z > int.MaxValue as unix timestamp can be either an int or a long
-        [TestCase(922337203685477)] // TimeSpan.MaxValue.TotalSeconds (should not overflow)
-        [TestCase(9223372036853736645)] // Way above TimeSpan.MaxValue.TotalSeconds (should cap to TimeSpan.MaxValue)
+        [TestCase(922337203685)] // TimeSpan.MaxValue.TotalSeconds (should not overflow)
+        [TestCase(922337203686)] // Way above TimeSpan.MaxValue.TotalSeconds (should cap to TimeSpan.MaxValue)
         public void should_support_long_values_for_eta_in_seconds(long eta)
         {
             _downloading.Eta = eta;
@@ -314,7 +314,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.TransmissionTests
             }
             else
             {
-                item.RemainingTime.Should().BeLessOrEqualTo(TimeSpan.MaxValue);
+                item.RemainingTime.Should().BeGreaterThanOrEqualTo(TimeSpan.MaxValue);
             }
         }
 

--- a/src/NzbDrone.Core.Test/FluentTest.cs
+++ b/src/NzbDrone.Core.Test/FluentTest.cs
@@ -124,7 +124,7 @@ namespace NzbDrone.Core.Test
 
             // Resolve
             var result = new UTF8Encoding().GetBytes(resultString);
-            result.Length.Should().BeLessOrEqualTo(1000);
+            result.Length.Should().BeGreaterThanOrEqualTo(1000);
         }
 
         [Test]

--- a/src/NzbDrone.Core.Test/MediaFiles/MediaInfo/MediaInfoFormatterTests/FormatAudioCodecFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/MediaInfo/MediaInfoFormatterTests/FormatAudioCodecFixture.cs
@@ -1,3 +1,4 @@
+using System;
 using FluentAssertions;
 using NUnit.Framework;
 using NzbDrone.Core.MediaFiles.MediaInfo;
@@ -8,7 +9,7 @@ namespace NzbDrone.Core.Test.MediaFiles.MediaInfo.MediaInfoFormatterTests
     [TestFixture]
     public class FormatAudioCodecFixture : TestBase
     {
-        private static string sceneName = "My.Series.S01E01-Sonarr";
+        private const string SceneName = "My.Series.S01E01-Sonarr";
 
         [TestCase("mp2, ,  ", "droned.s01e03.swedish.720p.hdtv.x264-prince", "MP2")]
         [TestCase("vorbis, ,  ", "DB Super HDTV", "Vorbis")]
@@ -18,26 +19,34 @@ namespace NzbDrone.Core.Test.MediaFiles.MediaInfo.MediaInfoFormatterTests
         [TestCase("truehd, thd+,  ", "Atmos", "TrueHD Atmos")]
         [TestCase("truehd, thd+,  ", "TrueHD.Atmos.7.1", "TrueHD Atmos")]
         [TestCase("truehd, thd+,  ", "", "TrueHD Atmos")]
+        [TestCase("truehd, , Dolby TrueHD + Dolby Atmos", "Atmos", "TrueHD Atmos")]
+        [TestCase("truehd, , Dolby TrueHD + Dolby Atmos", "TrueHD.Atmos.7.1", "TrueHD Atmos")]
+        [TestCase("truehd, , Dolby TrueHD + Dolby Atmos", "", "TrueHD Atmos")]
         [TestCase("wmav1, , ", "Droned.wmv", "WMA")]
         [TestCase("wmav2, , ", "B.N.S04E18.720p.WEB-DL", "WMA")]
         [TestCase("opus, ,  ", "Roadkill Ep3x11 - YouTube.webm", "Opus")]
         [TestCase("mp3, ,  ", "climbing.mp4", "MP3")]
         [TestCase("dts, , DTS-HD MA", "DTS-HD.MA", "DTS-HD MA")]
         [TestCase("dts, , DTS:X", "DTS-X", "DTS-X")]
+        [TestCase("dts, , DTS-HD MA + DTS:X IMAX", "DTS-X", "DTS-X")]
         [TestCase("dts, , DTS-HD MA", "DTS-HD.MA", "DTS-HD MA")]
         [TestCase("dts, , DTS-ES", "DTS-ES", "DTS-ES")]
         [TestCase("dts, , DTS-ES", "DTS", "DTS-ES")]
         [TestCase("dts, , DTS-HD HRA", "DTSHD-HRA", "DTS-HD HRA")]
         [TestCase("dts, , DTS", "DTS", "DTS")]
         [TestCase("eac3, ec+3,  ", "EAC3.Atmos", "EAC3 Atmos")]
+        [TestCase("eac3, , Dolby Digital Plus + Dolby Atmos", "EAC3.Atmos", "EAC3 Atmos")]
         [TestCase("eac3, ,  ", "DDP5.1", "EAC3")]
         [TestCase("ac3, ,  ", "DD5.1", "AC3")]
+        [TestCase("aac, ,  ", "AAC2.0", "AAC")]
+        [TestCase("aac, , HE-AAC", "AAC2.0", "HE-AAC")]
+        [TestCase("aac, , xHE-AAC", "AAC2.0", "xHE-AAC")]
         [TestCase("adpcm_ima_qt, ,  ", "Custom?", "PCM")]
         [TestCase("adpcm_ms, ,  ", "Custom", "PCM")]
 
         public void should_format_audio_format(string audioFormatPack, string sceneName, string expectedFormat)
         {
-            var split = audioFormatPack.Split(new string[] { ", " }, System.StringSplitOptions.None);
+            var split = audioFormatPack.Split(',', StringSplitOptions.TrimEntries);
             var mediaInfoModel = new MediaInfoModel
             {
                 AudioFormat = split[0],
@@ -57,7 +66,7 @@ namespace NzbDrone.Core.Test.MediaFiles.MediaInfo.MediaInfoFormatterTests
                 AudioCodecID = "Other Audio Codec"
             };
 
-            MediaInfoFormatter.FormatAudioCodec(mediaInfoModel, sceneName).Should().Be(mediaInfoModel.AudioFormat);
+            MediaInfoFormatter.FormatAudioCodec(mediaInfoModel, SceneName).Should().Be(mediaInfoModel.AudioFormat);
         }
     }
 }

--- a/src/NzbDrone.Core.Test/MediaFiles/MediaInfo/UpdateMediaInfoServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/MediaInfo/UpdateMediaInfoServiceFixture.cs
@@ -197,6 +197,7 @@ namespace NzbDrone.Core.Test.MediaFiles.MediaInfo
 
             Mocker.GetMock<IMediaFileService>()
                   .Verify(v => v.Update(It.IsAny<MovieFile>()), Times.Exactly(1));
+            ExceptionVerification.IgnoreWarns();
         }
 
         [Test]

--- a/src/NzbDrone.Core.Test/MediaFiles/UpgradeMediaFileServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/UpgradeMediaFileServiceFixture.cs
@@ -87,6 +87,7 @@ namespace NzbDrone.Core.Test.MediaFiles
             Subject.UpgradeMovieFile(_movieFile, _localMovie);
 
             Mocker.GetMock<IMediaFileService>().Verify(v => v.Delete(_localMovie.Movie.MovieFile, DeleteMediaFileReason.Upgrade), Times.Once());
+            ExceptionVerification.IgnoreWarns();
         }
 
         [Test]

--- a/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/TruncatedReleaseGroupFixture.cs
+++ b/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/TruncatedReleaseGroupFixture.cs
@@ -61,7 +61,6 @@ namespace NzbDrone.Core.Test.OrganizerTests.FileNameBuilderTests
             _namingConfig.StandardMovieFormat = "{Movie Title} ({Release Year}) {Quality Full}-{ReleaseGroup:12}";
 
             var result = Subject.BuildFileName(_movie, _movieFile);
-            result.Length.Should().BeLessOrEqualTo(255);
             result.Should().Be("The Fantastic Life of Mr. Sisko (2024) Bluray-1080p-IWishIWas...");
         }
 
@@ -75,7 +74,6 @@ namespace NzbDrone.Core.Test.OrganizerTests.FileNameBuilderTests
             _namingConfig.StandardMovieFormat = "{Movie Title} ({Release Year}) {Quality Full}-{ReleaseGroup:-17}";
 
             var result = Subject.BuildFileName(_movie, _movieFile);
-            result.Length.Should().BeLessOrEqualTo(255);
             result.Should().Be("The Fantastic Life of Mr. Sisko (2024) Bluray-1080p-...ASixFourImpala");
         }
     }

--- a/src/NzbDrone.Core/Download/Clients/Transmission/TransmissionBase.cs
+++ b/src/NzbDrone.Core/Download/Clients/Transmission/TransmissionBase.cs
@@ -96,13 +96,17 @@ namespace NzbDrone.Core.Download.Clients.Transmission
                         // TimeSpan.FromSeconds accepts double, but TimeSpan itself has a max value
                         // Use FromSeconds if within range, otherwise try FromMilliseconds, else cap
                         // 29,219 years is well beyond any reasonable ETA for a download
-                        if (torrent.Eta <= (long)TimeSpan.MaxValue.TotalSeconds)
+                        // Transmission reports ETA in seconds, but some builds return milliseconds when the value
+                        // grows very large. Use a heuristic to treat huge values as milliseconds.
+                        if (torrent.Eta >= 1000L * int.MaxValue)
+                        {
+                            item.RemainingTime = torrent.Eta <= (long)TimeSpan.MaxValue.TotalMilliseconds
+                                ? TimeSpan.FromMilliseconds(torrent.Eta)
+                                : TimeSpan.MaxValue;
+                        }
+                        else if (torrent.Eta < (long)Math.Floor(TimeSpan.MaxValue.TotalSeconds))
                         {
                             item.RemainingTime = TimeSpan.FromSeconds(torrent.Eta);
-                        }
-                        else if (torrent.Eta <= (long)TimeSpan.MaxValue.TotalMilliseconds)
-                        {
-                            item.RemainingTime = TimeSpan.FromMilliseconds(torrent.Eta);
                         }
                         else
                         {
@@ -313,9 +317,9 @@ namespace NzbDrone.Core.Download.Clients.Transmission
                 _logger.Error(ex, ex.Message);
 
                 return new NzbDroneValidationFailure("Host", _localizationService.GetLocalizedString("DownloadClientValidationUnableToConnect", new Dictionary<string, object> { { "clientName", Name } }))
-                       {
-                           DetailedDescription = ex.Message
-                       };
+                {
+                    DetailedDescription = ex.Message
+                };
             }
             catch (Exception ex)
             {

--- a/src/NzbDrone.Core/MediaFiles/MediaInfo/FFMpegCoreSideDataTypes.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaInfo/FFMpegCoreSideDataTypes.cs
@@ -1,0 +1,9 @@
+namespace NzbDrone.Core.MediaFiles.MediaInfo;
+
+internal static class FFMpegCoreSideDataTypes
+{
+    public const string DoviConfigurationRecordSideData = "DOVI configuration record";
+    public const string HdrDynamicMetadataSpmte2094 = "HDR Dynamic Metadata SMPTE2094-40 (HDR10+)";
+    public const string MasteringDisplayMetadata = "Mastering display metadata";
+    public const string ContentLightLevelMetadata = "Content light level metadata";
+}

--- a/src/NzbDrone.Core/MediaFiles/MediaInfo/MediaInfoFormatter.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaInfo/MediaInfoFormatter.cs
@@ -52,7 +52,11 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
 
             if (audioFormat == "truehd")
             {
-                return "TrueHD";
+                return audioProfile switch
+                {
+                    "Dolby TrueHD + Dolby Atmos" => "TrueHD Atmos",
+                    _ => "TrueHD"
+                };
             }
 
             if (audioFormat == "flac")
@@ -62,37 +66,16 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
 
             if (audioFormat == "dts")
             {
-                if (audioProfile == "DTS:X")
+                return audioProfile switch
                 {
-                    return "DTS-X";
-                }
-
-                if (audioProfile == "DTS-HD MA")
-                {
-                    return "DTS-HD MA";
-                }
-
-                if (audioProfile == "DTS-ES")
-                {
-                    return "DTS-ES";
-                }
-
-                if (audioProfile == "DTS-HD HRA")
-                {
-                    return "DTS-HD HRA";
-                }
-
-                if (audioProfile == "DTS Express")
-                {
-                    return "DTS Express";
-                }
-
-                if (audioProfile == "DTS 96/24")
-                {
-                    return "DTS 96/24";
-                }
-
-                return "DTS";
+                    "DTS:X" or "DTS-HD MA + DTS:X IMAX" => "DTS-X",
+                    "DTS-HD MA" => "DTS-HD MA",
+                    "DTS-ES" => "DTS-ES",
+                    "DTS-HD HRA" => "DTS-HD HRA",
+                    "DTS Express" => "DTS Express",
+                    "DTS 96/24" => "DTS 96/24",
+                    _ => "DTS"
+                };
             }
 
             if (audioCodecID == "ec+3")
@@ -102,7 +85,11 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
 
             if (audioFormat == "eac3")
             {
-                return "EAC3";
+                return audioProfile switch
+                {
+                    "Dolby Digital Plus + Dolby Atmos" => "EAC3 Atmos",
+                    _ => "EAC3"
+                };
             }
 
             if (audioFormat == "ac3")
@@ -117,7 +104,12 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
                     return "HE-AAC";
                 }
 
-                return "AAC";
+                return audioProfile switch
+                {
+                    "HE-AAC" => "HE-AAC",
+                    "xHE-AAC" => "xHE-AAC",
+                    _ => "AAC"
+                };
             }
 
             if (audioFormat == "mp3")

--- a/src/NzbDrone.Core/MediaFiles/MediaInfo/MediaInfoModel.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaInfo/MediaInfoModel.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
-using FFMpegCore;
 using NzbDrone.Core.Datastore;
 
 namespace NzbDrone.Core.MediaFiles.MediaInfo
@@ -9,7 +8,7 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
     public class MediaInfoModel : IEmbeddedDocument
     {
         public string RawStreamData { get; set; }
-        public string RawFrameData { get; set; }
+
         public int SchemaRevision { get; set; }
 
         public string ContainerFormat { get; set; }
@@ -28,8 +27,6 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
         public string VideoColourPrimaries { get; set; }
 
         public string VideoTransferCharacteristics { get; set; }
-
-        public DoviConfigurationRecordSideData DoviConfigurationRecord { get; set; }
 
         public HdrFormat VideoHdrFormat { get; set; }
 

--- a/src/NzbDrone.Core/MediaFiles/MediaInfo/VideoFileInfoReader.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaInfo/VideoFileInfoReader.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text.Json.Nodes;
 using FFMpegCore;
 using FFMpegCore.Exceptions;
 using NLog;
@@ -22,10 +23,9 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
         private readonly IDiskProvider _diskProvider;
         private readonly IConfigService _configService;
         private readonly Logger _logger;
-        private readonly List<FFProbePixelFormat> _pixelFormats;
 
-        public const int MINIMUM_MEDIA_INFO_SCHEMA_REVISION = 14;
-        public const int CURRENT_MEDIA_INFO_SCHEMA_REVISION = 14;
+        public const int MINIMUM_MEDIA_INFO_SCHEMA_REVISION = 13;
+        public const int CURRENT_MEDIA_INFO_SCHEMA_REVISION = 13;
 
         private static readonly string[] ValidHdrColourPrimaries = { "bt2020" };
         private static readonly string[] HlgTransferFunctions = { "arib-std-b67" };
@@ -40,16 +40,6 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
 
             // We bundle ffprobe for all platforms
             GlobalFFOptions.Configure(options => options.BinaryFolder = AppDomain.CurrentDomain.BaseDirectory);
-
-            try
-            {
-                _pixelFormats = FFProbe.GetPixelFormats();
-            }
-            catch (Exception e)
-            {
-                _logger.Error(e, "Failed to get supported pixel formats from ffprobe");
-                _pixelFormats = new List<FFProbePixelFormat>();
-            }
         }
 
         public MediaInfoModel GetMediaInfo(string filename)
@@ -68,15 +58,13 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
             try
             {
                 _logger.Debug("Getting media info from {0}", filename);
-                var ffprobeOutput = FFProbe.GetStreamJson(filename, ffOptions: new FFOptions { ExtraArguments = "-probesize 50000000" });
 
-                var analysis = FFProbe.AnalyseStreamJson(ffprobeOutput);
+                var analysis = FFProbe.Analyse(filename, customArguments: "-probesize 50000000");
                 var primaryVideoStream = GetPrimaryVideoStream(analysis);
 
                 if (analysis.PrimaryAudioStream?.ChannelLayout.IsNullOrWhiteSpace() ?? true)
                 {
-                    ffprobeOutput = FFProbe.GetStreamJson(filename, ffOptions: new FFOptions { ExtraArguments = "-probesize 150000000 -analyzeduration 150000000" });
-                    analysis = FFProbe.AnalyseStreamJson(ffprobeOutput);
+                    analysis = FFProbe.Analyse(filename, customArguments: "-probesize 150000000 -analyzeduration 150000000");
                 }
 
                 var mediaInfoModel = new MediaInfoModel();
@@ -89,7 +77,6 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
                 mediaInfoModel.VideoBitDepth = GetPixelFormat(primaryVideoStream?.PixelFormat)?.Components.Min(x => x.BitDepth) ?? 8;
                 mediaInfoModel.VideoColourPrimaries = primaryVideoStream?.ColorPrimaries;
                 mediaInfoModel.VideoTransferCharacteristics = primaryVideoStream?.ColorTransfer;
-                mediaInfoModel.DoviConfigurationRecord = primaryVideoStream?.SideDataList?.Find(x => x.GetType().Name == nameof(DoviConfigurationRecordSideData)) as DoviConfigurationRecordSideData;
                 mediaInfoModel.Height = primaryVideoStream?.Height ?? 0;
                 mediaInfoModel.Width = primaryVideoStream?.Width ?? 0;
                 mediaInfoModel.AudioFormat = analysis.PrimaryAudioStream?.CodecName;
@@ -107,8 +94,12 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
                 mediaInfoModel.Subtitles = analysis.SubtitleStreams?.Select(x => x.Language)
                     .Where(l => l.IsNotNullOrWhiteSpace())
                     .ToList();
-                mediaInfoModel.ScanType = "Progressive";
-                mediaInfoModel.RawStreamData = ffprobeOutput;
+                mediaInfoModel.ScanType = primaryVideoStream?.FieldOrder switch
+                {
+                    "tt" or "bb" or "tb" or "bt" => "Interlaced",
+                    _ => "Progressive"
+                };
+                mediaInfoModel.RawStreamData = string.Concat(analysis.OutputData);
                 mediaInfoModel.SchemaRevision = CURRENT_MEDIA_INFO_SCHEMA_REVISION;
 
                 if (analysis.Format.Tags?.TryGetValue("title", out var title) ?? false)
@@ -121,14 +112,11 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
                 // if it looks like PQ10 or similar HDR, do a frame analysis to figure out which type it is
                 if (PqTransferFunctions.Contains(mediaInfoModel.VideoTransferCharacteristics))
                 {
-                    var frameOutput = FFProbe.GetFrameJson(filename, ffOptions: new () { ExtraArguments = $"-read_intervals \"%+#1\" -select_streams v:{primaryVideoStream?.Index ?? 0}" });
-                    mediaInfoModel.RawFrameData = frameOutput;
-
-                    frames = FFProbe.AnalyseFrameJson(frameOutput);
+                    frames = FFProbe.GetFrames(filename, customArguments: $"-read_intervals \"%+#1\" -select_streams v:{primaryVideoStream?.Index ?? 0}");
                 }
 
-                var streamSideData = primaryVideoStream?.SideDataList ?? new ();
-                var framesSideData = frames?.Frames?.Count > 0 ? frames?.Frames[0]?.SideDataList ?? new () : new ();
+                var streamSideData = primaryVideoStream?.SideData ?? new();
+                var framesSideData = frames?.Frames.FirstOrDefault()?.SideData ?? new();
 
                 var sideData = streamSideData.Concat(framesSideData).ToList();
                 mediaInfoModel.VideoHdrFormat = GetHdrFormat(mediaInfoModel.VideoBitDepth, mediaInfoModel.VideoColourPrimaries, mediaInfoModel.VideoTransferCharacteristics, sideData);
@@ -189,7 +177,7 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
             return 0;
         }
 
-        private VideoStream GetPrimaryVideoStream(IMediaAnalysis mediaAnalysis)
+        private static VideoStream GetPrimaryVideoStream(IMediaAnalysis mediaAnalysis)
         {
             if (mediaAnalysis.VideoStreams.Count <= 1)
             {
@@ -202,23 +190,30 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
             return mediaAnalysis.VideoStreams.FirstOrDefault(s => !codecFilter.Contains(s.CodecName)) ?? mediaAnalysis.PrimaryVideoStream;
         }
 
-        private FFProbePixelFormat GetPixelFormat(string format)
+        private static FFProbePixelFormat GetPixelFormat(string format)
         {
-            return _pixelFormats.Find(x => x.Name == format);
+            if (format.IsNullOrWhiteSpace())
+            {
+                return null;
+            }
+
+            return FFProbe.TryGetPixelFormat(format, out var pixelFormat) ? pixelFormat : null;
         }
 
-        public static HdrFormat GetHdrFormat(int bitDepth, string colorPrimaries, string transferFunction, List<SideData> sideData)
+        public static HdrFormat GetHdrFormat(int bitDepth, string colorPrimaries, string transferFunction, List<Dictionary<string, JsonNode>> sideData)
         {
             if (bitDepth < 10)
             {
                 return HdrFormat.None;
             }
 
-            if (TryGetSideData<DoviConfigurationRecordSideData>(sideData, out var dovi))
+            if (TryGetSideData(sideData, FFMpegCoreSideDataTypes.DoviConfigurationRecordSideData, out var dovi))
             {
-                var hasHdr10Plus = TryGetSideData<HdrDynamicMetadataSpmte2094>(sideData, out _);
+                var hasHdr10Plus = TryGetSideData(sideData, FFMpegCoreSideDataTypes.HdrDynamicMetadataSpmte2094, out _);
 
-                return dovi.DvBlSignalCompatibilityId switch
+                dovi.TryGetValue("dv_bl_signal_compatibility_id", out var dvBlSignalCompatibilityId);
+
+                return dvBlSignalCompatibilityId?.GetValue<int>() switch
                 {
                     1 => hasHdr10Plus ? HdrFormat.DolbyVisionHdr10Plus : HdrFormat.DolbyVisionHdr10,
                     2 => HdrFormat.DolbyVisionSdr,
@@ -240,13 +235,13 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
 
             if (PqTransferFunctions.Contains(transferFunction))
             {
-                if (TryGetSideData<HdrDynamicMetadataSpmte2094>(sideData, out _))
+                if (TryGetSideData(sideData, FFMpegCoreSideDataTypes.HdrDynamicMetadataSpmte2094, out _))
                 {
                     return HdrFormat.Hdr10Plus;
                 }
 
-                if (TryGetSideData<MasteringDisplayMetadata>(sideData, out _) ||
-                    TryGetSideData<ContentLightLevelMetadata>(sideData, out _))
+                if (TryGetSideData(sideData, FFMpegCoreSideDataTypes.MasteringDisplayMetadata, out _) ||
+                    TryGetSideData(sideData, FFMpegCoreSideDataTypes.ContentLightLevelMetadata, out _))
                 {
                     return HdrFormat.Hdr10;
                 }
@@ -257,10 +252,11 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
             return HdrFormat.None;
         }
 
-        private static bool TryGetSideData<T>(List<SideData> list, out T result)
-        where T : SideData
+        private static bool TryGetSideData(IReadOnlyList<Dictionary<string, JsonNode>> list, string name, out Dictionary<string, JsonNode> result)
         {
-            result = (T)list?.FirstOrDefault(x => x.GetType().Name == typeof(T).Name);
+            result = list?.FirstOrDefault(item =>
+                item.TryGetValue("side_data_type", out var rawSideDataType) &&
+                rawSideDataType.GetValue<string>().Equals(name, StringComparison.OrdinalIgnoreCase));
 
             return result != null;
         }

--- a/src/NzbDrone.Core/Whisparr.Core.csproj
+++ b/src/NzbDrone.Core/Whisparr.Core.csproj
@@ -12,8 +12,8 @@
     <PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.1" />
     <PackageReference Include="Npgsql" Version="9.0.3" />
     <PackageReference Include="Polly" Version="8.6.0" />
-    <PackageReference Include="Servarr.FFMpegCore" Version="4.7.0-26" />
-    <PackageReference Include="Servarr.FFprobe" Version="5.1.4.112" />
+    <PackageReference Include="Openur.FFMpegCore" Version="5.4.0.31" />
+    <PackageReference Include="Openur.FFprobeStatic" Version="8.0.1.289" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.3" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.3" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />

--- a/src/NzbDrone.Integration.Test/ApiTests/ReleaseFixture.cs
+++ b/src/NzbDrone.Integration.Test/ApiTests/ReleaseFixture.cs
@@ -44,7 +44,7 @@ namespace NzbDrone.Integration.Test.ApiTests
         private bool BeValidRelease(ReleaseResource releaseResource)
         {
             releaseResource.Guid.Should().NotBeNullOrEmpty();
-            releaseResource.Age.Should().BeGreaterOrEqualTo(-1);
+            releaseResource.Age.Should().BeGreaterThanOrEqualTo(-1);
             releaseResource.Title.Should().NotBeNullOrWhiteSpace();
             releaseResource.DownloadUrl.Should().NotBeNullOrWhiteSpace();
             releaseResource.MovieTitles.First().Should().NotBeNullOrWhiteSpace();

--- a/src/NzbDrone.Mono.Test/Whisparr.Mono.Test.csproj
+++ b/src/NzbDrone.Mono.Test/Whisparr.Mono.Test.csproj
@@ -7,7 +7,7 @@
        See https://github.com/xamarin/XamarinComponents/issues/282
   -->
   <ItemGroup>
-    <PackageReference Include="Mono.Posix.NETStandard" Version="5.20.1.34-servarr20" />
+    <PackageReference Include="Mono.Posix.NETStandard" Version="5.20.1.34-servarr24" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NzbDrone.Common.Test\Whisparr.Common.Test.csproj" />

--- a/src/NzbDrone.Mono/Whisparr.Mono.csproj
+++ b/src/NzbDrone.Mono/Whisparr.Mono.csproj
@@ -8,7 +8,7 @@
        See https://github.com/xamarin/XamarinComponents/issues/282
   -->
   <ItemGroup>
-    <PackageReference Include="Mono.Posix.NETStandard" Version="5.20.1.34-servarr20" />
+    <PackageReference Include="Mono.Posix.NETStandard" Version="5.20.1.34-servarr24" />
     <PackageReference Include="System.IO.FileSystem.AccessControl" Version="5.0.0" />
   </ItemGroup>
   <ItemGroup>

--- a/src/NzbDrone.Test.Common/Whisparr.Test.Common.csproj
+++ b/src/NzbDrone.Test.Common/Whisparr.Test.Common.csproj
@@ -4,7 +4,7 @@
     <IsTestProject>false</IsTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.12.1" />
+    <PackageReference Include="FluentAssertions" Version="8.8.0" />
     <PackageReference Include="FluentValidation" Version="12.1.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="NLog" Version="6.1.0" />


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Updating another round of Nuget packages related to testing.  Had to tweak a few tests to newer package semantics, and hopefully for real fixed the math issue on the Transmission client+test.

##### Updated

- GitHubActionsTestLogger
- FluentAssertions
- Microsoft.NET.Test.Sdk
- Mono.Posix.NETStandard
- FFMpeg and FFProbe (switches from Servarr custom version to official version)


#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

- Refs #59