### PR TITLE
Fix: Navigate using the titleSlug

### DIFF
--- a/frontend/src/Activity/Blocklist/BlocklistRow.tsx
+++ b/frontend/src/Activity/Blocklist/BlocklistRow.tsx
@@ -80,7 +80,7 @@ function BlocklistRow(props: BlocklistRowProps) {
         if (name === 'movieMetadata.sortTitle') {
           return (
             <TableRowCell key={name}>
-              <MovieTitleLink foreignId={movie.foreignId} title={movie.title} />
+              <MovieTitleLink titleSlug={movie.titleSlug} title={movie.title} />
             </TableRowCell>
           );
         }

--- a/frontend/src/Activity/History/HistoryRow.tsx
+++ b/frontend/src/Activity/History/HistoryRow.tsx
@@ -118,7 +118,7 @@ function HistoryRow(props: HistoryRowProps) {
         if (name === 'movieMetadata.sortTitle') {
           return (
             <TableRowCell key={name}>
-              <MovieTitleLink foreignId={movie.foreignId} title={movie.title} />
+              <MovieTitleLink titleSlug={movie.titleSlug} title={movie.title} />
             </TableRowCell>
           );
         }

--- a/frontend/src/Activity/Queue/QueueRow.tsx
+++ b/frontend/src/Activity/Queue/QueueRow.tsx
@@ -190,7 +190,7 @@ function QueueRow(props: QueueRowProps) {
             <TableRowCell key={name}>
               {movie ? (
                 <MovieTitleLink
-                  foreignId={movie.foreignId}
+                  titleSlug={movie.titleSlug}
                   title={movie.title}
                 />
               ) : (

--- a/frontend/src/AddMovie/AddNewMovie/AddNewMovie/AddNewMovieSearchResult.js
+++ b/frontend/src/AddMovie/AddNewMovie/AddNewMovie/AddNewMovieSearchResult.js
@@ -96,6 +96,7 @@ class AddNewMovieSearchResult extends Component {
       tmdbId,
       tpdbId,
       title,
+      titleSlug,
       year,
       studioTitle,
       genres,
@@ -133,7 +134,7 @@ class AddNewMovieSearchResult extends Component {
 
     const hasMovieFile = !!movieFile || sizeOnDisk > 0;
 
-    const linkProps = isExistingMovie ? { to: `/movie/${existingMovieId}` } : { onPress: this.onPress };
+    const linkProps = isExistingMovie ? { to: `/movie/${titleSlug}` } : { onPress: this.onPress };
     const providerProps = itemType === 'movie' ? { tmdbId, tpdbId, website } : { stashId: foreignId, website };
 
     let ImageItem = MoviePoster;

--- a/frontend/src/Movie/Index/Overview/MovieIndexOverview.tsx
+++ b/frontend/src/Movie/Index/Overview/MovieIndexOverview.tsx
@@ -39,6 +39,7 @@ const titleRowHeight = 42;
 
 interface MovieIndexOverviewProps {
   movieId: number;
+  titleSlug: string;
   sortKey: string;
   posterWidth: number;
   posterHeight: number;
@@ -50,6 +51,7 @@ interface MovieIndexOverviewProps {
 function MovieIndexOverview(props: MovieIndexOverviewProps) {
   const {
     movieId,
+    titleSlug,
     sortKey,
     posterWidth,
     posterHeight,
@@ -126,7 +128,7 @@ function MovieIndexOverview(props: MovieIndexOverviewProps) {
     setIsDeleteMovieModalOpen(false);
   }, [setIsDeleteMovieModalOpen]);
 
-  const link = `/movie/${movieId}`;
+  const link = `/movie/${titleSlug}`;
 
   const elementStyle = {
     width: `${posterWidth}px`,

--- a/frontend/src/Movie/Index/Overview/MovieIndexOverview.tsx
+++ b/frontend/src/Movie/Index/Overview/MovieIndexOverview.tsx
@@ -39,7 +39,6 @@ const titleRowHeight = 42;
 
 interface MovieIndexOverviewProps {
   movieId: number;
-  titleSlug: string;
   sortKey: string;
   posterWidth: number;
   posterHeight: number;
@@ -51,7 +50,6 @@ interface MovieIndexOverviewProps {
 function MovieIndexOverview(props: MovieIndexOverviewProps) {
   const {
     movieId,
-    titleSlug,
     sortKey,
     posterWidth,
     posterHeight,
@@ -71,6 +69,7 @@ function MovieIndexOverview(props: MovieIndexOverviewProps) {
 
   const {
     title,
+    titleSlug,
     monitored,
     status,
     path,

--- a/frontend/src/Movie/Index/Overview/MovieIndexOverviews.tsx
+++ b/frontend/src/Movie/Index/Overview/MovieIndexOverviews.tsx
@@ -53,7 +53,11 @@ function Row({ index, style, data }: ListChildComponentProps<RowItemData>) {
 
   return (
     <div style={style}>
-      <MovieIndexOverview movieId={movie.id} {...otherData} />
+      <MovieIndexOverview
+        movieId={movie.id}
+        titleSlug={movie.titleSlug}
+        {...otherData}
+      />
     </div>
   );
 }

--- a/frontend/src/Movie/Index/Overview/MovieIndexOverviews.tsx
+++ b/frontend/src/Movie/Index/Overview/MovieIndexOverviews.tsx
@@ -53,11 +53,7 @@ function Row({ index, style, data }: ListChildComponentProps<RowItemData>) {
 
   return (
     <div style={style}>
-      <MovieIndexOverview
-        movieId={movie.id}
-        titleSlug={movie.titleSlug}
-        {...otherData}
-      />
+      <MovieIndexOverview movieId={movie.id} {...otherData} />
     </div>
   );
 }

--- a/frontend/src/Movie/Index/Posters/MovieIndexPoster.tsx
+++ b/frontend/src/Movie/Index/Posters/MovieIndexPoster.tsx
@@ -63,6 +63,7 @@ function MovieIndexPoster(props: MovieIndexPosterProps) {
 
   const {
     title,
+    titleSlug,
     monitored,
     status,
     images,
@@ -155,7 +156,7 @@ function MovieIndexPoster(props: MovieIndexPosterProps) {
     [movieId, selectState.selectedState, selectDispatch, foreignId]
   );
 
-  const link = `/movie/${movieId}`;
+  const link = `/movie/${titleSlug}`;
 
   const linkProps = isSelectMode ? { onPress: onSelectPress } : { to: link };
 

--- a/frontend/src/Movie/Index/Table/MovieIndexRow.tsx
+++ b/frontend/src/Movie/Index/Table/MovieIndexRow.tsx
@@ -4,7 +4,6 @@ import { useSelect } from 'App/SelectContext';
 import { MOVIE_SEARCH, REFRESH_MOVIE } from 'Commands/commandNames';
 import Icon from 'Components/Icon';
 import IconButton from 'Components/Link/IconButton';
-import Link from 'Components/Link/Link';
 import SpinnerIconButton from 'Components/Link/SpinnerIconButton';
 import MovieTagList from 'Components/MovieTagList';
 import RelativeDateCell from 'Components/Table/Cells/RelativeDateCell';
@@ -19,6 +18,7 @@ import MovieDetailsLinks from 'Movie/Details/MovieDetailsLinks';
 import EditMovieModal from 'Movie/Edit/EditMovieModal';
 import createMovieIndexItemSelector from 'Movie/Index/createMovieIndexItemSelector';
 import { Statistics } from 'Movie/Movie';
+import MovieTitleLink from 'Movie/MovieTitleLink';
 import { executeCommand } from 'Store/Actions/commandActions';
 import createUISettingsSelector from 'Store/Selectors/createUISettingsSelector';
 import { SelectStateInputProps } from 'typings/props';
@@ -50,6 +50,7 @@ function MovieIndexRow(props: MovieIndexRowProps) {
   const {
     monitored,
     foreignId,
+    titleSlug,
     title,
     website,
     studioTitle,
@@ -162,7 +163,7 @@ function MovieIndexRow(props: MovieIndexRowProps) {
         if (name === 'sortTitle') {
           return (
             <VirtualTableRowCell key={name} className={styles[name]}>
-              <Link to={`/movie/${movieId}`}>{title}</Link>
+              <MovieTitleLink titleSlug={titleSlug} title={title} />
             </VirtualTableRowCell>
           );
         }

--- a/frontend/src/Movie/MovieTitleLink.tsx
+++ b/frontend/src/Movie/MovieTitleLink.tsx
@@ -2,20 +2,18 @@ import React from 'react';
 import Link, { LinkProps } from 'Components/Link/Link';
 
 interface MovieTitleLinkProps extends LinkProps {
-  foreignId: string;
   title: string;
   year?: number;
   titleSlug?: string;
 }
 
 function MovieTitleLink({
-  foreignId,
   title,
   year = 0,
   titleSlug,
   ...otherProps
 }: MovieTitleLinkProps) {
-  const link = `/movie/${foreignId}`;
+  const link = `/movie/${titleSlug}`;
 
   return (
     <Link to={link} title={title} {...otherProps}>

--- a/frontend/src/Parse/ParseResult.tsx
+++ b/frontend/src/Parse/ParseResult.tsx
@@ -122,7 +122,7 @@ function ParseResult(props: ParseResultProps) {
           data={
             movie ? (
               <MovieTitleLink
-                foreignId={movie.foreignId}
+                titleSlug={movie.titleSlug}
                 title={movie.title}
                 year={movie.year}
               />

--- a/frontend/src/Performer/Details/SceneRow.tsx
+++ b/frontend/src/Performer/Details/SceneRow.tsx
@@ -40,6 +40,7 @@ interface SceneRowProps {
   runtime?: number;
   movieRuntimeFormat?: string;
   title: string;
+  titleSlug: string;
   isSaving?: boolean;
   path?: string;
   relativePath?: string;
@@ -107,6 +108,7 @@ class SceneRow extends Component<SceneRowProps, SceneRowState> {
       movieRuntimeFormat,
       releaseDate,
       title,
+      titleSlug,
       isSaving,
       studioTitle,
       studioForeignId,
@@ -163,7 +165,7 @@ class SceneRow extends Component<SceneRowProps, SceneRowState> {
           if (name === 'title') {
             return (
               <TableRowCell key={name} className={styles.title}>
-                <MovieTitleLink foreignId={foreignId} title={title} />
+                <MovieTitleLink titleSlug={titleSlug} title={title} />
               </TableRowCell>
             );
           }

--- a/frontend/src/Studio/Details/SceneRow.tsx
+++ b/frontend/src/Studio/Details/SceneRow.tsx
@@ -21,7 +21,6 @@ import styles from './SceneRow.css';
 
 interface SceneRowProps {
   id: number;
-  foreignId: string;
   movieFileId?: number;
   isAvailable: boolean;
   hasFile: boolean;
@@ -34,6 +33,7 @@ interface SceneRowProps {
   movieRuntimeFormat?: string;
   safeForWorkMode?: boolean;
   title: string;
+  titleSlug: string;
   isSaving?: boolean;
   movieFilePath?: string;
   movieFileSize?: number;
@@ -99,7 +99,6 @@ class SceneRow extends Component<SceneRowProps, SceneRowState> {
   render() {
     const {
       id,
-      foreignId,
       movieFileId,
       monitored,
       performerNames,
@@ -110,6 +109,7 @@ class SceneRow extends Component<SceneRowProps, SceneRowState> {
       movieRuntimeFormat,
       releaseDate,
       title,
+      titleSlug,
       isSaving,
       movieFilePath,
       movieFileSize,
@@ -141,7 +141,7 @@ class SceneRow extends Component<SceneRowProps, SceneRowState> {
           if (name === 'title') {
             return (
               <TableRowCell key={name} className={styles.title}>
-                <MovieTitleLink foreignId={foreignId} title={title} />
+                <MovieTitleLink titleSlug={titleSlug} title={title} />
               </TableRowCell>
             );
           }

--- a/frontend/src/Wanted/CutoffUnmet/CutoffUnmetRow.tsx
+++ b/frontend/src/Wanted/CutoffUnmet/CutoffUnmetRow.tsx
@@ -26,11 +26,11 @@ interface CutoffUnmetRowProps {
 
 function CutoffUnmetRow({
   id,
-  foreignId,
   movieFileId,
   releaseDate,
   lastSearchTime,
   title,
+  titleSlug,
   year,
   isSelected,
   columns,
@@ -58,7 +58,7 @@ function CutoffUnmetRow({
         if (name === 'movieMetadata.sortTitle') {
           return (
             <TableRowCell key={name}>
-              <MovieTitleLink foreignId={foreignId} title={title} />
+              <MovieTitleLink titleSlug={titleSlug} title={title} />
             </TableRowCell>
           );
         }

--- a/frontend/src/Wanted/Missing/MissingRow.tsx
+++ b/frontend/src/Wanted/Missing/MissingRow.tsx
@@ -19,6 +19,7 @@ interface MissingRowProps {
   physicalRelease?: string;
   lastSearchTime?: string;
   title: string;
+  titleSlug: string;
   year: number;
   releaseDate?: string;
   isSelected?: boolean;
@@ -28,11 +29,11 @@ interface MissingRowProps {
 
 function MissingRow({
   id,
-  foreignId,
   movieFileId,
   releaseDate,
   lastSearchTime,
   title,
+  titleSlug,
   year,
   isSelected,
   columns,
@@ -60,7 +61,7 @@ function MissingRow({
         if (name === 'movieMetadata.sortTitle') {
           return (
             <TableRowCell key={name}>
-              <MovieTitleLink foreignId={foreignId} title={title} />
+              <MovieTitleLink titleSlug={titleSlug} title={title} />
             </TableRowCell>
           );
         }

--- a/src/Whisparr.Api.V3/Movies/MovieController.cs
+++ b/src/Whisparr.Api.V3/Movies/MovieController.cs
@@ -263,9 +263,9 @@ namespace Whisparr.Api.V3.Movies
 
             if (!isNumeric)
             {
-                if (id.StartsWith("tmdbid:"))
+                if (id.StartsWith("tmdb:"))
                 {
-                    if (int.TryParse(id.Replace("tmdbid:", ""), out var tmdbid))
+                    if (int.TryParse(id.Replace("tmdb:", ""), out var tmdbid))
                     {
                         var resourceByForeignId = _moviesService.FindByTmdbId(tmdbid);
                         resource = resourceByForeignId.ToResource(_configService.AvailabilityDelay, _qualityUpgradableSpecification);

--- a/src/Whisparr.Api.V3/Movies/MovieController.cs
+++ b/src/Whisparr.Api.V3/Movies/MovieController.cs
@@ -263,8 +263,19 @@ namespace Whisparr.Api.V3.Movies
 
             if (!isNumeric)
             {
-                var resourceByForeignId = _moviesService.FindByForeignId(id);
-                resource = resourceByForeignId.ToResource(_configService.AvailabilityDelay, _qualityUpgradableSpecification);
+                if (id.StartsWith("tmdbid:"))
+                {
+                    if (int.TryParse(id.Replace("tmdbid:", ""), out var tmdbid))
+                    {
+                        var resourceByForeignId = _moviesService.FindByTmdbId(tmdbid);
+                        resource = resourceByForeignId.ToResource(_configService.AvailabilityDelay, _qualityUpgradableSpecification);
+                    }
+                }
+                else
+                {
+                    var resourceByForeignId = _moviesService.FindByForeignId(id);
+                    resource = resourceByForeignId.ToResource(_configService.AvailabilityDelay, _qualityUpgradableSpecification);
+                }
             }
             else if (isNumeric)
             {

--- a/src/Whisparr.Api.V3/Movies/MovieResource.cs
+++ b/src/Whisparr.Api.V3/Movies/MovieResource.cs
@@ -115,8 +115,8 @@ namespace Whisparr.Api.V3.Movies
 
             var collection = model.MovieMetadata.Value.CollectionTmdbId > 0 ? new MovieCollectionResource { Title = model.MovieMetadata.Value.CollectionTitle, TmdbId = model.MovieMetadata.Value.CollectionTmdbId } : null;
 
-            // Convert to tmdbid: if TmdbId is present, to allow GetMovieById(string id) to be used.
-            var titleSlug = model.TmdbId > 0 ? $"tmdbid:{model.TmdbId}" : model.MovieMetadata.Value.ForeignId;
+            // Convert to tmdb: if TmdbId is present, to allow GetMovieById(string id) to be used.
+            var titleSlug = model.TmdbId > 0 ? $"tmdb:{model.TmdbId}" : model.MovieMetadata.Value.ForeignId;
 
             return new MovieResource
             {

--- a/src/Whisparr.Api.V3/Movies/MovieResource.cs
+++ b/src/Whisparr.Api.V3/Movies/MovieResource.cs
@@ -115,6 +115,9 @@ namespace Whisparr.Api.V3.Movies
 
             var collection = model.MovieMetadata.Value.CollectionTmdbId > 0 ? new MovieCollectionResource { Title = model.MovieMetadata.Value.CollectionTitle, TmdbId = model.MovieMetadata.Value.CollectionTmdbId } : null;
 
+            // Convert to tmdbid: if TmdbId is present, to allow GetMovieById(string id) to be used.
+            var titleSlug = model.TmdbId > 0 ? $"tmdbid:{model.TmdbId}" : model.MovieMetadata.Value.ForeignId;
+
             return new MovieResource
             {
                 Id = model.Id,
@@ -150,7 +153,7 @@ namespace Whisparr.Api.V3.Movies
                 Runtime = model.MovieMetadata.Value.Runtime,
                 CleanTitle = model.MovieMetadata.Value.CleanTitle,
                 ImdbId = model.ImdbId,
-                TitleSlug = model.MovieMetadata.Value.ForeignId.ToString(),
+                TitleSlug = titleSlug,
                 RootFolderPath = model.RootFolderPath,
                 Website = model.MovieMetadata.Value.Website,
                 Genres = model.MovieMetadata.Value.Genres,


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Calculate a titleSlug for TMDB that is not numeric, so that the correct API endpoint is hit.

Use the titleSlug for navigation, so that the external Id is displayed for all items.

MovieTitleLink is now used again for all navigations to format and the link description and href.

another potential way to fix, would be to calculate tmdb title slug to match the TMDB site.

https://www.themoviedb.org/movie/699665-consumed-by-desire

They use a title slug that is the id and then the title.
699665-consumed-by-desire

#### Screenshot (if UI related)

#### Todos
- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX