### PR TITLE
Chore: CI build timeouts

### DIFF
--- a/src/NzbDrone.Core/Messaging/Events/EventAggregator.cs
+++ b/src/NzbDrone.Core/Messaging/Events/EventAggregator.cs
@@ -72,15 +72,34 @@ namespace NzbDrone.Core.Messaging.Events
 
             _logger.Trace("Publishing {0}", eventName);
 
+            // Resolve subscribers outside the lock to avoid deadlock:
+            // DI resolution can trigger constructor logging (NLog), and ProgressMessageTarget
+            // calls PublishEvent while holding the NLog Target lock. If we hold _eventSubscribers
+            // during DI resolution, we get: NLog lock → _eventSubscribers (thread A) vs
+            // _eventSubscribers → DI → NLog lock (thread B) = deadlock.
             EventSubscribers<TEvent> subscribers;
             lock (_eventSubscribers)
             {
-                if (!_eventSubscribers.TryGetValue(eventName, out var target))
-                {
-                    _eventSubscribers[eventName] = target = new EventSubscribers<TEvent>(_serviceFactory);
-                }
+                _eventSubscribers.TryGetValue(eventName, out var cached);
+                subscribers = cached as EventSubscribers<TEvent>;
+            }
 
-                subscribers = target as EventSubscribers<TEvent>;
+            if (subscribers == null)
+            {
+                var newSubscribers = new EventSubscribers<TEvent>(_serviceFactory);
+
+                lock (_eventSubscribers)
+                {
+                    if (!_eventSubscribers.TryGetValue(eventName, out var cached))
+                    {
+                        _eventSubscribers[eventName] = newSubscribers;
+                        subscribers = newSubscribers;
+                    }
+                    else
+                    {
+                        subscribers = cached as EventSubscribers<TEvent>;
+                    }
+                }
             }
 
             // call synchronous handlers first.

--- a/src/NzbDrone.Core/Movies/Collections/MovieCollectionService.cs
+++ b/src/NzbDrone.Core/Movies/Collections/MovieCollectionService.cs
@@ -20,7 +20,7 @@ namespace NzbDrone.Core.Movies.Collections
         bool UpsertMany(List<MovieCollection> collections);
     }
 
-    public class MovieCollectionService : IMovieCollectionService, IHandleAsync<MoviesDeletedEvent>
+    public class MovieCollectionService : IMovieCollectionService, IHandle<MoviesDeletedEvent>
     {
         private readonly IMovieCollectionRepository _repo;
         private readonly IMovieService _movieService;
@@ -70,7 +70,7 @@ namespace NzbDrone.Core.Movies.Collections
         {
             var storedCollection = GetCollection(collection.Id);
 
-            var updatedCollection =  _repo.Update(collection);
+            var updatedCollection = _repo.Update(collection);
 
             _eventAggregator.PublishEvent(new CollectionEditedEvent(updatedCollection, storedCollection));
 
@@ -109,7 +109,7 @@ namespace NzbDrone.Core.Movies.Collections
             return _repo.UpsertMany(collections);
         }
 
-        public void HandleAsync(MoviesDeletedEvent message)
+        public void Handle(MoviesDeletedEvent message)
         {
             var collections = message.Movies.Select(x => x.MovieMetadata.Value.CollectionTmdbId).Distinct();
 

--- a/src/NzbDrone.Core/Movies/Performers/Commands/RefreshPerformersCommand.cs
+++ b/src/NzbDrone.Core/Movies/Performers/Commands/RefreshPerformersCommand.cs
@@ -20,6 +20,8 @@ namespace NzbDrone.Core.Movies.Performers.Commands
 
         public override bool SendUpdatesToClient => true;
 
+        public override bool IsTypeExclusive => true;
+
         public override bool UpdateScheduledTask => !PerformerIds.Any();
     }
 }

--- a/src/NzbDrone.Core/Movies/Performers/PerformerAddedHandler.cs
+++ b/src/NzbDrone.Core/Movies/Performers/PerformerAddedHandler.cs
@@ -18,12 +18,25 @@ namespace NzbDrone.Core.Movies.Performers
 
         public void Handle(PerformerAddedEvent message)
         {
-            _commandQueueManager.Push(new RefreshPerformersCommand(new List<int> { message.Performer.Id }));
+            if (message.Performer.Monitored || message.Performer.MoviesMonitored)
+            {
+                _commandQueueManager.Push(new RefreshPerformersCommand(new List<int> { message.Performer.Id }));
+            }
         }
 
         public void Handle(PerformersAddedEvent message)
         {
-            _commandQueueManager.PushMany(message.Performers.Select(s => new RefreshPerformersCommand(new List<int> { s.Id })).ToList());
+            // Skip refresh for unmonitored performers (e.g. added as side-effect of movie refresh).
+            // Their metadata is already fetched by AddPerformerService, and SyncPerformerItems
+            // would bail out immediately for unmonitored performers anyway.
+            var performersToRefresh = message.Performers
+                .Where(s => s.Monitored || s.MoviesMonitored)
+                .ToList();
+
+            if (performersToRefresh.Any())
+            {
+                _commandQueueManager.PushMany(performersToRefresh.Select(s => new RefreshPerformersCommand(new List<int> { s.Id })).ToList());
+            }
         }
     }
 }

--- a/src/NzbDrone.Core/Movies/Performers/PerformerService.cs
+++ b/src/NzbDrone.Core/Movies/Performers/PerformerService.cs
@@ -11,7 +11,7 @@ using NzbDrone.Core.Parser;
 
 namespace NzbDrone.Core.Movies.Performers
 {
-    public interface IPerformerService : IHandleAsync<PerformerUpdatedEvent>
+    public interface IPerformerService : IHandle<PerformerUpdatedEvent>
     {
         Performer AddPerformer(Performer performer);
         List<Performer> AddPerformers(List<Performer> performers);
@@ -175,7 +175,7 @@ namespace NzbDrone.Core.Movies.Performers
             }
         }
 
-        public void HandleAsync(PerformerUpdatedEvent message)
+        public void Handle(PerformerUpdatedEvent message)
         {
             var movies = _movieService.GetByPerformerForeignId(message.Performer.ForeignId);
             var ids = movies.Select(x => x.Id).ToList();

--- a/src/NzbDrone.Integration.Test/IntegrationTestBase.cs
+++ b/src/NzbDrone.Integration.Test/IntegrationTestBase.cs
@@ -100,6 +100,7 @@ namespace NzbDrone.Integration.Test
             RestClient = new RestClient(RootUrl + "api/v3/");
             RestClient.AddDefaultHeader("Authentication", ApiKey);
             RestClient.AddDefaultHeader("X-Api-Key", ApiKey);
+            RestClient.Timeout = 15000;
 
             AutoTagging = new ClientBase<AutoTaggingResource>(RestClient, ApiKey);
             Blocklist = new ClientBase<BlocklistResource>(RestClient, ApiKey);

--- a/src/Whisparr.Api.V3/Performers/PerformerController.cs
+++ b/src/Whisparr.Api.V3/Performers/PerformerController.cs
@@ -31,7 +31,7 @@ namespace Whisparr.Api.V3.Performers
 {
     /// <summary>Controller for managing performers in Whisparr</summary>
     [V3ApiController]
-    public class PerformerController : RestControllerWithSignalR<PerformerResource, Performer>, IHandleAsync<PerformerUpdatedEvent>, IHandleAsync<PerformersDeletedEvent>
+    public class PerformerController : RestControllerWithSignalR<PerformerResource, Performer>, IHandle<PerformerUpdatedEvent>, IHandle<PerformersDeletedEvent>
     {
         private static readonly HashSet<string> _allowedPerformerSortKeys = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
             {
@@ -290,7 +290,7 @@ namespace Whisparr.Api.V3.Performers
 
         /// <summary>Handles performer updated events to broadcast changes via SignalR</summary>
         [NonAction]
-        public void HandleAsync(PerformerUpdatedEvent message)
+        public void Handle(PerformerUpdatedEvent message)
         {
             var resource = MapToResource(message.Performer);
 
@@ -298,7 +298,7 @@ namespace Whisparr.Api.V3.Performers
         }
 
         [NonAction]
-        public void HandleAsync(PerformersDeletedEvent message)
+        public void Handle(PerformersDeletedEvent message)
         {
             if (message?.Performers == null || !message.Performers.Any())
             {

--- a/src/Whisparr.Api.V3/Studios/StudioController.cs
+++ b/src/Whisparr.Api.V3/Studios/StudioController.cs
@@ -30,7 +30,7 @@ using Whisparr.Http.REST.Attributes;
 namespace Whisparr.Api.V3.Studios
 {
     [V3ApiController]
-    public class StudioController : RestControllerWithSignalR<StudioResource, Studio>, IHandleAsync<StudioUpdatedEvent>, IHandleAsync<StudiosDeletedEvent>
+    public class StudioController : RestControllerWithSignalR<StudioResource, Studio>, IHandle<StudioUpdatedEvent>, IHandle<StudiosDeletedEvent>
     {
         private static readonly HashSet<string> _allowedStudioSortKeys = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
             {
@@ -319,7 +319,7 @@ namespace Whisparr.Api.V3.Studios
 
         /// <summary>Handles studio updated events to broadcast changes via SignalR</summary>
         [NonAction]
-        public void HandleAsync(StudioUpdatedEvent message)
+        public void Handle(StudioUpdatedEvent message)
         {
             var resource = MapToResource(message.Studio);
 
@@ -328,7 +328,7 @@ namespace Whisparr.Api.V3.Studios
 
         /// <summary>Handles studios deleted events to broadcast changes via SignalR</summary>
         [NonAction]
-        public void HandleAsync(StudiosDeletedEvent message)
+        public void Handle(StudiosDeletedEvent message)
         {
             if (message?.Studios == null || !message.Studios.Any())
             {


### PR DESCRIPTION
These timeouts started when I moved several event handlers to async.  This was a poor understanding on my part, but the gist is, this caused these failures due to thread deadlocks across fixture runs.  I'm reverting them for now, and will assess moving back in the future once I understand the actual cause fo the deadlocking.  The result of it was that a server instance would hang, and then the next test would try to start up, only to fail due to the port being in use already.

Below is an example from my local repro.  You see it trying to spool up for the 17th test fixture, but failing because 6986's process hung.

```
2026-02-28 13:23:34.186 [info]  [6986] > [v10.0.0.21937] System.IO.IOException: Failed to bind to address http://[::]:6986: address already in use.
2026-02-28 13:23:34.186 [info]  [6987] > [Info] FluentMigrator.Runner.MigrationRunner: => 0.000507s
2026-02-28 13:23:34.186 [info]  [6988] > [Info] FluentMigrator.Runner.MigrationRunner: => 0.000928s
2026-02-28 13:23:34.186 [info]  [6985] > [Debug] Api: [GET] /api/v3/command/: 200.OK (0 ms)
2026-02-28 13:23:34.186 [info]  [6986] >  ---> Microsoft.AspNetCore.Connections.AddressInUseException: Address already in use
```

#### Database Migration

<!-- If you update database schema, the migration number must be noted here -->

NO

#### Screenshot(s) (if UI related)

<details>
<!-- paste screenshots below here.-->

<!-- paste screenshots above here.  MAKE SURE THE ARE SFW -->
</details>

#### Todos

- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)

#### Issues Fixed or Closed by this PR

<!-- If multiple, put each on a separate line -->

- Fixes whisparr/whisparr#XXXX
