### PR TITLE
Fix: Sporadic MediaCover download exceptions

### DIFF
--- a/src/NzbDrone.Common/Http/HttpClient.cs
+++ b/src/NzbDrone.Common/Http/HttpClient.cs
@@ -264,7 +264,7 @@ namespace NzbDrone.Common.Http
 
         public async Task DownloadFileAsync(string url, string fileName)
         {
-            var fileNamePart = fileName + ".part";
+            var fileNamePart = fileName + "." + Guid.NewGuid().ToString("N") + ".part";
 
             try
             {


### PR DESCRIPTION
#### Database Migration
NO

#### Description
MediaCovers would fail to download due to a race condition in HttpClient.  This is correct for by making the temporary file names globally unique, so separate threads can't stmp on each other.  This primarily happens when doing a bulk add/refresh, where many download requests would be queued up at once.  This impacted all MediaCovers, not just Performer.

Example error was:
```
[v10.0.0.35268] System.IO.FileNotFoundException: Could not find file '/Users/plz12345/Library/Application Support/Whisparr/MediaCover/performer/1143/headshot.jpg.part'.
File name: '/Users/plz12345/Library/Application Support/Whisparr/MediaCover/performer/1143/headshot.jpg.part'
   at System.IO.File.Move(String sourceFileName, String destFileName, Boolean overwrite)
   at NzbDrone.Common.Http.HttpClient.DownloadFileAsync(String url, String fileName) in ./NzbDrone.Common/Http/HttpClient.cs:line 301
   at NzbDrone.Common.Http.HttpClient.DownloadFile(String url, String fileName) in ./NzbDrone.Common/Http/HttpClient.cs:line 316
   at NzbDrone.Core.MediaCover.MediaCoverService.DownloadCover(Performer performer, MediaCover cover) in ./NzbDrone.Core/MediaCover/MediaCoverService.cs:line 498
   at NzbDrone.Core.MediaCover.MediaCoverService.EnsureCovers(Performer performer) in ./NzbDrone.Core/MediaCover/MediaCoverService.cs:line 448
```

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX