### PR TITLE
New - Add total request time header to API responses

### DIFF
--- a/src/NzbDrone.Host/Startup.cs
+++ b/src/NzbDrone.Host/Startup.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Net;
+using System.Threading.Tasks;
 using DryIoc;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
@@ -260,6 +262,20 @@ namespace NzbDrone.Host
             {
                 firewallAdapter.MakeAccessible();
             }
+
+            app.Use(async (context, next) =>
+            {
+                var sw = Stopwatch.StartNew();
+                context.Response.OnStarting(() =>
+                {
+                    context.Response.Headers["X-Total-Request-Time"] = sw.ElapsedMilliseconds.ToString();
+                    return Task.CompletedTask;
+                });
+
+                await next();
+
+                sw.Stop();
+            });
 
             app.UseForwardedHeaders();
             app.UseMiddleware<LoggingMiddleware>();


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Adds a header `X-Total-Request-Time` to all API responses.  This helps in determining raw performance of the API side of things, vs. any browser overhead seen by the user.  Time is displayed in milliseconds.

<img width="350" height="373" alt="image" src="https://github.com/user-attachments/assets/424ac15d-d1d6-4809-8ddd-540ed923c790" />


#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

- Fixes #XXXX