### PR TITLE
Fix: Year coloring and stats on Studio, Performer

### DIFF
--- a/frontend/src/Performer/Details/PerformerDetailsYear.tsx
+++ b/frontend/src/Performer/Details/PerformerDetailsYear.tsx
@@ -66,6 +66,7 @@ function PerformerDetailsYear(props: PerformerDetailsYearProps) {
   const movieFileCount = movies.filter(
     (m) => m.sizeOnDisk && m.sizeOnDisk > 0
   ).length;
+  const missingMonitored = movies.some((m) => m.monitored && !m.movieFileId);
   const sizeOnDisk = movies.reduce((total, movie) => {
     if (movie.sizeOnDisk) {
       return total + movie.sizeOnDisk;
@@ -88,19 +89,25 @@ function PerformerDetailsYear(props: PerformerDetailsYearProps) {
   const sortedMovies = moviesCopy;
 
   // Determine movie count background color
-  function getMovieCountKind(
-    monitored: boolean,
-    movieFileCount: number,
-    movieCount: number
-  ) {
-    if (movieFileCount === movieCount && movieCount > 0) {
-      return kinds.SUCCESS;
+  function getMovieCountKind() {
+    switch (true) {
+      case missingMonitored:
+        return kinds.DANGER;
+      case movieFileCount !== totalMovieCount &&
+        !missingMonitored &&
+        monitoredMovieCount > 0:
+        return kinds.WARNING;
+      case movieFileCount !== totalMovieCount &&
+        !missingMonitored &&
+        monitoredMovieCount === 0:
+        return kinds.DEFAULT;
+      case movieFileCount === totalMovieCount:
+        return kinds.SUCCESS;
+      default:
+        return kinds.DANGER;
     }
-    if (!monitored) {
-      return kinds.WARNING;
-    }
-    return kinds.DANGER;
   }
+  const yearKind = getMovieCountKind();
 
   function handleBulkMonitorPress() {
     bulkMonitor(movies);
@@ -148,10 +155,7 @@ function PerformerDetailsYear(props: PerformerDetailsYearProps) {
             className={styles.movieCountTooltip}
             canFlip={true}
             anchor={
-              <Label
-                kind={getMovieCountKind(true, movieFileCount, totalMovieCount)}
-                size={sizes.LARGE}
-              >
+              <Label kind={yearKind} size={sizes.LARGE}>
                 <span>
                   {movieFileCount} / {totalMovieCount}
                 </span>
@@ -228,7 +232,7 @@ function PerformerDetailsYear(props: PerformerDetailsYearProps) {
                     return (
                       <SceneRow
                         key={movie.id}
-                        {...movie}
+                        movie={movie}
                         safeForWorkMode={safeForWorkMode}
                         columns={columns}
                         onMonitorMoviePress={handleMonitorMoviePress}

--- a/frontend/src/Performer/Details/SceneRow.tsx
+++ b/frontend/src/Performer/Details/SceneRow.tsx
@@ -1,4 +1,5 @@
-import React, { Component } from 'react';
+import React from 'react';
+import { useSelector } from 'react-redux';
 import { Link } from 'react-router-dom';
 import Icon from 'Components/Icon';
 import MonitorToggleButton from 'Components/MonitorToggleButton';
@@ -7,55 +8,21 @@ import TableRowCell from 'Components/Table/Cells/TableRowCell';
 import Column from 'Components/Table/Column';
 import TableRow from 'Components/Table/TableRow';
 import Tooltip from 'Components/Tooltip/Tooltip';
-import { icons, tooltipPositions } from 'Helpers/Props';
+import { icons } from 'Helpers/Props';
 import MovieIndexProgressBar from 'Movie/Index/ProgressBar/MovieIndexProgressBar';
-import { MovieStatus } from 'Movie/Movie';
-import MovieFormats from 'Movie/MovieFormats';
+import Movie, { MovieStatus } from 'Movie/Movie';
 import MovieSearchCell from 'Movie/MovieSearchCell';
 import MovieTitleLink from 'Movie/MovieTitleLink';
-import MediaInfo from 'MovieFile/Editor/MediaInfo';
-import { MovieFile } from 'MovieFile/MovieFile';
-import MovieFileLanguageConnector from 'MovieFile/MovieFileLanguages';
-import type { default as CustomFormatType } from 'typings/CustomFormat';
+import createUISettingsSelector from 'Store/Selectors/createUISettingsSelector';
 import formatRuntime from 'Utilities/Date/formatRuntime';
 import formatBytes from 'Utilities/Number/formatBytes';
-import formatCustomFormatScore from 'Utilities/Number/formatCustomFormatScore';
 import translate from 'Utilities/String/translate';
 import styles from './SceneRow.css';
 
 interface SceneRowProps {
-  id: number;
-  itemType: string;
-  foreignId: string;
-  movieFileId?: number;
-  isAvailable: boolean;
-  hasFile: boolean;
-  movieFile?: MovieFile;
-  monitored: boolean;
-  languages?: string[];
-  audioLanguages?: string[];
-  performerNames?: string[];
-  joinedPerformers?: string;
-  releaseDate?: string;
-  runtime?: number;
-  movieRuntimeFormat?: string;
-  title: string;
-  titleSlug: string;
+  movie: Movie;
   isSaving?: boolean;
-  path?: string;
-  relativePath?: string;
-  movieFilePath?: string;
-  movieFileRelativePath?: string;
-  sizeOnDisk?: number;
-  releaseGroup?: string;
-  rootFolderPath?: string;
-  status: MovieStatus;
   safeForWorkMode?: boolean;
-  studioTitle?: string;
-  studioForeignId?: string;
-  customFormats?: CustomFormatType[];
-  customFormatScore?: number;
-  mediaInfo?: ReturnType<typeof MediaInfo>;
   columns: Column[];
   onMonitorMoviePress: (
     id: number,
@@ -64,328 +31,200 @@ interface SceneRowProps {
   ) => void;
 }
 
+/*
 interface SceneRowState {
   isDetailsModalOpen: boolean;
 }
+*/
 
-class SceneRow extends Component<SceneRowProps, SceneRowState> {
-  constructor(props: SceneRowProps, context?: object) {
-    super(props, context);
-    this.state = {
-      isDetailsModalOpen: false,
-    };
+export default function SceneRow(props: SceneRowProps) {
+  const { movieRuntimeFormat } = useSelector(createUISettingsSelector());
+
+  /*
+const onManualSearchPress = (): void => {
+  setIsDetailsModalOpen(true);
+};
+
+
+const onDetailsModalClose = (): void => {
+  setIsDetailsModalOpen(false);
+};
+*/
+  function onMonitorToggle(): void {
+    const { id, monitored } = props.movie;
+    props.onMonitorMoviePress(id, !monitored);
   }
 
-  onManualSearchPress = (): void => {
-    this.setState({ isDetailsModalOpen: true });
+  const { isSaving, columns, movie } = props;
+
+  const {
+    id,
+    itemType,
+    foreignId,
+    monitored,
+    performerNames,
+    runtime,
+    path,
+    isAvailable,
+    hasFile,
+    movieFile,
+    releaseDate,
+    title,
+    titleSlug,
+    studioTitle,
+    studioForeignId,
+    sizeOnDisk,
+  } = movie;
+
+  const status = movie.status as MovieStatus;
+  const externalLink = () => {
+    if (!foreignId) return '';
+    if (foreignId.startsWith('tpdbId:')) {
+      return `https://www.theporndb.net/movies/${foreignId.replace(
+        'tpdbId:',
+        ''
+      )}`;
+    }
+    if (parseInt(foreignId) > 0) {
+      return `https://www.themoviedb.org/movie/${foreignId.replace(
+        'tmdbId:',
+        ''
+      )}`;
+    }
+    // failsafe, though we shouldn't ever need this
+    return `https://stashdb.org/scene/${foreignId}`;
   };
 
-  onDetailsModalClose = (): void => {
-    this.setState({ isDetailsModalOpen: false });
-  };
+  const url = externalLink();
+  return (
+    <TableRow>
+      {columns.map((column) => {
+        const { name, isVisible } = column;
+        if (!isVisible) return null;
 
-  onMonitorToggle = (): void => {
-    const { id, monitored, onMonitorMoviePress } = this.props;
-    onMonitorMoviePress(id, !monitored);
-  };
+        if (name === 'monitored') {
+          return (
+            <TableRowCell key={name} className={styles.monitored}>
+              <MonitorToggleButton
+                className={styles.monitorToggleButton}
+                size={20}
+                type={itemType === 'scene' ? 'sceneMonitor' : 'movieMonitor'}
+                monitored={monitored}
+                moviesMonitored={monitored}
+                isSaving={isSaving}
+                isDisabled={false}
+                onPress={onMonitorToggle}
+              />
+            </TableRowCell>
+          );
+        }
 
-  render() {
-    const {
-      id,
-      itemType,
-      foreignId,
-      movieFileId,
-      monitored,
-      performerNames,
-      runtime,
-      path,
-      relativePath,
-      languages,
-      audioLanguages,
-      isAvailable,
-      hasFile,
-      movieFile,
-      movieRuntimeFormat,
-      releaseDate,
-      title,
-      titleSlug,
-      isSaving,
-      studioTitle,
-      studioForeignId,
-      sizeOnDisk,
-      releaseGroup,
-      customFormats = [],
-      customFormatScore,
-      columns,
-    } = this.props;
+        if (name === 'title') {
+          return (
+            <TableRowCell key={name} className={styles.title}>
+              <MovieTitleLink titleSlug={titleSlug} title={title} />
+            </TableRowCell>
+          );
+        }
 
-    const status = this.props.status as MovieStatus;
-    const externalLink = () => {
-      if (!foreignId) return '';
-      if (foreignId.startsWith('tpdbId:')) {
-        return `https://www.theporndb.net/movies/${foreignId.replace(
-          'tpdbId:',
-          ''
-        )}`;
-      }
-      if (parseInt(foreignId) > 0) {
-        return `https://www.themoviedb.org/movie/${foreignId.replace(
-          'tmdbId:',
-          ''
-        )}`;
-      }
-      // failsafe, though we shouldn't ever need this
-      return `https://stashdb.org/scene/${foreignId}`;
-    };
-
-    const url = externalLink();
-    return (
-      <TableRow>
-        {columns.map((column) => {
-          const { name, isVisible } = column;
-          if (!isVisible) return null;
-
-          if (name === 'monitored') {
-            return (
-              <TableRowCell key={name} className={styles.monitored}>
-                <MonitorToggleButton
-                  className={styles.monitorToggleButton}
-                  size={20}
-                  type={itemType === 'scene' ? 'sceneMonitor' : 'movieMonitor'}
-                  monitored={monitored}
-                  moviesMonitored={monitored}
-                  isSaving={isSaving}
-                  isDisabled={false}
-                  onPress={this.onMonitorToggle}
-                />
-              </TableRowCell>
-            );
-          }
-
-          if (name === 'title') {
-            return (
-              <TableRowCell key={name} className={styles.title}>
-                <MovieTitleLink titleSlug={titleSlug} title={title} />
-              </TableRowCell>
-            );
-          }
-
-          // Fully populated Studio will link to it, otherwise just show name
-          if (name === 'studioTitle') {
-            return (
-              <TableRowCell key={name} className={styles.studio}>
-                {studioForeignId ? (
-                  <Link to={`/studio/${studioForeignId}`}>{studioTitle}</Link>
-                ) : (
-                  <Tooltip
-                    anchor={
-                      <span>
-                        {studioTitle}
-                        <a href={url} target="_blank">
-                          <Icon
-                            className={styles.externalLink}
-                            name={icons.EXTERNAL_LINK}
-                          />
-                        </a>
-                      </span>
-                    }
-                    tooltip={translate('StudioNotInStashDb')}
-                  />
-                )}
-              </TableRowCell>
-            );
-          }
-
-          if (name === 'releaseDate') {
-            return <RelativeDateCell key={name} date={releaseDate} />;
-          }
-
-          if (name === 'credits' && performerNames) {
-            // TODO: Workaround for duplicates before slicing
-            const uniquePerformers = Array.from(new Set(performerNames));
-            const joinedPerformers = uniquePerformers
-              .sort((a, b) => (a > b ? 1 : -1))
-              .slice(0, 4)
-              .join(', ');
-            return (
-              <TableRowCell key={name} className={styles.performers}>
-                <span title={joinedPerformers}>{joinedPerformers}</span>
-              </TableRowCell>
-            );
-          }
-
-          if (name === 'runtime') {
-            return (
-              <TableRowCell key={name} className={styles.runtime}>
-                {typeof runtime === 'number'
-                  ? formatRuntime(runtime, movieRuntimeFormat)
-                  : null}
-              </TableRowCell>
-            );
-          }
-
-          if (name === 'customFormats') {
-            return customFormats.length > 0 ? (
-              <TableRowCell key={name}>
-                <MovieFormats formats={customFormats as CustomFormatType[]} />
-              </TableRowCell>
-            ) : null;
-          }
-
-          if (name === 'customFormatScore') {
-            return (
-              <TableRowCell key={name} className={styles.customFormatScore}>
+        // Fully populated Studio will link to it, otherwise just show name
+        if (name === 'studioTitle') {
+          return (
+            <TableRowCell key={name} className={styles.studio}>
+              {studioForeignId ? (
+                <Link to={`/studio/${studioForeignId}`}>{studioTitle}</Link>
+              ) : (
                 <Tooltip
-                  anchor={formatCustomFormatScore(
-                    customFormatScore,
-                    customFormats ? customFormats.length : 0
-                  )}
-                  tooltip={
-                    <MovieFormats
-                      formats={customFormats as CustomFormatType[]}
-                    />
+                  anchor={
+                    <span>
+                      {studioTitle}
+                      <a href={url} target="_blank">
+                        <Icon
+                          className={styles.externalLink}
+                          name={icons.EXTERNAL_LINK}
+                        />
+                      </a>
+                    </span>
                   }
-                  position={tooltipPositions.BOTTOM}
+                  tooltip={translate('StudioNotInStashDb')}
                 />
-              </TableRowCell>
-            );
-          }
+              )}
+            </TableRowCell>
+          );
+        }
 
-          if (name === 'languages') {
-            return languages && languages.length > 0 ? (
-              <TableRowCell key={name} className={styles.languages}>
-                {typeof movieFileId === 'number' ? (
-                  <MovieFileLanguageConnector movieFileId={movieFileId} />
-                ) : null}
-              </TableRowCell>
-            ) : null;
-          }
+        if (name === 'releaseDate') {
+          return <RelativeDateCell key={name} date={releaseDate} />;
+        }
 
-          if (name === 'audioLanguages') {
-            return audioLanguages && audioLanguages.length > 0 ? (
-              <TableRowCell key={name} className={styles.audio}>
-                {typeof movieFileId === 'number' ? (
-                  <MovieFileLanguageConnector movieFileId={movieFileId} />
-                ) : null}
-              </TableRowCell>
-            ) : null;
-          }
+        if (name === 'credits' && performerNames) {
+          // TODO: Workaround for duplicates before slicing
+          const uniquePerformers = Array.from(new Set(performerNames));
+          const joinedPerformers = uniquePerformers
+            .sort((a, b) => (a > b ? 1 : -1))
+            .slice(0, 4)
+            .join(', ');
+          return (
+            <TableRowCell key={name} className={styles.performers}>
+              <span title={joinedPerformers}>{joinedPerformers}</span>
+            </TableRowCell>
+          );
+        }
 
-          if (name === 'audioInfo') {
-            return (
-              <TableRowCell key={name} className={styles.audio}>
-                {movieFile && movieFile.mediaInfo ? (
-                  <MediaInfo {...movieFile.mediaInfo} />
-                ) : null}
-              </TableRowCell>
-            );
-          }
+        if (name === 'runtime') {
+          return (
+            <TableRowCell key={name} className={styles.runtime}>
+              {typeof runtime === 'number'
+                ? formatRuntime(runtime, movieRuntimeFormat)
+                : null}
+            </TableRowCell>
+          );
+        }
 
-          if (name === 'audioLanguages') {
-            return (
-              <TableRowCell key={name} className={styles.audioLanguages}>
-                {movieFile && movieFile.mediaInfo ? (
-                  <MediaInfo {...movieFile.mediaInfo} />
-                ) : null}
-              </TableRowCell>
-            );
-          }
+        if (name === 'path') {
+          return path ? (
+            <TableRowCell
+              key={name}
+              className={props.safeForWorkMode ? styles.blurred : styles.path}
+            >
+              {path}
+            </TableRowCell>
+          ) : null;
+        }
 
-          if (name === 'subtitleLanguages') {
-            return (
-              <TableRowCell key={name} className={styles.subtitles}>
-                {movieFile && movieFile.mediaInfo ? (
-                  <MediaInfo {...movieFile.mediaInfo} />
-                ) : null}
-              </TableRowCell>
-            );
-          }
+        if (name === 'sizeOnDisk') {
+          return (
+            <TableRowCell key={name} className={styles.size}>
+              {sizeOnDisk ? formatBytes(sizeOnDisk) : null}
+            </TableRowCell>
+          );
+        }
 
-          if (name === 'videoCodec') {
-            return (
-              <TableRowCell key={name} className={styles.video}>
-                {movieFile && movieFile.mediaInfo ? (
-                  <MediaInfo {...movieFile.mediaInfo} />
-                ) : null}
-              </TableRowCell>
-            );
-          }
+        if (name === 'status') {
+          return (
+            <TableRowCell key={name} className={styles.status}>
+              <MovieIndexProgressBar
+                movieId={id}
+                isAvailable={isAvailable}
+                hasFile={hasFile}
+                movieFile={movieFile}
+                monitored={monitored}
+                detailedProgressBar={true}
+                bottomRadius={false}
+                isStandAlone={true}
+                status={status}
+                width={100}
+              />
+            </TableRowCell>
+          );
+        }
 
-          if (name === 'videoDynamicRangeType') {
-            return (
-              <TableRowCell key={name} className={styles.videoDynamicRangeType}>
-                {movieFile && movieFile.mediaInfo ? (
-                  <MediaInfo {...movieFile.mediaInfo} />
-                ) : null}
-              </TableRowCell>
-            );
-          }
+        if (name === 'actions') {
+          return <MovieSearchCell key={name} movieId={id} />;
+        }
 
-          if (name === 'path') {
-            return path ? (
-              <TableRowCell
-                key={name}
-                className={
-                  this.props.safeForWorkMode ? styles.blurred : styles.path
-                }
-              >
-                {path}
-              </TableRowCell>
-            ) : null;
-          }
-
-          if (name === 'relativePath') {
-            return relativePath ? (
-              <TableRowCell key={name} className={styles.relativePath}>
-                {relativePath}
-              </TableRowCell>
-            ) : null;
-          }
-
-          if (name === 'sizeOnDisk') {
-            return (
-              <TableRowCell key={name} className={styles.size}>
-                {sizeOnDisk ? formatBytes(sizeOnDisk) : null}
-              </TableRowCell>
-            );
-          }
-
-          if (name === 'releaseGroup') {
-            return (
-              <TableRowCell key={name} className={styles.releaseGroup}>
-                {releaseGroup ? releaseGroup : null}
-              </TableRowCell>
-            );
-          }
-
-          if (name === 'status') {
-            return (
-              <TableRowCell key={name} className={styles.status}>
-                <MovieIndexProgressBar
-                  movieId={id}
-                  isAvailable={isAvailable}
-                  hasFile={hasFile}
-                  movieFile={movieFile}
-                  monitored={monitored}
-                  detailedProgressBar={true}
-                  bottomRadius={false}
-                  isStandAlone={true}
-                  status={status}
-                  width={100}
-                />
-              </TableRowCell>
-            );
-          }
-
-          if (name === 'actions') {
-            return <MovieSearchCell key={name} movieId={id} />;
-          }
-
-          return null;
-        })}
-      </TableRow>
-    );
-  }
+        return null;
+      })}
+    </TableRow>
+  );
 }
-
-export default SceneRow;

--- a/frontend/src/Store/Actions/studioScenesActions.js
+++ b/frontend/src/Store/Actions/studioScenesActions.js
@@ -56,30 +56,10 @@ export const defaultState = {
       isSortable: true
     },
     {
-      name: 'audioInfo',
-      label: () => translate('AudioInfo'),
-      isVisible: false
-    },
-    {
-      name: 'videoCodec',
-      label: () => translate('VideoCodec'),
-      isVisible: false
-    },
-    {
-      name: 'videoDynamicRangeType',
-      label: () => translate('VideoDynamicRange'),
-      isVisible: false
-    },
-    {
       name: 'sizeOnDisk',
       label: () => translate('Size'),
       isVisible: false,
       isSortable: true
-    },
-    {
-      name: 'releaseGroup',
-      label: () => translate('ReleaseGroup'),
-      isVisible: false
     },
     {
       name: 'status',

--- a/frontend/src/Studio/Details/SceneRow.css
+++ b/frontend/src/Studio/Details/SceneRow.css
@@ -1,82 +1,84 @@
-.blurredText {
-  display: inline-block;
-  color: transparent;
-  text-shadow: 0 0 6px rgba(255, 255, 255, 0.6);
+.blurred{
+  filter: blur(5px);
+  transition: filter 0.2s;
 }
 
-.blurredCell {
-  position: relative;
-  overflow: hidden;
-}
-
-.blurredCell::before {
-  position: absolute;
-  top: 0;
-  right: 0;
-  left: 0;
-  height: 1px;
-  background: var(--borderColor);
-  content: '';
-  pointer-events: none;
-}
-
+.performers,
 .title {
-  composes: cell from '~Components/Table/Cells/TableRowCell.css';
-
   white-space: wrap;
+}
+
+.title,
+.studio,
+.monitored,
+.performers,
+.runtime,
+.size,
+.path,
+.relativePath,
+.languages,
+.audio,
+.video,
+.status,
+.audioLanguages,
+.videoDynamicRangeType,
+.subtitles,
+.releaseGroup,
+.customFormatScore {
+  composes: cell from '~Components/Table/Cells/TableRowCell.css';
+}
+
+.externalLink {
+  margin-left: 5px;
+  width: 12px;
+  height: 12px;
 }
 
 .monitored {
-  composes: cell from '~Components/Table/Cells/TableRowCell.css';
-
+  position: relative;
+  padding: 0;
   width: 42px;
+  height: 42px;
 }
 
-.performers {
-  composes: cell from '~Components/Table/Cells/TableRowCell.css';
-
-  white-space: wrap;
+.monitorToggleButton {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0;
+  padding: 0;
+  width: 32px; /* adjust as needed */
+  height: 32px; /* adjust as needed */
+  border: none;
+  background: none;
+  transform: translate(-50%, -50%);
 }
 
 .runtime {
-  composes: cell from '~Components/Table/Cells/TableRowCell.css';
-
   width: 80px;
-}
-
-.size {
-  composes: cell from '~Components/Table/Cells/TableRowCell.css';
-
-  width: 100px;
 }
 
 .languages,
 .audio,
 .video,
-.path,
-.releaseDate,
+.size,
 .status {
-  composes: cell from '~Components/Table/Cells/TableRowCell.css';
-
   width: 100px;
 }
 
 .audioLanguages,
 .videoDynamicRangeType,
 .subtitles {
-  composes: cell from '~Components/Table/Cells/TableRowCell.css';
-
   width: 165px;
 }
 
 .releaseGroup {
-  composes: cell from '~Components/Table/Cells/TableRowCell.css';
-
   width: 120px;
 }
 
 .customFormatScore {
-  composes: cell from '~Components/Table/Cells/TableRowCell.css';
-
   width: 55px;
 }

--- a/frontend/src/Studio/Details/SceneRow.css.d.ts
+++ b/frontend/src/Studio/Details/SceneRow.css.d.ts
@@ -7,6 +7,7 @@ interface CssExports {
   'customFormatScore': string;
   'languages': string;
   'monitored': string;
+  'monitorToggleButton': string;
   'path': string;
   'performers': string;
   'releaseDate': string;

--- a/frontend/src/Studio/Details/SceneRow.tsx
+++ b/frontend/src/Studio/Details/SceneRow.tsx
@@ -1,46 +1,23 @@
-import React, { Component } from 'react';
+import React from 'react';
+import { useSelector } from 'react-redux';
 import MonitorToggleButton from 'Components/MonitorToggleButton';
 import RelativeDateCell from 'Components/Table/Cells/RelativeDateCell';
 import TableRowCell from 'Components/Table/Cells/TableRowCell';
 import Column from 'Components/Table/Column';
 import TableRow from 'Components/Table/TableRow';
-import Tooltip from 'Components/Tooltip/Tooltip';
-import { tooltipPositions } from 'Helpers/Props';
 import MovieIndexProgressBar from 'Movie/Index/ProgressBar/MovieIndexProgressBar';
-import MovieFormats from 'Movie/MovieFormats';
+import Movie, { MovieStatus } from 'Movie/Movie';
 import MovieSearchCell from 'Movie/MovieSearchCell';
 import MovieTitleLink from 'Movie/MovieTitleLink';
-import MediaInfo from 'MovieFile/Editor/MediaInfo';
-import { MovieFile } from 'MovieFile/MovieFile';
-import MovieFileLanguageConnector from 'MovieFile/MovieFileLanguages';
-import type { default as CustomFormatType } from 'typings/CustomFormat';
+import createUISettingsSelector from 'Store/Selectors/createUISettingsSelector';
 import formatRuntime from 'Utilities/Date/formatRuntime';
 import formatBytes from 'Utilities/Number/formatBytes';
-import formatCustomFormatScore from 'Utilities/Number/formatCustomFormatScore';
 import styles from './SceneRow.css';
 
 interface SceneRowProps {
-  id: number;
-  movieFileId?: number;
-  isAvailable: boolean;
-  hasFile: boolean;
-  movieFile?: MovieFile;
-  monitored: boolean;
-  performerNames?: string[];
-  joinedPerformers?: string;
-  releaseDate?: string;
-  runtime?: number;
-  movieRuntimeFormat?: string;
-  safeForWorkMode?: boolean;
-  title: string;
-  titleSlug: string;
+  movie: Movie;
   isSaving?: boolean;
-  movieFilePath?: string;
-  movieFileSize?: number;
-  releaseGroup?: string;
-  customFormats?: CustomFormatType[];
-  customFormatScore?: number;
-  mediaInfo?: ReturnType<typeof MediaInfo>;
+  safeForWorkMode?: boolean;
   columns: Column[];
   onMonitorMoviePress: (
     id: number,
@@ -49,285 +26,153 @@ interface SceneRowProps {
   ) => void;
 }
 
+/*
 interface SceneRowState {
   isDetailsModalOpen: boolean;
 }
+*/
 
-class SceneRow extends Component<SceneRowProps, SceneRowState> {
-  constructor(props: SceneRowProps, context?: object) {
-    super(props, context);
-    this.state = {
-      isDetailsModalOpen: false,
-    };
+export default function SceneRow(props: SceneRowProps) {
+  const { movieRuntimeFormat } = useSelector(createUISettingsSelector());
+
+  /*
+const onManualSearchPress = (): void => {
+  setIsDetailsModalOpen(true);
+  };
+
+
+const onDetailsModalClose = (): void => {
+  setIsDetailsModalOpen(false);
+  };
+*/
+  function onMonitorToggle(): void {
+    const { id, monitored } = props.movie;
+    props.onMonitorMoviePress(id, !monitored);
   }
 
-  onManualSearchPress = (): void => {
-    this.setState({ isDetailsModalOpen: true });
-  };
+  const { isSaving, columns, movie } = props;
 
-  onDetailsModalClose = (): void => {
-    this.setState({ isDetailsModalOpen: false });
-  };
+  const {
+    id,
+    itemType,
+    monitored,
+    performerNames,
+    runtime,
+    path,
+    isAvailable,
+    hasFile,
+    movieFile,
+    releaseDate,
+    title,
+    titleSlug,
+    sizeOnDisk,
+  } = movie;
 
-  onMonitorMoviePress = (
-    value: boolean | { monitored: boolean; moviesMonitored: boolean },
-    options: { shiftKey: boolean }
-  ): void => {
-    // Support both boolean and object signatures
-    const { monitored } =
-      typeof value === 'object' && value !== null && 'monitored' in value
-        ? value
-        : { monitored: value as boolean };
-    this.props.onMonitorMoviePress(this.props.id, monitored, options);
-  };
+  const status = movie.status as MovieStatus;
 
-  renderBlurredCell = ({
-    className,
-    children,
-    ...otherProps
-  }: {
-    className?: string;
-    children?: React.ReactNode;
-  }) => {
-    return (
-      <TableRowCell className={className} {...otherProps}>
-        <span className={styles.blurred}>{children}</span>
-      </TableRowCell>
-    );
-  };
+  return (
+    <TableRow>
+      {columns.map((column) => {
+        const { name, isVisible } = column;
+        if (!isVisible) return null;
 
-  render() {
-    const {
-      id,
-      movieFileId,
-      monitored,
-      performerNames,
-      runtime,
-      isAvailable,
-      hasFile,
-      movieFile,
-      movieRuntimeFormat,
-      releaseDate,
-      title,
-      titleSlug,
-      isSaving,
-      movieFilePath,
-      movieFileSize,
-      releaseGroup,
-      safeForWorkMode,
-      customFormats = [],
-      customFormatScore,
-      columns,
-    } = this.props;
-
-    return (
-      <TableRow>
-        {columns.map((column) => {
-          const { name, isVisible } = column;
-          if (!isVisible) return null;
-
-          if (name === 'monitored') {
-            return (
-              <TableRowCell key={name} className={styles.monitored}>
-                <MonitorToggleButton
-                  monitored={monitored}
-                  isSaving={isSaving}
-                  onPress={this.onMonitorMoviePress}
-                />
-              </TableRowCell>
-            );
-          }
-
-          if (name === 'title') {
-            return (
-              <TableRowCell key={name} className={styles.title}>
-                <MovieTitleLink titleSlug={titleSlug} title={title} />
-              </TableRowCell>
-            );
-          }
-
-          if (name === 'credits' && performerNames) {
-            const joinedPerformers = performerNames
-              .slice(0, 4)
-              .sort((a, b) => (a > b ? 1 : -1))
-              .join(', ');
-            return (
-              <TableRowCell key={name} className={styles.performers}>
-                <span title={joinedPerformers}>{joinedPerformers}</span>
-              </TableRowCell>
-            );
-          }
-
-          if (name === 'path') {
-            return (
-              <TableRowCell
-                key={name}
-                className={
-                  safeForWorkMode
-                    ? `${styles.path} ${styles.blurred}`
-                    : styles.path
-                }
-              >
-                {safeForWorkMode ? (
-                  <span className={styles.blurred}>{movieFilePath}</span>
-                ) : (
-                  movieFilePath
-                )}
-              </TableRowCell>
-            );
-          }
-
-          if (name === 'releaseDate') {
-            return (
-              <RelativeDateCell
-                key={name}
-                className={styles.releaseDate}
-                date={releaseDate}
+        if (name === 'monitored') {
+          return (
+            <TableRowCell key={name} className={styles.monitored}>
+              <MonitorToggleButton
+                className={styles.monitorToggleButton}
+                size={20}
+                type={itemType === 'scene' ? 'sceneMonitor' : 'movieMonitor'}
+                monitored={monitored}
+                moviesMonitored={monitored}
+                isSaving={isSaving}
+                isDisabled={false}
+                onPress={onMonitorToggle}
               />
-            );
-          }
+            </TableRowCell>
+          );
+        }
 
-          if (name === 'runtime') {
-            return (
-              <TableRowCell key={name} className={styles.runtime}>
-                {typeof runtime === 'number'
-                  ? formatRuntime(runtime, movieRuntimeFormat)
-                  : ''}
-              </TableRowCell>
-            );
-          }
+        if (name === 'title') {
+          return (
+            <TableRowCell key={name} className={styles.title}>
+              <MovieTitleLink titleSlug={titleSlug} title={title} />
+            </TableRowCell>
+          );
+        }
 
-          if (name === 'customFormats') {
-            return (
-              <TableRowCell key={name}>
-                <MovieFormats formats={customFormats as CustomFormatType[]} />
-              </TableRowCell>
-            );
-          }
+        if (name === 'releaseDate') {
+          return <RelativeDateCell key={name} date={releaseDate} />;
+        }
 
-          if (name === 'customFormatScore') {
-            return (
-              <TableRowCell key={name} className={styles.customFormatScore}>
-                <Tooltip
-                  anchor={formatCustomFormatScore(
-                    customFormatScore,
-                    customFormats ? customFormats.length : 0
-                  )}
-                  tooltip={
-                    <MovieFormats
-                      formats={customFormats as CustomFormatType[]}
-                    />
-                  }
-                  position={tooltipPositions.BOTTOM}
-                />
-              </TableRowCell>
-            );
-          }
+        if (name === 'credits' && performerNames) {
+          // TODO: Workaround for duplicates before slicing
+          const uniquePerformers = Array.from(new Set(performerNames));
+          const joinedPerformers = uniquePerformers
+            .sort((a, b) => (a > b ? 1 : -1))
+            .slice(0, 4)
+            .join(', ');
+          return (
+            <TableRowCell key={name} className={styles.performers}>
+              <span title={joinedPerformers}>{joinedPerformers}</span>
+            </TableRowCell>
+          );
+        }
 
-          if (name === 'languages') {
-            return (
-              <TableRowCell key={name} className={styles.languages}>
-                {typeof movieFileId === 'number' ? (
-                  <MovieFileLanguageConnector movieFileId={movieFileId} />
-                ) : null}
-              </TableRowCell>
-            );
-          }
+        if (name === 'runtime') {
+          return (
+            <TableRowCell key={name} className={styles.runtime}>
+              {typeof runtime === 'number'
+                ? formatRuntime(runtime, movieRuntimeFormat)
+                : null}
+            </TableRowCell>
+          );
+        }
 
-          if (name === 'audioInfo') {
-            return (
-              <TableRowCell key={name} className={styles.audio}>
-                {movieFile && movieFile.mediaInfo ? (
-                  <MediaInfo {...movieFile.mediaInfo} />
-                ) : null}
-              </TableRowCell>
-            );
-          }
+        if (name === 'path') {
+          return path ? (
+            <TableRowCell
+              key={name}
+              className={props.safeForWorkMode ? styles.blurred : styles.path}
+            >
+              {path}
+            </TableRowCell>
+          ) : null;
+        }
 
-          if (name === 'audioLanguages') {
-            return (
-              <TableRowCell key={name} className={styles.audioLanguages}>
-                {movieFile && movieFile.mediaInfo ? (
-                  <MediaInfo {...movieFile.mediaInfo} />
-                ) : null}
-              </TableRowCell>
-            );
-          }
+        if (name === 'sizeOnDisk') {
+          return (
+            <TableRowCell key={name} className={styles.size}>
+              {sizeOnDisk ? formatBytes(sizeOnDisk) : null}
+            </TableRowCell>
+          );
+        }
 
-          if (name === 'subtitleLanguages') {
-            return (
-              <TableRowCell key={name} className={styles.subtitles}>
-                {movieFile && movieFile.mediaInfo ? (
-                  <MediaInfo {...movieFile.mediaInfo} />
-                ) : null}
-              </TableRowCell>
-            );
-          }
+        if (name === 'status') {
+          return (
+            <TableRowCell key={name} className={styles.status}>
+              <MovieIndexProgressBar
+                movieId={id}
+                isAvailable={isAvailable}
+                hasFile={hasFile}
+                movieFile={movieFile}
+                monitored={monitored}
+                detailedProgressBar={true}
+                bottomRadius={false}
+                isStandAlone={true}
+                status={status}
+                width={100}
+              />
+            </TableRowCell>
+          );
+        }
 
-          if (name === 'videoCodec') {
-            return (
-              <TableRowCell key={name} className={styles.video}>
-                {movieFile && movieFile.mediaInfo ? (
-                  <MediaInfo {...movieFile.mediaInfo} />
-                ) : null}
-              </TableRowCell>
-            );
-          }
+        if (name === 'actions') {
+          return <MovieSearchCell key={name} movieId={id} />;
+        }
 
-          if (name === 'videoDynamicRangeType') {
-            return (
-              <TableRowCell key={name} className={styles.videoDynamicRangeType}>
-                {movieFile && movieFile.mediaInfo ? (
-                  <MediaInfo {...movieFile.mediaInfo} />
-                ) : null}
-              </TableRowCell>
-            );
-          }
-
-          if (name === 'size') {
-            return (
-              <TableRowCell key={name} className={styles.size}>
-                {!!movieFileSize && formatBytes(movieFileSize)}
-              </TableRowCell>
-            );
-          }
-
-          if (name === 'releaseGroup') {
-            return (
-              <TableRowCell key={name} className={styles.releaseGroup}>
-                {releaseGroup}
-              </TableRowCell>
-            );
-          }
-
-          if (name === 'status') {
-            return (
-              <TableRowCell key={name} className={styles.status}>
-                <MovieIndexProgressBar
-                  movieId={id}
-                  isAvailable={isAvailable}
-                  hasFile={hasFile}
-                  movieFile={movieFile}
-                  monitored={monitored}
-                  detailedProgressBar={true}
-                  bottomRadius={false}
-                  isStandAlone={true}
-                  status="released"
-                  width={100}
-                />
-              </TableRowCell>
-            );
-          }
-
-          if (name === 'actions') {
-            return <MovieSearchCell key={name} movieId={id} />;
-          }
-
-          return null;
-        })}
-      </TableRow>
-    );
-  }
+        return null;
+      })}
+    </TableRow>
+  );
 }
-
-export default SceneRow;

--- a/frontend/src/Studio/Details/StudioDetailsYear.tsx
+++ b/frontend/src/Studio/Details/StudioDetailsYear.tsx
@@ -1,4 +1,3 @@
-import _ from 'lodash';
 import React from 'react';
 import Icon from 'Components/Icon';
 import Label from 'Components/Label';
@@ -37,53 +36,28 @@ interface StudioDetailsYearProps {
   onYearRefreshPress?: (ids: number[]) => void;
 }
 
-function getYearStatistics(movies: Movie[]) {
-  let movieCount = 0;
-  let movieFileCount = 0;
-  let totalMovieCount = 0;
-  let monitoredMovieCount = 0;
-  let hasMonitoredMovies = false;
-
-  movies.forEach((movie) => {
-    if (movie.movieFile || (movie.monitored && movie.isAvailable)) {
-      movieCount++;
-    }
-
-    if (movie.movieFile) {
-      movieFileCount++;
-    }
-
-    if (movie.monitored) {
-      monitoredMovieCount++;
-      hasMonitoredMovies = true;
-    }
-
-    totalMovieCount++;
-  });
-
-  return {
-    movieCount,
-    movieFileCount,
-    totalMovieCount,
-    monitoredMovieCount,
-    hasMonitoredMovies,
-  };
-}
-
 function getMovieCountKind(
-  monitored: boolean,
+  missingMonitored: boolean,
   movieFileCount: number,
-  movieCount: number
+  totalMovieCount: number,
+  monitoredMovieCount: number
 ) {
-  if (movieFileCount === movieCount && movieCount > 0) {
-    return kinds.SUCCESS;
+  switch (true) {
+    case missingMonitored:
+      return kinds.DANGER;
+    case movieFileCount !== totalMovieCount &&
+      !missingMonitored &&
+      monitoredMovieCount > 0:
+      return kinds.WARNING;
+    case movieFileCount !== totalMovieCount &&
+      !missingMonitored &&
+      monitoredMovieCount === 0:
+      return kinds.DEFAULT;
+    case movieFileCount === totalMovieCount:
+      return kinds.SUCCESS;
+    default:
+      return kinds.DANGER;
   }
-
-  if (!monitored) {
-    return kinds.WARNING;
-  }
-
-  return kinds.DANGER;
 }
 
 function StudioDetailsYear(props: StudioDetailsYearProps) {
@@ -106,6 +80,19 @@ function StudioDetailsYear(props: StudioDetailsYearProps) {
     sortKey,
     sortDirection,
   } = useStudioDetailsYearData(studioId, works);
+
+  const totalMovieCount = works.length;
+  const monitoredMovieCount = works.filter((m) => m.monitored).length;
+  const movieFileCount = works.filter(
+    (m) => m.sizeOnDisk && m.sizeOnDisk > 0
+  ).length;
+  const missingMonitored = works.some((m) => m.monitored && !m.movieFileId);
+  const sizeOnDisk = works.reduce((total, movie) => {
+    if (movie.sizeOnDisk) {
+      return total + movie.sizeOnDisk;
+    }
+    return total;
+  }, 0);
 
   const {
     onMonitorYearPress,
@@ -145,15 +132,12 @@ function StudioDetailsYear(props: StudioDetailsYearProps) {
     return null;
   }
 
-  const {
-    movieCount,
+  const yearKind = getMovieCountKind(
+    missingMonitored,
     movieFileCount,
     totalMovieCount,
-    monitoredMovieCount,
-    hasMonitoredMovies,
-  } = getYearStatistics(items);
-
-  const sizeOnDisk = _.sumBy(items, 'sizeOnDisk');
+    monitoredMovieCount
+  );
 
   return (
     <div className={styles.season}>
@@ -169,16 +153,9 @@ function StudioDetailsYear(props: StudioDetailsYearProps) {
             className={styles.movieCountTooltip}
             canFlip={true}
             anchor={
-              <Label
-                kind={getMovieCountKind(
-                  studioMonitored,
-                  movieFileCount,
-                  movieCount
-                )}
-                size={sizes.LARGE}
-              >
+              <Label kind={yearKind} size={sizes.LARGE}>
                 <span>
-                  {movieFileCount} / {movieCount}
+                  {movieFileCount} / {totalMovieCount}
                 </span>
               </Label>
             }
@@ -226,7 +203,7 @@ function StudioDetailsYear(props: StudioDetailsYearProps) {
               </MenuItem>
               <MenuItem
                 isDisabled={
-                  isSearching || !hasMonitoredMovies || !studioMonitored
+                  isSearching || monitoredMovieCount === 0 || !studioMonitored
                 }
                 onPress={onSearchPress}
               >
@@ -254,14 +231,14 @@ function StudioDetailsYear(props: StudioDetailsYearProps) {
               className={styles.actionButton}
               name={icons.SEARCH}
               title={
-                hasMonitoredMovies && studioMonitored
+                monitoredMovieCount > 0 && studioMonitored
                   ? translate('SearchForMonitoredMoviesYear')
                   : translate('NoMonitoredMoviesYear')
               }
               size={24}
               isSpinning={isSearching}
               isDisabled={
-                isSearching || !hasMonitoredMovies || !studioMonitored
+                isSearching || monitoredMovieCount === 0 || !studioMonitored
               }
               onPress={onSearchPress}
             />
@@ -287,6 +264,7 @@ function StudioDetailsYear(props: StudioDetailsYearProps) {
                   {items.map((item: Movie) => (
                     <SceneRow
                       key={item.id}
+                      movie={item}
                       columns={columns}
                       {...item}
                       safeForWorkMode={safeForWorkMode}


### PR DESCRIPTION
#### Database Migration
NO

#### Description
- Fixed coloring on year groupings on performer and studio
- Fixed missing stats on the year counts label/hover tip
- Removed unused/unfulfilled columns
- Lightly refactored each year component for consistency

See screenshots for examples

#### Screenshot (if UI related)
<details>
Nothing monitored
<img width="1708" height="289" alt="image" src="https://github.com/user-attachments/assets/24db2680-4f24-441c-aaa0-b77a646980c3" />

At least one monitored
<img width="1701" height="333" alt="image" src="https://github.com/user-attachments/assets/83698ed6-07cb-4184-aef0-84ee1eac567d" />

At least one missing
<img width="1699" height="334" alt="image" src="https://github.com/user-attachments/assets/dd757bf2-7b26-47d3-8c13-7c6b6aec8dc4" />

Stats fixed
<img width="1712" height="348" alt="image" src="https://github.com/user-attachments/assets/c6f9b4bd-f706-430d-aaa9-f2df19912b8f" />
</details>

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

- Fixes: whisparr/whisparr#1023