### PR TITLE
Fix: MovieEditedEvent causes large scan of tracked downloads

### DIFF
--- a/src/NzbDrone.Core.Test/Download/TrackedDownloads/TrackedDownloadServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/TrackedDownloads/TrackedDownloadServiceFixture.cs
@@ -134,7 +134,7 @@ namespace NzbDrone.Core.Test.Download.TrackedDownloads
                   .Setup(s => s.Map(It.IsAny<ParsedMovieInfo>(), It.IsAny<string>(), It.IsAny<int>(), null))
                   .Returns(default(RemoteMovie));
 
-            Subject.Handle(new MoviesDeletedEvent(new List<Movie> { remoteMovie.Movie }, false, false));
+            Subject.HandleAsync(new MoviesDeletedEvent(new List<Movie> { remoteMovie.Movie }, false, false));
 
             var trackedDownloads = Subject.GetTrackedDownloads();
             trackedDownloads.Should().HaveCount(1);
@@ -191,7 +191,7 @@ namespace NzbDrone.Core.Test.Download.TrackedDownloads
                   .Setup(s => s.Map(It.IsAny<ParsedMovieInfo>(), It.IsAny<string>(), It.IsAny<int>(), null))
                   .Returns(default(RemoteMovie));
 
-            Subject.Handle(new MoviesDeletedEvent(new List<Movie> { remoteMovie.Movie }, false, false));
+            Subject.HandleAsync(new MoviesDeletedEvent(new List<Movie> { remoteMovie.Movie }, false, false));
 
             var trackedDownloads = Subject.GetTrackedDownloads();
             trackedDownloads.Should().HaveCount(1);

--- a/src/NzbDrone.Core/Download/TrackedDownloads/TrackedDownloadService.cs
+++ b/src/NzbDrone.Core/Download/TrackedDownloads/TrackedDownloadService.cs
@@ -31,7 +31,7 @@ namespace NzbDrone.Core.Download.TrackedDownloads
                                           IHandle<MovieAddedEvent>,
                                           IHandleAsync<MovieEditedEvent>,
                                           IHandleAsync<MoviesBulkEditedEvent>,
-                                          IHandle<MoviesDeletedEvent>
+                                          IHandleAsync<MoviesDeletedEvent>
     {
         private readonly IParsingService _parsingService;
         private readonly IHistoryService _historyService;
@@ -282,11 +282,13 @@ namespace NzbDrone.Core.Download.TrackedDownloads
 
         public void HandleAsync(MovieEditedEvent message)
         {
+            if (message == null || message.Movie == null)
+            {
+                return;
+            }
+
             var cachedItems = _cache.Values
-                .Where(t =>
-                    t.RemoteMovie?.Movie != null &&
-                    message.Movie.TmdbId != 0 &&
-                    (t.RemoteMovie.Movie.Id == message.Movie?.Id || t.RemoteMovie.Movie.TmdbId == message.Movie?.TmdbId))
+                .Where(t => MovieMatches(t.RemoteMovie?.Movie, message.Movie))
                 .ToList();
 
             if (cachedItems.Any())
@@ -299,10 +301,13 @@ namespace NzbDrone.Core.Download.TrackedDownloads
 
         public void HandleAsync(MoviesBulkEditedEvent message)
         {
+            if (message == null || message.Movies == null || !message.Movies.Any())
+            {
+                return;
+            }
+
             var cachedItems = _cache.Values
-                .Where(t =>
-                    t.RemoteMovie?.Movie != null &&
-                    message.Movies.Any(m => (m.Id == t.RemoteMovie.Movie.Id || (m.TmdbId != 0 && m.TmdbId == t.RemoteMovie.Movie.TmdbId))))
+                .Where(t => message.Movies.Any(m => MovieMatches(t.RemoteMovie?.Movie, m)))
                 .ToList();
 
             if (cachedItems.Any())
@@ -313,12 +318,15 @@ namespace NzbDrone.Core.Download.TrackedDownloads
             }
         }
 
-        public void Handle(MoviesDeletedEvent message)
+        public void HandleAsync(MoviesDeletedEvent message)
         {
+            if (message == null || message.Movies == null || !message.Movies.Any())
+            {
+                return;
+            }
+
             var cachedItems = _cache.Values
-                .Where(t =>
-                    t.RemoteMovie?.Movie != null &&
-                    message.Movies.Any(m => m.Id == t.RemoteMovie.Movie.Id || m.TmdbId == t.RemoteMovie.Movie.TmdbId))
+                .Where(t => message.Movies.Any(m => MovieMatches(t.RemoteMovie?.Movie, m)))
                 .ToList();
 
             if (cachedItems.Any())
@@ -327,6 +335,17 @@ namespace NzbDrone.Core.Download.TrackedDownloads
 
                 _eventAggregator.PublishEvent(new TrackedDownloadRefreshedEvent(GetTrackedDownloads()));
             }
+        }
+
+        private static bool MovieMatches(Movie cachedMovie, Movie messageMovie)
+        {
+            if (cachedMovie == null || messageMovie == null)
+            {
+                return false;
+            }
+
+            return cachedMovie.Id == messageMovie.Id ||
+                   (messageMovie.TmdbId != 0 && cachedMovie.TmdbId == messageMovie.TmdbId);
         }
     }
 }

--- a/src/NzbDrone.Core/Download/TrackedDownloads/TrackedDownloadService.cs
+++ b/src/NzbDrone.Core/Download/TrackedDownloads/TrackedDownloadService.cs
@@ -29,8 +29,8 @@ namespace NzbDrone.Core.Download.TrackedDownloads
 
     public class TrackedDownloadService : ITrackedDownloadService,
                                           IHandle<MovieAddedEvent>,
-                                          IHandle<MovieEditedEvent>,
-                                          IHandle<MoviesBulkEditedEvent>,
+                                          IHandleAsync<MovieEditedEvent>,
+                                          IHandleAsync<MoviesBulkEditedEvent>,
                                           IHandle<MoviesDeletedEvent>
     {
         private readonly IParsingService _parsingService;
@@ -280,11 +280,12 @@ namespace NzbDrone.Core.Download.TrackedDownloads
             }
         }
 
-        public void Handle(MovieEditedEvent message)
+        public void HandleAsync(MovieEditedEvent message)
         {
             var cachedItems = _cache.Values
                 .Where(t =>
                     t.RemoteMovie?.Movie != null &&
+                    message.Movie.TmdbId != 0 &&
                     (t.RemoteMovie.Movie.Id == message.Movie?.Id || t.RemoteMovie.Movie.TmdbId == message.Movie?.TmdbId))
                 .ToList();
 
@@ -296,12 +297,12 @@ namespace NzbDrone.Core.Download.TrackedDownloads
             }
         }
 
-        public void Handle(MoviesBulkEditedEvent message)
+        public void HandleAsync(MoviesBulkEditedEvent message)
         {
             var cachedItems = _cache.Values
                 .Where(t =>
                     t.RemoteMovie?.Movie != null &&
-                    message.Movies.Any(m => m.Id == t.RemoteMovie.Movie.Id || m.TmdbId == t.RemoteMovie.Movie.TmdbId))
+                    message.Movies.Any(m => (m.Id == t.RemoteMovie.Movie.Id || (m.TmdbId != 0 && m.TmdbId == t.RemoteMovie.Movie.TmdbId))))
                 .ToList();
 
             if (cachedItems.Any())


### PR DESCRIPTION
#### Database Migration

<!-- If you update database schema, the migration number must be noted here -->

NO

#### Description

I was troubleshooting significant latency in editing movie/scene items, which appeared as 2500ms when toggling the movie monitor.

I found the issue in a synchronous event handler in TrackedDownloadService, intended to update tracked items when a library item is edited.

The problem was a comparison of “event movie TMDB ID = Tracked Download TMDB ID). Since all StashDB scenes have a default TMDB ID of 0, as do all un-matched downloads, this comparison always returns true.

I added an explicit check and moved both single and bulk events to async, as their downstream behavior relies on SignalR and doesn’t require synchronization.

```
2026-02-26 22:14:46.6|Trace|EventAggregator|Publishing MovieEditedEvent
2026-02-26 22:14:46.6|Trace|EventAggregator|MovieEditedEvent -> TrackedDownloadService
... a bunch of parser matching on my active tracked downloads (in Whisparr's category)
2026-02-26 22:14:49.1|Trace|EventAggregator|MovieEditedEvent <- TrackedDownloadService

```
~2+ seconds of toggle monitor lag, finally explained.

#### Todos

- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)