### PR TITLE
Fix: Path filter for scenes and movies

### DIFF
--- a/src/NzbDrone.Core/Datastore/PagedFilters/StringFilter.cs
+++ b/src/NzbDrone.Core/Datastore/PagedFilters/StringFilter.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Linq.Expressions;
 using System.Text.Json;
 
@@ -12,13 +14,32 @@ namespace NzbDrone.Core.Datastore.PagedFilters
             string operation,
             Expression<Func<T, string>> propertySelector)
         {
-            if (element.ValueKind != JsonValueKind.String)
-            {
-                return;
-            }
+            List<string> values;
 
-            var value = element.GetString();
-            if (string.IsNullOrWhiteSpace(value))
+            if (element.ValueKind == JsonValueKind.String)
+            {
+                var s = element.GetString();
+                if (string.IsNullOrWhiteSpace(s))
+                {
+                    return;
+                }
+
+                values = new List<string> { s };
+            }
+            else if (element.ValueKind == JsonValueKind.Array)
+            {
+                values = element.EnumerateArray()
+                    .Where(e => e.ValueKind == JsonValueKind.String)
+                    .Select(e => e.GetString())
+                    .Where(s => !string.IsNullOrWhiteSpace(s))
+                    .ToList();
+
+                if (!values.Any())
+                {
+                    return;
+                }
+            }
+            else
             {
                 return;
             }
@@ -26,69 +47,72 @@ namespace NzbDrone.Core.Datastore.PagedFilters
             var param = propertySelector.Parameters[0];
             var property = propertySelector.Body;
 
-            // Build property != null
-            var notNull = Expression.NotEqual(property, Expression.Constant(null, typeof(string)));
-
-            // Build property.Contains(value)
             var containsMethod = typeof(string).GetMethod("Contains", new[] { typeof(string) });
-            var containsCall = Expression.Call(property, containsMethod, Expression.Constant(value));
+            var startsWithMethod = typeof(string).GetMethod("StartsWith", new[] { typeof(string) });
+            var endsWithMethod = typeof(string).GetMethod("EndsWith", new[] { typeof(string) });
+            var nullConst = Expression.Constant(null, typeof(string));
 
-            Expression final;
-
-            switch (operation)
+            // Each value produces one filter expression added to FilterExpressions (ANDed together).
+            // For positive ops (contains/startswith/endswith) multiple values mean "path matches ALL".
+            // For negative ops (notcontains/notstartswith/notendswith) multiple values mean "path matches NONE".
+            foreach (var value in values)
             {
-                case "contains":
-                    final = Expression.AndAlso(notNull, containsCall);
-                    break;
+                var valueConst = Expression.Constant(value);
+                var notNull = Expression.NotEqual(property, nullConst);
+                Expression final;
 
-                case "notcontains":
-                    final = Expression.OrElse(
-                        Expression.Equal(property, Expression.Constant(null, typeof(string))),
-                        Expression.Not(containsCall));
+                switch (operation)
+                {
+                    case "contains":
+                        var containsCall = Expression.Call(property, containsMethod, valueConst);
+                        final = Expression.AndAlso(notNull, containsCall);
+                        break;
 
-                    break;
+                    case "notcontains":
+                        var notContainsCall = Expression.Call(property, containsMethod, valueConst);
+                        final = Expression.OrElse(
+                            Expression.Equal(property, nullConst),
+                            Expression.Not(notContainsCall));
+                        break;
 
-                case "equal":
-                    final = Expression.Equal(property, Expression.Constant(value));
-                    break;
+                    case "equal":
+                        final = Expression.Equal(property, valueConst);
+                        break;
 
-                case "notequal":
-                    final = Expression.NotEqual(property, Expression.Constant(value));
-                    break;
+                    case "notequal":
+                        final = Expression.NotEqual(property, valueConst);
+                        break;
 
-                case "startswith":
-                    var startsWithMethod = typeof(string).GetMethod("StartsWith", new[] { typeof(string) });
-                    var startsWithCall = Expression.Call(property, startsWithMethod, Expression.Constant(value));
-                    final = Expression.AndAlso(notNull, startsWithCall);
-                    break;
-                case "notstartswith":
-                    var notStartsWithMethod = typeof(string).GetMethod("StartsWith", new[] { typeof(string) });
-                    var notStartsWithCall = Expression.Call(property, notStartsWithMethod, Expression.Constant(value));
-                    final = Expression.OrElse(
-                        Expression.Equal(property, Expression.Constant(null, typeof(string))),
-                        Expression.Not(notStartsWithCall));
+                    case "startswith":
+                        var startsWithCall = Expression.Call(property, startsWithMethod, valueConst);
+                        final = Expression.AndAlso(notNull, startsWithCall);
+                        break;
 
-                    break;
-                case "endswith":
-                    var endsWithMethod = typeof(string).GetMethod("EndsWith", new[] { typeof(string) });
-                    var endsWithCall = Expression.Call(property, endsWithMethod, Expression.Constant(value));
-                    final = Expression.AndAlso(notNull, endsWithCall);
-                    break;
-                case "notendswith":
-                    var notEndsWithMethod = typeof(string).GetMethod("EndsWith", new[] { typeof(string) });
-                    var notEndsWithCall = Expression.Call(property, notEndsWithMethod, Expression.Constant(value));
-                    final = Expression.OrElse(
-                        Expression.Equal(property, Expression.Constant(null, typeof(string))),
-                        Expression.Not(notEndsWithCall));
+                    case "notstartswith":
+                        var notStartsWithCall = Expression.Call(property, startsWithMethod, valueConst);
+                        final = Expression.OrElse(
+                            Expression.Equal(property, nullConst),
+                            Expression.Not(notStartsWithCall));
+                        break;
 
-                    break;
+                    case "endswith":
+                        var endsWithCall = Expression.Call(property, endsWithMethod, valueConst);
+                        final = Expression.AndAlso(notNull, endsWithCall);
+                        break;
 
-                default:
-                    return;
+                    case "notendswith":
+                        var notEndsWithCall = Expression.Call(property, endsWithMethod, valueConst);
+                        final = Expression.OrElse(
+                            Expression.Equal(property, nullConst),
+                            Expression.Not(notEndsWithCall));
+                        break;
+
+                    default:
+                        return;
+                }
+
+                pageSpec.FilterExpressions.Add(Expression.Lambda<Func<T, bool>>(final, param));
             }
-
-            var lambda = Expression.Lambda<Func<T, bool>>(final, param);
-            pageSpec.FilterExpressions.Add(lambda);
         }
     }
 }

--- a/src/Whisparr.Api.V3/Movies/Helpers/Paging.cs
+++ b/src/Whisparr.Api.V3/Movies/Helpers/Paging.cs
@@ -31,51 +31,50 @@ namespace Whisparr.Api.V3.Movies.Helpers
                 {
                     case "added":
                         DateFilter.Apply(pageSpec, jsonElement, op, p => p.Added);
-
                         break;
+
                     case "itemtype":
                         EnumFilterLazy.Apply(pageSpec, jsonElement, op, p => p.MovieMetadata.Value.ItemType);
 
                         break;
                     case "monitored":
                         BooleanFilter.Apply<Movie>(pageSpec, jsonElement, op, p => p.Monitored);
-
                         break;
+
                     case "path":
                         StringFilter.Apply(pageSpec, jsonElement, op, p => p.Path);
-
                         break;
+
                     case "qualityprofileid":
                         NumericFilterInt.Apply(pageSpec, jsonElement, op, p => p.QualityProfileId);
-
                         break;
+
                     case "releasedate":
                         DateFilter.Apply(pageSpec, jsonElement, op, p => p.MovieMetadata.Value.ReleaseDateUtc);
-
                         break;
+
                     case "status":
                         EnumFilterLazy.Apply(pageSpec, jsonElement, op, p => p.MovieMetadata.Value.Status);
-
                         break;
+
                     case "runtime":
                         NumericFilterInt.Apply(pageSpec, jsonElement, op, p => p.MovieMetadata.Value.Runtime);
                         break;
+
                     case "sizeondisk": // Special case due to optional inner join on MovieFile and wanting to support filtering for movies without files (size 0 or null)
                         SizeOnDiskFilter.Apply(pageSpec, jsonElement, op);
                         break;
 
                     case "tags": // In-memory filtering for tags, with special handling for contains and notcontains operations
                         TagsFilter.Apply(pageSpec, jsonElement, op);
-
                         break;
 
                     case "title":
                         StringFilter.Apply(pageSpec, jsonElement, op, p => p.MovieMetadata.Value.Title);
-
                         break;
+
                     case "year":
                         NumericFilterInt.Apply(pageSpec, jsonElement, op, p => p.Year);
-
                         break;
                 }
             }


### PR DESCRIPTION
#### Database Migration

<!-- If you update database schema, the migration number must be noted here -->

NO

#### Description

Fixes an issue reported where notcontains was still returning items that contained the string being filtered upon.

Note, this does not impact performers or studios in any way, as those need a filter migration to the new model.

#### Screenshot(s) (if UI related)

<details>
<!-- paste screenshots below here.-->

<!-- paste screenshots above here.  MAKE SURE THE ARE SFW -->
</details>

#### Todos

- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)

#### Issues Fixed or Closed by this PR

<!-- If multiple, put each on a separate line -->

- Fixes whisparr/whisparr#1042
