### PR TITLE
Fix: Unable to use "is not" filters after server-side filtering enabled

### DIFF
--- a/src/NzbDrone.Core.Test/Datastore/WhereBuilderPostgresFixture.cs
+++ b/src/NzbDrone.Core.Test/Datastore/WhereBuilderPostgresFixture.cs
@@ -197,5 +197,32 @@ namespace NzbDrone.Core.Test.Datastore
 
             _subject.ToString().Should().Be($"(\"MovieMetadata\".\"Status\" = ANY (@Clause1_P1))");
         }
+
+        [Test]
+        public void postgres_where_not_in_list()
+        {
+            var list = new List<int> { 1, 2, 3 };
+            _subject = Where(x => !list.Contains(x.Id));
+
+            _subject.ToString().Should().Be($"NOT (\"Movies\".\"Id\" = ANY (('{{1, 2, 3}}')))");
+        }
+
+        [Test]
+        public void postgres_where_not_in_list_single_value()
+        {
+            var list = new List<int> { 5 };
+            _subject = Where(x => !list.Contains(x.Id));
+
+            _subject.ToString().Should().Be($"NOT (\"Movies\".\"Id\" = ANY (('{{5}}')))");
+        }
+
+        [Test]
+        public void postgres_where_not_in_string_list()
+        {
+            var list = new List<string> { "first", "second" };
+            _subject = WhereMeta(x => !list.Contains(x.CleanTitle));
+
+            _subject.ToString().Should().Be($"NOT (\"MovieMetadata\".\"CleanTitle\" = ANY (@Clause1_P1))");
+        }
     }
 }

--- a/src/NzbDrone.Core.Test/Datastore/WhereBuilderSqliteFixture.cs
+++ b/src/NzbDrone.Core.Test/Datastore/WhereBuilderSqliteFixture.cs
@@ -199,5 +199,34 @@ namespace NzbDrone.Core.Test.Datastore
 
             _subject.ToString().Should().Be($"(\"MovieMetadata\".\"Status\" IN @Clause1_P1)");
         }
+
+        [Test]
+        public void where_not_in_list()
+        {
+            var list = new List<int> { 1, 2, 3 };
+            _subject = Where(x => !list.Contains(x.Id));
+
+            _subject.ToString().Should().Be($"NOT (\"Movies\".\"Id\" IN (1, 2, 3))");
+            _subject.Parameters.ParameterNames.Should().BeEmpty();
+        }
+
+        [Test]
+        public void where_not_in_list_single_value()
+        {
+            var list = new List<int> { 5 };
+            _subject = Where(x => !list.Contains(x.Id));
+
+            _subject.ToString().Should().Be($"NOT (\"Movies\".\"Id\" IN (5))");
+            _subject.Parameters.ParameterNames.Should().BeEmpty();
+        }
+
+        [Test]
+        public void where_not_in_string_list()
+        {
+            var list = new List<string> { "first", "second" };
+            _subject = WhereMeta(x => !list.Contains(x.CleanTitle));
+
+            _subject.ToString().Should().Be($"NOT (\"MovieMetadata\".\"CleanTitle\" IN @Clause1_P1)");
+        }
     }
 }

--- a/src/NzbDrone.Core/Datastore/WhereBuilderPostgres.cs
+++ b/src/NzbDrone.Core/Datastore/WhereBuilderPostgres.cs
@@ -57,6 +57,23 @@ namespace NzbDrone.Core.Datastore
             return expression;
         }
 
+        protected override Expression VisitUnary(UnaryExpression expression)
+        {
+            switch (expression.NodeType)
+            {
+                case ExpressionType.Not:
+                    _sb.Append("NOT ");
+                    Visit(expression.Operand);
+                    return expression;
+                case ExpressionType.Convert:
+                case ExpressionType.ConvertChecked:
+                    Visit(expression.Operand);
+                    return expression;
+                default:
+                    return base.VisitUnary(expression);
+            }
+        }
+
         protected override Expression VisitMethodCall(MethodCallExpression expression)
         {
             var method = expression.Method.Name;

--- a/src/NzbDrone.Core/Datastore/WhereBuilderSqlite.cs
+++ b/src/NzbDrone.Core/Datastore/WhereBuilderSqlite.cs
@@ -57,6 +57,23 @@ namespace NzbDrone.Core.Datastore
             return expression;
         }
 
+        protected override Expression VisitUnary(UnaryExpression expression)
+        {
+            switch (expression.NodeType)
+            {
+                case ExpressionType.Not:
+                    _sb.Append("NOT ");
+                    Visit(expression.Operand);
+                    return expression;
+                case ExpressionType.Convert:
+                case ExpressionType.ConvertChecked:
+                    Visit(expression.Operand);
+                    return expression;
+                default:
+                    return base.VisitUnary(expression);
+            }
+        }
+
         protected override Expression VisitMethodCall(MethodCallExpression expression)
         {
             var method = expression.Method.Name;


### PR DESCRIPTION
#### Database Migration
NO

#### Description
The BaseRepository didn't have the use of a "NOT IN" SQL builder type.  This was never an issue because this type of filtering would normally happen client-side, but after moving to server-side filtering, it became apparent.  Simple repro would be a filter like "performer hair color is not blonde" on the front end, which would translate the raw SQL without the `NOT`, and actuyally invert the expected results.

Tests pass and UX passes locally, but I don't have Postgres in dev env, so relying on CI to tell us if that is OK.

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

- Fixes whisparr/whisparr#1019