### PR TITLE
Fix: Exclude musl from normal linux updater

### DIFF
--- a/src/NzbDrone.Core/Update/GithubUpdatePackageProvider.cs
+++ b/src/NzbDrone.Core/Update/GithubUpdatePackageProvider.cs
@@ -162,6 +162,14 @@ namespace NzbDrone.Core.Update
                         a.name.Contains(arch, StringComparison.OrdinalIgnoreCase) &&
                         a.name.EndsWith(".zip", StringComparison.OrdinalIgnoreCase));
                 }
+                else if (OsInfo.Os == Os.Linux)
+                {
+                    // Exclude musl assets for non-musl Linux: "linux" matches "linux-musl-x64" too
+                    asset = release.assets.FirstOrDefault(a =>
+                        a.name.Contains(osAssetString, StringComparison.OrdinalIgnoreCase) &&
+                        a.name.Contains(arch, StringComparison.OrdinalIgnoreCase) &&
+                        !a.name.Contains("musl", StringComparison.OrdinalIgnoreCase));
+                }
                 else
                 {
                     asset = release.assets.FirstOrDefault(a =>


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Adds an explicit exclusion to prevent non-musl linux clients from seeing the musl-packages during update checks.  musl linux will hit the default selection case, since the OSAssetString is distinct enough to not overlap anything else.
#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

- Fixes whisparr/whisparr#1016