### PR TITLE
Fix: Correct errors when pages load before movie data

### DIFF
--- a/frontend/src/Movie/MovieStatus.tsx
+++ b/frontend/src/Movie/MovieStatus.tsx
@@ -19,15 +19,14 @@ interface MovieStatusProps {
 }
 
 function MovieStatus({ movieId, movieFileId }: MovieStatusProps) {
-  const {
-    isAvailable,
-    monitored,
-    grabbed = false,
-  } = useMovie(movieId) as Movie;
-
   const queueItem = useSelector(createQueueItemSelectorForHook(movieId));
   const movieFile = useMovieFile(movieFileId);
+  const movie = useMovie(movieId) as Movie;
+  if (!movie) {
+    return null;
+  }
 
+  const { isAvailable, monitored, grabbed = false } = movie;
   const hasMovieFile = !!movieFile;
   const isQueued = !!queueItem;
 

--- a/frontend/src/Movie/useMovie.ts
+++ b/frontend/src/Movie/useMovie.ts
@@ -14,7 +14,13 @@ export function createMovieSelector(movieId?: number) {
     (state: AppState) => state.movies.itemMap,
     (state: AppState) => state.movies.items,
     (itemMap, allMovies) => {
-      return movieId ? allMovies[itemMap[movieId]] : undefined;
+      return movieId &&
+        allMovies &&
+        itemMap &&
+        itemMap[movieId] !== undefined &&
+        allMovies[itemMap[movieId]]
+        ? allMovies[itemMap[movieId]]
+        : undefined;
     }
   );
 }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
load the browser directly in to "/wanted/missing" as the movie state is not populated it attempt to return a movie.

Added some null protection around when it is loaded.

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX