### PR TITLE
Chore: Bump Selenium, remove Microsoft.Bcl.AsyncInterfaces

### DIFF
--- a/src/NzbDrone.Automation.Test/Whisparr.Automation.Test.csproj
+++ b/src/NzbDrone.Automation.Test/Whisparr.Automation.Test.csproj
@@ -3,11 +3,9 @@
     <TargetFrameworks>net10.0</TargetFrameworks>
   </PropertyGroup>
 <ItemGroup>
-  <PackageReference Include="Selenium.WebDriver" Version="4.27.0" />
-  <PackageReference Include="Selenium.Support" Version="4.27.0" />
-  <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="137.0.7151.6800" />
-  <!-- Suppress warning about missing async interfaces in .NET 6, can remove after moving to .NET 8 -->
-  <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
+  <PackageReference Include="Selenium.WebDriver" Version="4.40.0" />
+  <PackageReference Include="Selenium.Support" Version="4.40.0" />
+  <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="145.0.7632.6700" />
 </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NzbDrone.Test.Common\Whisparr.Test.Common.csproj" />


### PR DESCRIPTION
Microsoft.Bcl.AsyncInterfaces is no longer needed after moving to .NET 8.  Selenium is purely used for test cases, and those all pass on the latest version.

#### Database Migration
NO

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

- Refs #59