### PR TITLE
Fix: Show Movie Monitor Toggle

### DIFF
--- a/frontend/src/Performer/Index/PerformerIndex.tsx
+++ b/frontend/src/Performer/Index/PerformerIndex.tsx
@@ -50,6 +50,7 @@ function PerformerIndex(_: PerformerIndexProps): JSX.Element {
     selectedFilterKey,
     sortDirection,
     view,
+    showMovieMonitorToggle,
     handleFirstPagePress,
     handleLastPagePress,
     handleNextPagePress,
@@ -177,6 +178,7 @@ function PerformerIndex(_: PerformerIndexProps): JSX.Element {
                 sortKey={sortKey}
                 sortDirection={sortDirection}
                 columns={columns}
+                showMovieMonitorToggle={showMovieMonitorToggle}
                 onSortPress={handleSortPress}
               />
               <TablePager

--- a/frontend/src/Performer/Index/Table/PerformerIndexRow.tsx
+++ b/frontend/src/Performer/Index/Table/PerformerIndexRow.tsx
@@ -25,11 +25,12 @@ interface PerformerIndexRowProps {
   performer: Performer;
   sortKey: string;
   columns: Column[];
+  showMovieMonitorToggle?: boolean;
   isSelectMode: boolean;
 }
 
 function PerformerIndexRow(props: PerformerIndexRowProps) {
-  const { performer, columns, isSelectMode } = props;
+  const { performer, columns, isSelectMode, showMovieMonitorToggle } = props;
   const {
     id: performerId,
     fullName,
@@ -111,15 +112,17 @@ function PerformerIndexRow(props: PerformerIndexRowProps) {
             title="scene"
             name={monitored ? icons.SCENE : icons.SCENEUNMONITOR}
           />
-          <Icon
-            containerClassName={
-              moviesMonitored
-                ? styles.statusIcon
-                : `${styles.statusIcon} ${styles.unmonitored}`
-            }
-            title="movie"
-            name={moviesMonitored ? icons.FILM : icons.FILMUNMONITOR}
-          />
+          {showMovieMonitorToggle ? (
+            <Icon
+              containerClassName={
+                moviesMonitored
+                  ? styles.statusIcon
+                  : `${styles.statusIcon} ${styles.unmonitored}`
+              }
+              title="movie"
+              name={moviesMonitored ? icons.FILM : icons.FILMUNMONITOR}
+            />
+          ) : null}
         </TableRowCell>
       );
       return;

--- a/frontend/src/Performer/Index/Table/PerformerIndexTable.tsx
+++ b/frontend/src/Performer/Index/Table/PerformerIndexTable.tsx
@@ -13,6 +13,7 @@ interface PerformerIndexTableProps {
   sortDirection?: SortDirection;
   isSelectMode: boolean;
   columns: Column[];
+  showMovieMonitorToggle?: boolean;
   onSortPress?: (name: string, sortDirection?: SortDirection) => void;
 }
 
@@ -22,6 +23,7 @@ function PerformerIndexTable({
   sortDirection,
   isSelectMode,
   columns,
+  showMovieMonitorToggle,
   onSortPress,
 }: PerformerIndexTableProps) {
   return (
@@ -37,6 +39,7 @@ function PerformerIndexTable({
           <TableRow key={performer.id}>
             <PerformerIndexRow
               performer={performer}
+              showMovieMonitorToggle={showMovieMonitorToggle}
               sortKey={sortKey}
               columns={columns}
               isSelectMode={isSelectMode}

--- a/frontend/src/Performer/Index/usePerformerIndex.ts
+++ b/frontend/src/Performer/Index/usePerformerIndex.ts
@@ -18,8 +18,8 @@ import {
   setPerformerTableOption,
   setPerformerView,
 } from 'Store/Actions/performerActions';
+import { fetchGeneralSettings } from 'Store/Actions/Settings/general';
 import { createCustomFiltersSelector } from 'Store/Selectors/createClientSideCollectionSelector';
-import { useGeneralSettings } from 'Studio/Details/useStudioDetails';
 import { usePerformerIndexQuery } from './usePerformerIndexQuery';
 
 /**
@@ -29,6 +29,22 @@ interface PageFilter {
   key: string;
   operator: string;
   value: string | number | boolean;
+}
+
+/**
+ * Hook to fetch and manage general application settings.
+ * Dispatches the fetchGeneralSettings action on mount and returns the general settings state.
+ *
+ * @returns {AppState['settings']['general']['item']} The general settings object
+ */
+export function useGeneralSettings() {
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    dispatch(fetchGeneralSettings());
+  }, [dispatch]);
+
+  return useSelector((state: AppState) => state.settings.general.item);
 }
 
 /**

--- a/frontend/src/Performer/Index/usePerformerIndex.ts
+++ b/frontend/src/Performer/Index/usePerformerIndex.ts
@@ -19,6 +19,7 @@ import {
   setPerformerView,
 } from 'Store/Actions/performerActions';
 import { createCustomFiltersSelector } from 'Store/Selectors/createClientSideCollectionSelector';
+import { useGeneralSettings } from 'Studio/Details/useStudioDetails';
 import { usePerformerIndexQuery } from './usePerformerIndexQuery';
 
 /**
@@ -90,6 +91,13 @@ export function usePerformerIndex() {
     undefined
   );
   const [isSelectMode, setIsSelectMode] = useState<boolean>(false);
+
+  const generalSettings = useGeneralSettings();
+
+  // Determine if we should show the movie monitor toggle
+  const showMovieMonitorToggle = useMemo(() => {
+    return !!(generalSettings?.whisparrMovieMetadataSource !== 'none');
+  }, [generalSettings?.whisparrMovieMetadataSource]);
 
   // Pagination handlers
 
@@ -227,6 +235,10 @@ export function usePerformerIndex() {
     scrollerRef,
     selectedFilterKey,
     view,
+
+    // Derived data
+    showMovieMonitorToggle,
+
     handleFirstPagePress,
     handleLastPagePress,
     handleNextPagePress,

--- a/frontend/src/Studio/Details/useStudioDetails.ts
+++ b/frontend/src/Studio/Details/useStudioDetails.ts
@@ -191,10 +191,21 @@ export const useStudioDetails = (foreignId: string): UseStudioDetailsReturn => {
     prevStudioRef.current = studio;
   }, [studio, isManualRefresh]);
 
-  // Determine if we should show the movie monitor toggle
+  // Determine if we should show the monitor toggle
   const showMovieMonitorToggle = useMemo(() => {
-    return generalSettings?.whisparrMovieMetadataSource === 'TMDb';
-  }, [generalSettings?.whisparrMovieMetadataSource]);
+    return !!(
+      (generalSettings?.whisparrMovieMetadataSource === 'tmdb' &&
+        studio?.tmdbId &&
+        studio.tmdbId > 0) ||
+      (generalSettings?.whisparrMovieMetadataSource === 'tpdb' &&
+        studio?.tpdbId &&
+        studio.tpdbId.length > 0)
+    );
+  }, [
+    generalSettings?.whisparrMovieMetadataSource,
+    studio?.tmdbId,
+    studio?.tpdbId,
+  ]);
 
   // Handler: Refresh studio
   const onRefreshPress = useCallback(() => {

--- a/frontend/src/Studio/Index/StudioIndex.tsx
+++ b/frontend/src/Studio/Index/StudioIndex.tsx
@@ -45,6 +45,7 @@ function StudioIndex(): JSX.Element {
     selectedFilterKey,
     sortDirection,
     view,
+    showMovieMonitorToggle,
     handleFirstPagePress,
     handleLastPagePress,
     handleNextPagePress,
@@ -173,6 +174,7 @@ function StudioIndex(): JSX.Element {
                 sortKey={sortKey}
                 sortDirection={sortDirection}
                 columns={columns}
+                showMovieMonitorToggle={showMovieMonitorToggle}
                 onSortPress={handleSortPress}
               />
               <TablePager

--- a/frontend/src/Studio/Index/Table/StudioIndexRow.tsx
+++ b/frontend/src/Studio/Index/Table/StudioIndexRow.tsx
@@ -24,10 +24,11 @@ interface StudioIndexRowProps {
   sortKey: string;
   columns: Column[];
   isSelectMode: boolean;
+  showMovieMonitorToggle: boolean;
 }
 
 function StudioIndexRow(props: StudioIndexRowProps) {
-  const { studio, columns, isSelectMode } = props;
+  const { studio, columns, isSelectMode, showMovieMonitorToggle } = props;
   const { id: studioId, qualityProfileId } = studio;
 
   const {
@@ -107,15 +108,17 @@ function StudioIndexRow(props: StudioIndexRowProps) {
             title="scene"
             name={monitored ? icons.SCENE : icons.SCENEUNMONITOR}
           />
-          <Icon
-            containerClassName={
-              moviesMonitored
-                ? styles.statusIcon
-                : `${styles.statusIcon} ${styles.unmonitored}`
-            }
-            title="movie"
-            name={moviesMonitored ? icons.FILM : icons.FILMUNMONITOR}
-          />
+          {showMovieMonitorToggle ? (
+            <Icon
+              containerClassName={
+                moviesMonitored
+                  ? styles.statusIcon
+                  : `${styles.statusIcon} ${styles.unmonitored}`
+              }
+              title="movie"
+              name={moviesMonitored ? icons.FILM : icons.FILMUNMONITOR}
+            />
+          ) : null}
         </TableRowCell>
       );
       return;

--- a/frontend/src/Studio/Index/Table/StudioIndexTable.tsx
+++ b/frontend/src/Studio/Index/Table/StudioIndexTable.tsx
@@ -13,6 +13,7 @@ interface StudioIndexTableProps {
   sortDirection?: SortDirection;
   isSelectMode: boolean;
   columns: Column[];
+  showMovieMonitorToggle: boolean;
   onSortPress?: (name: string, sortDirection?: SortDirection) => void;
 }
 
@@ -22,6 +23,7 @@ function StudioIndexTable({
   sortDirection,
   isSelectMode,
   columns,
+  showMovieMonitorToggle,
   onSortPress,
 }: StudioIndexTableProps) {
   return (
@@ -40,6 +42,7 @@ function StudioIndexTable({
               sortKey={sortKey}
               columns={columns}
               isSelectMode={isSelectMode}
+              showMovieMonitorToggle={showMovieMonitorToggle}
             />
           </TableRow>
         ))}

--- a/frontend/src/Studio/Index/useStudioIndex.ts
+++ b/frontend/src/Studio/Index/useStudioIndex.ts
@@ -4,6 +4,7 @@ import { useHistory } from 'react-router-dom';
 import ModelBase from 'App/ModelBase';
 import { useSelect } from 'App/SelectContext';
 import AppState from 'App/State/AppState';
+import { useGeneralSettings } from 'Performer/Details/usePerformerDetails';
 import {
   setStudioFilter,
   setStudioPage,
@@ -152,6 +153,13 @@ export function useStudioIndex() {
     return null;
   }
 
+  const generalSettings = useGeneralSettings();
+
+  // Determine if we should show the movie monitor toggle
+  const showMovieMonitorToggle = useMemo(() => {
+    return !!(generalSettings?.whisparrMovieMetadataSource !== 'none');
+  }, [generalSettings?.whisparrMovieMetadataSource]);
+
   /**
    * Handle filter selection from the filter menu
    * Resets to first page
@@ -216,6 +224,10 @@ export function useStudioIndex() {
     scrollerRef,
     selectedFilterKey,
     view,
+
+    // Derived data
+    showMovieMonitorToggle,
+
     handleFirstPagePress,
     handleLastPagePress,
     handleNextPagePress,

--- a/frontend/src/Studio/Index/useStudioIndex.ts
+++ b/frontend/src/Studio/Index/useStudioIndex.ts
@@ -4,7 +4,7 @@ import { useHistory } from 'react-router-dom';
 import ModelBase from 'App/ModelBase';
 import { useSelect } from 'App/SelectContext';
 import AppState from 'App/State/AppState';
-import { useGeneralSettings } from 'Performer/Details/usePerformerDetails';
+import { fetchGeneralSettings } from 'Store/Actions/Settings/general';
 import {
   setStudioFilter,
   setStudioPage,
@@ -22,6 +22,22 @@ interface PageFilter {
   key: string;
   operator: string;
   value: string | number | boolean;
+}
+
+/**
+ * Hook to fetch and manage general application settings.
+ * Dispatches the fetchGeneralSettings action on mount and returns the general settings state.
+ *
+ * @returns {AppState['settings']['general']['item']} The general settings object
+ */
+export function useGeneralSettings() {
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    dispatch(fetchGeneralSettings());
+  }, [dispatch]);
+
+  return useSelector((state: AppState) => state.settings.general.item);
 }
 
 /**


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Correct the checks to display the movie monitor toggle if it can be monitored.

Hide if it is none, or check that the source has a populated key value.

The case was incorrect for the source. 

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX