### PR TITLE
Fix: Give V3 a unique Key for browser data so it works alongside V2

### DIFF
--- a/frontend/src/Store/Middleware/createPersistState.js
+++ b/frontend/src/Store/Middleware/createPersistState.js
@@ -96,7 +96,7 @@ function merge(initialState, persistedState) {
   return computedState;
 }
 
-const KEY = 'WhisparrV3';
+const KEY = 'WhisparrEros';
 
 const config = {
   slicer,

--- a/frontend/src/Store/Middleware/createPersistState.js
+++ b/frontend/src/Store/Middleware/createPersistState.js
@@ -96,7 +96,7 @@ function merge(initialState, persistedState) {
   return computedState;
 }
 
-const KEY = 'whisparr';
+const KEY = 'WhisparrV3';
 
 const config = {
   slicer,


### PR DESCRIPTION
#### Database Migration
NO

#### Description
V2 and V3 used the same persistent key that is used to store data in local storage.

This does cause issues when some one changes form v2 to v3 as there is already values, usually when they add some items as a dropdown will have a value that does not exist in V3.

Best to separate the data with a different key. 

Downside for all users is any existing settings are lost, and the defaults are applied. 
Upside is that the correct defaults for all items are used and they do not need to be manually cleared.

This gives a known starting point for the data. 

Can this go in after the import change #108 

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX