### PR TITLE
Fix: Hide movies and monitor toggle when unusable/disabled

### DIFF
--- a/frontend/src/Components/Page/Sidebar/PageSidebar.tsx
+++ b/frontend/src/Components/Page/Sidebar/PageSidebar.tsx
@@ -17,6 +17,7 @@ import usePrevious from 'Helpers/Hooks/usePrevious';
 import { icons } from 'Helpers/Props';
 import { VERTICAL } from 'Helpers/Props/scrollDirections';
 import { setIsSidebarVisible } from 'Store/Actions/appActions';
+import { useGeneralSettings } from 'Studio/Details/useStudioDetails';
 import dimensions from 'Styles/Variables/dimensions';
 import HealthStatus from 'System/Status/Health/HealthStatus';
 import translate from 'Utilities/String/translate';
@@ -44,7 +45,7 @@ interface SidebarItem {
   }[];
 }
 
-const LINKS: SidebarItem[] = [
+let LINKS: SidebarItem[] = [
   {
     iconName: icons.SCENE,
     title: () => translate('Scenes'),
@@ -275,6 +276,18 @@ function PageSidebar({ isSidebarVisible, isSmallScreen }: PageSidebarProps) {
     top: dimensions.headerHeight,
     height: `${window.innerHeight - HEADER_HEIGHT}px`,
   });
+
+  const generalSettings = useGeneralSettings();
+
+  if (generalSettings.whisparrMovieMetadataSource?.toLowerCase() === 'none') {
+    LINKS = LINKS.reduce((acc, link) => {
+      if (link.title && link.iconName === icons.FILM) {
+        return acc;
+      }
+      acc.push(link);
+      return acc;
+    }, [] as SidebarItem[]);
+  }
 
   const urlBase = window.Whisparr?.urlBase;
   const pathname = urlBase

--- a/frontend/src/Helpers/Hooks/useShowMovieMonitorToggleButton.ts
+++ b/frontend/src/Helpers/Hooks/useShowMovieMonitorToggleButton.ts
@@ -1,0 +1,20 @@
+import { useGeneralSettings } from '../../Settings/General/useGeneralSettings';
+
+export function useShowMovieMonitorToggleButton(
+  tmdbid?: number,
+  tpdbid?: string
+) {
+  const generalSettings = useGeneralSettings();
+  const source = generalSettings.whisparrMovieMetadataSource;
+
+  switch (true) {
+    case source === 'none':
+      return false;
+    case source === 'tmdb' && tmdbid && tmdbid > 0:
+      return true;
+    case source === 'tpdb' && tpdbid && tpdbid.length > 0:
+      return true;
+    default:
+      return false;
+  }
+}

--- a/frontend/src/Performer/Details/PerformerDetails.tsx
+++ b/frontend/src/Performer/Details/PerformerDetails.tsx
@@ -214,11 +214,12 @@ function PerformerDetails() {
     year,
     movies: movies.filter((m) => m.year === year),
   }));
-  const showMovieMonitorToggle = () => {
+  const showMovieMonitorToggle = (): boolean => {
     const source = generalSettings.whisparrMovieMetadataSource;
     return (
       (source?.toLowerCase() === 'tmdb' && tmdbId && tmdbId > 0) ||
-      (source?.toLowerCase() === 'tpdb' && tpdbId && tpdbId.length > 0)
+      (source?.toLowerCase() === 'tpdb' && tpdbId && tpdbId.length > 0) ||
+      false
     );
   };
 
@@ -562,6 +563,7 @@ function PerformerDetails() {
         <EditPerformerModal
           isOpen={isEditMovieModalOpen}
           performer={performer}
+          showMovieMonitor={showMovieMonitorToggle()}
           onModalClose={handleEditMovieModalClose}
         />
       </PageContentBody>

--- a/frontend/src/Performer/Details/PerformerDetails.tsx
+++ b/frontend/src/Performer/Details/PerformerDetails.tsx
@@ -17,6 +17,7 @@ import PageToolbarButton from 'Components/Page/Toolbar/PageToolbarButton';
 import PageToolbarSection from 'Components/Page/Toolbar/PageToolbarSection';
 import PageToolbarSeparator from 'Components/Page/Toolbar/PageToolbarSeparator';
 import Tooltip from 'Components/Tooltip/Tooltip';
+import { useShowMovieMonitorToggleButton } from 'Helpers/Hooks/useShowMovieMonitorToggleButton';
 import { icons, kinds, sizes, tooltipPositions } from 'Helpers/Props';
 import {
   ASCENDING,
@@ -39,7 +40,6 @@ import PerformerDetailsLinks from './PerformerDetailsLinks';
 import PerformerDetailsYear from './PerformerDetailsYear';
 import PerformerTags from './PerformerTags';
 import {
-  useGeneralSettings,
   usePerformerDetails,
   usePerformerDetailsMovies,
   usePerformerScenesColumns,
@@ -58,7 +58,6 @@ function PerformerDetails() {
 
   const { shortDateFormat } = useSelector(createUISettingsSelector());
 
-  const generalSettings = useGeneralSettings();
   const {
     performer,
     isPerformerDetailsFetching,
@@ -68,6 +67,11 @@ function PerformerDetails() {
     onMonitorTogglePress,
     onYearRefreshPress,
   } = usePerformerDetails(performerForeignId);
+
+  const showMovieMonitorToggle = useShowMovieMonitorToggleButton(
+    performer?.tmdbId,
+    performer?.tpdbId
+  );
 
   const { data: movies = [] } = usePerformerDetailsMovies(performerForeignId);
   const years = Array.from(
@@ -214,14 +218,6 @@ function PerformerDetails() {
     year,
     movies: movies.filter((m) => m.year === year),
   }));
-  const showMovieMonitorToggle = (): boolean => {
-    const source = generalSettings.whisparrMovieMetadataSource;
-    return (
-      (source?.toLowerCase() === 'tmdb' && tmdbId && tmdbId > 0) ||
-      (source?.toLowerCase() === 'tpdb' && tpdbId && tpdbId.length > 0) ||
-      false
-    );
-  };
 
   // Handlers
   function handleDeleteMovieModalClose() {
@@ -327,7 +323,7 @@ function PerformerDetails() {
                       onPress={handleMonitorTogglePress}
                     />
 
-                    {showMovieMonitorToggle() ? (
+                    {showMovieMonitorToggle ? (
                       <MonitorToggleButton
                         className={
                           moviesMonitored
@@ -563,7 +559,7 @@ function PerformerDetails() {
         <EditPerformerModal
           isOpen={isEditMovieModalOpen}
           performer={performer}
-          showMovieMonitor={showMovieMonitorToggle()}
+          showMovieMonitor={showMovieMonitorToggle}
           onModalClose={handleEditMovieModalClose}
         />
       </PageContentBody>

--- a/frontend/src/Performer/Details/usePerformerDetails.ts
+++ b/frontend/src/Performer/Details/usePerformerDetails.ts
@@ -138,10 +138,7 @@ export const usePerformerDetails = (foreignId: string) => {
       monitorToggleMutation.isPending ||
       isManualRefresh,
     isManualRefresh,
-    performerDetailsError:
-      performerDetailsError ||
-      performerDetailsError ||
-      monitorToggleMutation.error,
+    performerDetailsError: performerDetailsError || monitorToggleMutation.error,
     onRefreshPress,
     onYearRefreshPress,
     onSearchPress,

--- a/frontend/src/Performer/Details/usePerformerDetails.ts
+++ b/frontend/src/Performer/Details/usePerformerDetails.ts
@@ -8,7 +8,6 @@ import useApiQuery from 'Helpers/Hooks/useApiQuery';
 import Movie from 'Movie/Movie';
 import Performer from 'Performer/Performer';
 import { executeCommand } from 'Store/Actions/commandActions';
-import { fetchGeneralSettings } from 'Store/Actions/Settings/general';
 
 const PATH = 'performer';
 
@@ -146,17 +145,6 @@ export const usePerformerDetails = (foreignId: string) => {
     searchMoviesByIds,
   };
 };
-
-// Used to fetch general.whisparrMovieMetadataSource setting
-export function useGeneralSettings() {
-  const dispatch = useDispatch();
-
-  useEffect(() => {
-    dispatch(fetchGeneralSettings());
-  }, [dispatch]);
-
-  return useSelector((state: AppState) => state.settings.general.item);
-}
 
 export function usePerformerDetailsMovies(performerForeignId: string) {
   return useApiQuery<Movie[]>({

--- a/frontend/src/Performer/Edit/EditPerformerModal.tsx
+++ b/frontend/src/Performer/Edit/EditPerformerModal.tsx
@@ -13,7 +13,7 @@ interface EditPerformerModalProps {
   onModalClose: () => void;
 }
 
-function EditPerformerModal(props: EditPerformerModalProps) {
+function EditPerformerModal(props: Readonly<EditPerformerModalProps>) {
   const { isOpen, performer, showMovieMonitor, onModalClose } = props;
   const dispatch = useDispatch();
 

--- a/frontend/src/Performer/Edit/EditPerformerModal.tsx
+++ b/frontend/src/Performer/Edit/EditPerformerModal.tsx
@@ -9,11 +9,12 @@ import useEditPerformerModal from './useEditPerformerModal';
 interface EditPerformerModalProps {
   isOpen: boolean;
   performer: Performer;
+  showMovieMonitor: boolean;
   onModalClose: () => void;
 }
 
 function EditPerformerModal(props: EditPerformerModalProps) {
-  const { isOpen, performer, onModalClose } = props;
+  const { isOpen, performer, showMovieMonitor, onModalClose } = props;
   const dispatch = useDispatch();
 
   // Get editing state and handlers from hook
@@ -42,6 +43,7 @@ function EditPerformerModal(props: EditPerformerModalProps) {
     <Modal isOpen={isOpen} onModalClose={handleModalClose}>
       <EditPerformerModalContent
         performerId={performer.id}
+        showMovieMonitor={showMovieMonitor}
         fullName={modalData.fullName}
         images={modalData.images}
         overview={modalData.overview}

--- a/frontend/src/Performer/Edit/EditPerformerModalContent.js
+++ b/frontend/src/Performer/Edit/EditPerformerModalContent.js
@@ -36,6 +36,7 @@ class EditPerformerModalContent extends Component {
       fullName,
       images,
       item,
+      showMovieMonitor,
       isSaving,
       onInputChange,
       onModalClose,
@@ -90,17 +91,19 @@ class EditPerformerModalContent extends Component {
                   />
                 </FormGroup>
 
-                <FormGroup>
-                  <FormLabel>{translate('MonitoredMovie')}</FormLabel>
+                {showMovieMonitor && (
+                  <FormGroup>
+                    <FormLabel>{translate('MonitoredMovie')}</FormLabel>
 
-                  <FormInputGroup
-                    type={inputTypes.CHECK}
-                    name="moviesMonitored"
-                    helpText={translate('MonitoredPerformerMovieHelpText')}
-                    {...moviesMonitored}
-                    onChange={onInputChange}
-                  />
-                </FormGroup>
+                    <FormInputGroup
+                      type={inputTypes.CHECK}
+                      name="moviesMonitored"
+                      helpText={translate('MonitoredPerformerMovieHelpText')}
+                      {...moviesMonitored}
+                      onChange={onInputChange}
+                    />
+                  </FormGroup>
+                )}
 
                 <FormGroup>
                   <FormLabel>{translate('QualityProfile')}</FormLabel>
@@ -177,6 +180,7 @@ EditPerformerModalContent.propTypes = {
   fullName: PropTypes.string.isRequired,
   images: PropTypes.arrayOf(PropTypes.object).isRequired,
   item: PropTypes.object.isRequired,
+  showMovieMonitor: PropTypes.bool.isRequired,
   isSaving: PropTypes.bool.isRequired,
   isPathChanging: PropTypes.bool.isRequired,
   isSmallScreen: PropTypes.bool.isRequired,

--- a/frontend/src/Performer/Index/PerformerIndex.tsx
+++ b/frontend/src/Performer/Index/PerformerIndex.tsx
@@ -35,7 +35,7 @@ interface PerformerIndexProps {
   initialScrollTop?: number;
 }
 
-function PerformerIndex(_: PerformerIndexProps): JSX.Element {
+function PerformerIndex(_: Readonly<PerformerIndexProps>): JSX.Element {
   const {
     items,
     totalItems,
@@ -50,7 +50,6 @@ function PerformerIndex(_: PerformerIndexProps): JSX.Element {
     selectedFilterKey,
     sortDirection,
     view,
-    showMovieMonitorToggle,
     handleFirstPagePress,
     handleLastPagePress,
     handleNextPagePress,
@@ -178,7 +177,6 @@ function PerformerIndex(_: PerformerIndexProps): JSX.Element {
                 sortKey={sortKey}
                 sortDirection={sortDirection}
                 columns={columns}
-                showMovieMonitorToggle={showMovieMonitorToggle}
                 onSortPress={handleSortPress}
               />
               <TablePager

--- a/frontend/src/Performer/Index/Posters/PerformerIndexPoster.tsx
+++ b/frontend/src/Performer/Index/Posters/PerformerIndexPoster.tsx
@@ -16,6 +16,7 @@ import QualityProfileName from 'Settings/Profiles/Quality/QualityProfileName';
 import formatBytes from 'Utilities/Number/formatBytes';
 import titleCase from 'Utilities/String/titleCase';
 import translate from 'Utilities/String/translate';
+import { useGeneralSettings } from '../usePerformerIndex';
 import PerformerIndexProgressBar from './PerformerIndexProgressBar';
 import styles from './PerformerIndexPoster.css';
 
@@ -58,6 +59,21 @@ function PerformerIndexPoster(props: PerformerIndexPosterProps) {
   const elementStyle = {
     width: `${posterWidth}px`,
     height: `${posterHeight}px`,
+  };
+
+  const generalSettings = useGeneralSettings();
+
+  const showMovieMonitorToggle = (): boolean => {
+    const source = generalSettings.whisparrMovieMetadataSource;
+    return (
+      (source?.toLowerCase() === 'tmdb' &&
+        performer.tmdbId &&
+        performer.tmdbId > 0) ||
+      (source?.toLowerCase() === 'tpdb' &&
+        performer.tpdbId &&
+        performer.tpdbId.length > 0) ||
+      false
+    );
   };
 
   return (
@@ -200,6 +216,7 @@ function PerformerIndexPoster(props: PerformerIndexPosterProps) {
       <EditPerformerModal
         isOpen={isEditPerformerModalOpen}
         performer={performer}
+        showMovieMonitor={showMovieMonitorToggle()}
         onModalClose={onEditPerformerModalClose}
       />
     </div>

--- a/frontend/src/Performer/Index/Posters/PerformerIndexPoster.tsx
+++ b/frontend/src/Performer/Index/Posters/PerformerIndexPoster.tsx
@@ -5,6 +5,7 @@ import Label from 'Components/Label';
 import IconButton from 'Components/Link/IconButton';
 import Link from 'Components/Link/Link';
 import Popover from 'Components/Tooltip/Popover';
+import { useShowMovieMonitorToggleButton } from 'Helpers/Hooks/useShowMovieMonitorToggleButton';
 import { icons } from 'Helpers/Props';
 import MovieIndexPosterSelect from 'Movie/Index/Select/MovieIndexPosterSelect';
 import MovieHeadshot from 'Movie/MovieHeadshot';
@@ -16,7 +17,6 @@ import QualityProfileName from 'Settings/Profiles/Quality/QualityProfileName';
 import formatBytes from 'Utilities/Number/formatBytes';
 import titleCase from 'Utilities/String/titleCase';
 import translate from 'Utilities/String/translate';
-import { useGeneralSettings } from '../usePerformerIndex';
 import PerformerIndexProgressBar from './PerformerIndexProgressBar';
 import styles from './PerformerIndexPoster.css';
 
@@ -61,20 +61,10 @@ function PerformerIndexPoster(props: PerformerIndexPosterProps) {
     height: `${posterHeight}px`,
   };
 
-  const generalSettings = useGeneralSettings();
-
-  const showMovieMonitorToggle = (): boolean => {
-    const source = generalSettings.whisparrMovieMetadataSource;
-    return (
-      (source?.toLowerCase() === 'tmdb' &&
-        performer.tmdbId &&
-        performer.tmdbId > 0) ||
-      (source?.toLowerCase() === 'tpdb' &&
-        performer.tpdbId &&
-        performer.tpdbId.length > 0) ||
-      false
-    );
-  };
+  const showMovieMonitorToggle = useShowMovieMonitorToggleButton(
+    performer?.tmdbId,
+    performer?.tpdbId
+  );
 
   return (
     <div className={styles.content}>
@@ -216,7 +206,7 @@ function PerformerIndexPoster(props: PerformerIndexPosterProps) {
       <EditPerformerModal
         isOpen={isEditPerformerModalOpen}
         performer={performer}
-        showMovieMonitor={showMovieMonitorToggle()}
+        showMovieMonitor={showMovieMonitorToggle}
         onModalClose={onEditPerformerModalClose}
       />
     </div>

--- a/frontend/src/Performer/Index/Table/PerformerIndexRow.tsx
+++ b/frontend/src/Performer/Index/Table/PerformerIndexRow.tsx
@@ -25,7 +25,7 @@ interface PerformerIndexRowProps {
   performer: Performer;
   sortKey: string;
   columns: Column[];
-  showMovieMonitorToggle?: boolean;
+  showMovieMonitorToggle: boolean;
   isSelectMode: boolean;
 }
 
@@ -280,6 +280,7 @@ function PerformerIndexRow(props: PerformerIndexRowProps) {
       <EditPerformerModal
         isOpen={isEditPerformerModalOpen}
         performer={performer}
+        showMovieMonitor={showMovieMonitorToggle}
         onModalClose={onEditPerformerModalClose}
       />
     </TableRowCell>

--- a/frontend/src/Performer/Index/Table/PerformerIndexRow.tsx
+++ b/frontend/src/Performer/Index/Table/PerformerIndexRow.tsx
@@ -8,6 +8,7 @@ import TableRowCell from 'Components/Table/Cells/TableRowCell';
 import VirtualTableSelectCell from 'Components/Table/Cells/VirtualTableSelectCell';
 import Column from 'Components/Table/Column';
 import Tooltip from 'Components/Tooltip/Tooltip';
+import { useShowMovieMonitorToggleButton } from 'Helpers/Hooks/useShowMovieMonitorToggleButton';
 import { icons, kinds } from 'Helpers/Props';
 import PerformerDetailsLinks from 'Performer/Details/PerformerDetailsLinks';
 import EditPerformerModal from 'Performer/Edit/EditPerformerModal';
@@ -25,12 +26,11 @@ interface PerformerIndexRowProps {
   performer: Performer;
   sortKey: string;
   columns: Column[];
-  showMovieMonitorToggle: boolean;
   isSelectMode: boolean;
 }
 
 function PerformerIndexRow(props: PerformerIndexRowProps) {
-  const { performer, columns, isSelectMode, showMovieMonitorToggle } = props;
+  const { performer, columns, isSelectMode } = props;
   const {
     id: performerId,
     fullName,
@@ -56,6 +56,10 @@ function PerformerIndexRow(props: PerformerIndexRowProps) {
     tpdbId,
   } = performer;
   const countryCodeName = countryCode(country);
+  const showMovieMonitorToggle = useShowMovieMonitorToggleButton(
+    tmdbId,
+    tpdbId
+  );
 
   const [isEditPerformerModalOpen, setIsEditPerformerModalOpen] =
     useState(false);

--- a/frontend/src/Performer/Index/Table/PerformerIndexRow.tsx
+++ b/frontend/src/Performer/Index/Table/PerformerIndexRow.tsx
@@ -113,7 +113,7 @@ function PerformerIndexRow(props: PerformerIndexRowProps) {
                 ? styles.statusIcon
                 : `${styles.statusIcon} ${styles.unmonitored}`
             }
-            title="scene"
+            title={translate('MonitoredScene')}
             name={monitored ? icons.SCENE : icons.SCENEUNMONITOR}
           />
           {showMovieMonitorToggle ? (
@@ -123,7 +123,7 @@ function PerformerIndexRow(props: PerformerIndexRowProps) {
                   ? styles.statusIcon
                   : `${styles.statusIcon} ${styles.unmonitored}`
               }
-              title="movie"
+              title={translate('MonitorMovies')}
               name={moviesMonitored ? icons.FILM : icons.FILMUNMONITOR}
             />
           ) : null}
@@ -275,7 +275,6 @@ function PerformerIndexRow(props: PerformerIndexRowProps) {
           />
         </TableRowCell>
       );
-      return;
     }
   });
 

--- a/frontend/src/Performer/Index/Table/PerformerIndexTable.tsx
+++ b/frontend/src/Performer/Index/Table/PerformerIndexTable.tsx
@@ -13,7 +13,7 @@ interface PerformerIndexTableProps {
   sortDirection?: SortDirection;
   isSelectMode: boolean;
   columns: Column[];
-  showMovieMonitorToggle?: boolean;
+  showMovieMonitorToggle: boolean;
   onSortPress?: (name: string, sortDirection?: SortDirection) => void;
 }
 

--- a/frontend/src/Performer/Index/Table/PerformerIndexTable.tsx
+++ b/frontend/src/Performer/Index/Table/PerformerIndexTable.tsx
@@ -13,7 +13,6 @@ interface PerformerIndexTableProps {
   sortDirection?: SortDirection;
   isSelectMode: boolean;
   columns: Column[];
-  showMovieMonitorToggle: boolean;
   onSortPress?: (name: string, sortDirection?: SortDirection) => void;
 }
 
@@ -23,9 +22,8 @@ function PerformerIndexTable({
   sortDirection,
   isSelectMode,
   columns,
-  showMovieMonitorToggle,
   onSortPress,
-}: PerformerIndexTableProps) {
+}: Readonly<PerformerIndexTableProps>) {
   return (
     <Table
       columns={columns}
@@ -39,7 +37,6 @@ function PerformerIndexTable({
           <TableRow key={performer.id}>
             <PerformerIndexRow
               performer={performer}
-              showMovieMonitorToggle={showMovieMonitorToggle}
               sortKey={sortKey}
               columns={columns}
               isSelectMode={isSelectMode}

--- a/frontend/src/Settings/General/useGeneralSettings.ts
+++ b/frontend/src/Settings/General/useGeneralSettings.ts
@@ -1,0 +1,15 @@
+import { useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import AppState from 'App/State/AppState';
+import { fetchGeneralSettings } from 'Store/Actions/settingsActions';
+
+// Used to fetch general.whisparrMovieMetadataSource setting
+export function useGeneralSettings() {
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    dispatch(fetchGeneralSettings());
+  }, [dispatch]);
+
+  return useSelector((state: AppState) => state.settings.general.item);
+}

--- a/frontend/src/Studio/Details/StudioDetails.tsx
+++ b/frontend/src/Studio/Details/StudioDetails.tsx
@@ -25,6 +25,7 @@ import PageToolbarSection from 'Components/Page/Toolbar/PageToolbarSection';
 import PageToolbarSeparator from 'Components/Page/Toolbar/PageToolbarSeparator';
 import posterPlaceholder from 'Components/posterPlaceholder';
 import Tooltip from 'Components/Tooltip/Tooltip';
+import { useShowMovieMonitorToggleButton } from 'Helpers/Hooks/useShowMovieMonitorToggleButton';
 import { icons, kinds, sizes, tooltipPositions } from 'Helpers/Props';
 import QualityProfileName from 'Settings/Profiles/Quality/QualityProfileName';
 import { setStudioScenesExpanded } from 'Store/Actions/studioScenesActions';
@@ -75,7 +76,6 @@ function StudioDetails() {
     isManualRefresh,
     isStudioDetailsFetching,
     isStudioRefreshing,
-    showMovieMonitorToggle,
     studioDetailsError,
     handleDeleteMovieModalClose,
     handleDeleteMoviePress,
@@ -88,6 +88,11 @@ function StudioDetails() {
     onSearchPress,
     onYearRefreshPress,
   } = useStudioDetails(studioForeignId);
+
+  const showMovieMonitorToggle = useShowMovieMonitorToggleButton(
+    studio?.tmdbId,
+    studio?.tpdbId
+  );
 
   const studioTags = useStudioTags(studio?.tags || []);
   const studioId = studio?.id;

--- a/frontend/src/Studio/Details/useStudioDetails.ts
+++ b/frontend/src/Studio/Details/useStudioDetails.ts
@@ -425,8 +425,7 @@ export function buildStudioWorksData(
     works: allWorks.filter((w) => w.year === year),
   }));
 
-  const runningYears =
-    years.length > 0 ? `${years[years.length - 1]}-${years[0]}` : '';
+  const runningYears = years.length > 0 ? `${years.at(-1)}-${years[0]}` : '';
 
   const allExpanded =
     years.length > 0 && years.every((year) => expandedState[year]);

--- a/frontend/src/Studio/Edit/EditStudioModal.tsx
+++ b/frontend/src/Studio/Edit/EditStudioModal.tsx
@@ -19,7 +19,7 @@ function EditStudioModal({
   onModalClose,
   studio,
   ...otherProps
-}: EditStudioModalProps) {
+}: Readonly<EditStudioModalProps>) {
   const dispatch = useDispatch();
   const modalData = useEditStudioModal(studio);
   const prevIsSavingRef = useRef(modalData.isSaving);

--- a/frontend/src/Studio/Edit/EditStudioModal.tsx
+++ b/frontend/src/Studio/Edit/EditStudioModal.tsx
@@ -49,6 +49,7 @@ function EditStudioModal({
         images={modalData.images}
         overview={modalData.overview}
         item={modalData.item}
+        showMovieMonitor={modalData.showMovieMonitor}
         isSaving={modalData.isSaving}
         saveError={modalData.saveError}
         isPathChanging={modalData.isPathChanging}

--- a/frontend/src/Studio/Edit/EditStudioModalContent.tsx
+++ b/frontend/src/Studio/Edit/EditStudioModalContent.tsx
@@ -49,6 +49,7 @@ function EditStudioModalContent(props: EditStudioModalContentProps) {
     images,
     overview,
     item,
+    showMovieMonitor,
     isSaving,
     onInputChange,
     onModalClose,
@@ -110,16 +111,20 @@ function EditStudioModalContent(props: EditStudioModalContentProps) {
                   onChange={onInputChange}
                 />
               </FormGroup>
-              <FormGroup>
-                <FormLabel>{translate('MonitoredMovie')}</FormLabel>
-                <FormInputGroup
-                  type={inputTypes.CHECK}
-                  name="moviesMonitored"
-                  helpText={translate('MonitoredStudioMovieHelpText')}
-                  {...moviesMonitored}
-                  onChange={onInputChange}
-                />
-              </FormGroup>
+
+              {showMovieMonitor ? (
+                <FormGroup>
+                  <FormLabel>{translate('MonitoredMovie')}</FormLabel>
+                  <FormInputGroup
+                    type={inputTypes.CHECK}
+                    name="moviesMonitored"
+                    helpText={translate('MonitoredStudioMovieHelpText')}
+                    {...moviesMonitored}
+                    onChange={onInputChange}
+                  />
+                </FormGroup>
+              ) : null}
+
               <FormGroup>
                 <FormLabel>{translate('MonitorAfter')}</FormLabel>
                 <FormInputGroup

--- a/frontend/src/Studio/Edit/EditStudioModalContent.tsx
+++ b/frontend/src/Studio/Edit/EditStudioModalContent.tsx
@@ -43,7 +43,7 @@ interface EditStudioModalContentProps {
   [key: string]: unknown;
 }
 
-function EditStudioModalContent(props: EditStudioModalContentProps) {
+function EditStudioModalContent(props: Readonly<EditStudioModalContentProps>) {
   const {
     title,
     images,

--- a/frontend/src/Studio/Edit/useEditStudioModal.ts
+++ b/frontend/src/Studio/Edit/useEditStudioModal.ts
@@ -5,6 +5,7 @@ import useApiMutation from 'Helpers/Hooks/useApiMutation';
 import { setStudioValue } from 'Store/Actions/studioActions';
 import createDimensionsSelector from 'Store/Selectors/createDimensionsSelector';
 import selectSettings from 'Store/Selectors/selectSettings';
+import { useGeneralSettings } from 'Studio/Index/useStudioIndex';
 import Studio from 'Studio/Studio';
 import type { PendingSection } from 'typings/pending';
 
@@ -29,6 +30,7 @@ interface UseEditStudioModalResult {
   isPathChanging: boolean;
   originalPath: string;
   item: PendingSection<StudioSettings>;
+  showMovieMonitor: boolean;
   isSmallScreen: boolean;
   onInputChange: (payload: { name: string; value: unknown }) => void;
   onSavePress: () => void;
@@ -88,6 +90,21 @@ export default function useEditStudioModal(
 
   const settings = selectSettings(studioSettings, pendingChanges, saveError);
 
+  const generalSettings = useGeneralSettings();
+
+  const showMovieMonitorToggle = (): boolean => {
+    const source = generalSettings.whisparrMovieMetadataSource;
+    return (
+      (source?.toLowerCase() === 'tmdb' &&
+        studio.tmdbId &&
+        studio.tmdbId > 0) ||
+      (source?.toLowerCase() === 'tpdb' &&
+        studio.tpdbId &&
+        studio.tpdbId.length > 0) ||
+      false
+    );
+  };
+
   return {
     title: studio.title,
     images: studio.images,
@@ -96,6 +113,7 @@ export default function useEditStudioModal(
     isPathChanging,
     originalPath: (studio as unknown as { path?: string }).path || '',
     item: settings.settings,
+    showMovieMonitor: showMovieMonitorToggle(),
     isSmallScreen: dimensions.isSmallScreen,
     onInputChange,
     onSavePress,

--- a/frontend/src/Studio/Index/StudioIndex.tsx
+++ b/frontend/src/Studio/Index/StudioIndex.tsx
@@ -45,7 +45,6 @@ function StudioIndex(): JSX.Element {
     selectedFilterKey,
     sortDirection,
     view,
-    showMovieMonitorToggle,
     handleFirstPagePress,
     handleLastPagePress,
     handleNextPagePress,
@@ -174,7 +173,6 @@ function StudioIndex(): JSX.Element {
                 sortKey={sortKey}
                 sortDirection={sortDirection}
                 columns={columns}
-                showMovieMonitorToggle={showMovieMonitorToggle}
                 onSortPress={handleSortPress}
               />
               <TablePager

--- a/frontend/src/Studio/Index/Table/StudioIndexRow.tsx
+++ b/frontend/src/Studio/Index/Table/StudioIndexRow.tsx
@@ -8,6 +8,7 @@ import TableRowCell from 'Components/Table/Cells/TableRowCell';
 import VirtualTableSelectCell from 'Components/Table/Cells/VirtualTableSelectCell';
 import Column from 'Components/Table/Column';
 import Tooltip from 'Components/Tooltip/Tooltip';
+import { useShowMovieMonitorToggleButton } from 'Helpers/Hooks/useShowMovieMonitorToggleButton';
 import { icons, kinds } from 'Helpers/Props';
 import QUalityProfileName from 'Settings/Profiles/Quality/QualityProfileName';
 import StudioDetailsLinks from 'Studio/Details/StudioDetailsLinks';
@@ -24,11 +25,10 @@ interface StudioIndexRowProps {
   sortKey: string;
   columns: Column[];
   isSelectMode: boolean;
-  showMovieMonitorToggle: boolean;
 }
 
 function StudioIndexRow(props: StudioIndexRowProps) {
-  const { studio, columns, isSelectMode, showMovieMonitorToggle } = props;
+  const { studio, columns, isSelectMode } = props;
   const { id: studioId, qualityProfileId } = studio;
 
   const {
@@ -53,6 +53,10 @@ function StudioIndexRow(props: StudioIndexRowProps) {
   const safeForWorkMode = React.useContext(SafeForWorkModeContext);
   const [isEditStudioModalOpen, setIsEditStudioModalOpen] = useState(false);
   const [selectState, selectDispatch] = useSelect();
+  const showMovieMonitorToggle = useShowMovieMonitorToggleButton(
+    studio?.tmdbId,
+    studio?.tpdbId
+  );
 
   const onEditStudioPress = useCallback(() => {
     setIsEditStudioModalOpen(true);
@@ -105,7 +109,7 @@ function StudioIndexRow(props: StudioIndexRowProps) {
                 ? styles.statusIcon
                 : `${styles.statusIcon} ${styles.unmonitored}`
             }
-            title="scene"
+            title={translate('MonitoredScene')}
             name={monitored ? icons.SCENE : icons.SCENEUNMONITOR}
           />
           {showMovieMonitorToggle ? (
@@ -115,7 +119,7 @@ function StudioIndexRow(props: StudioIndexRowProps) {
                   ? styles.statusIcon
                   : `${styles.statusIcon} ${styles.unmonitored}`
               }
-              title="movie"
+              title={translate('MonitorMovies')}
               name={moviesMonitored ? icons.FILM : icons.FILMUNMONITOR}
             />
           ) : null}
@@ -235,7 +239,6 @@ function StudioIndexRow(props: StudioIndexRowProps) {
           />
         </TableRowCell>
       );
-      return;
     }
   });
 

--- a/frontend/src/Studio/Index/Table/StudioIndexTable.tsx
+++ b/frontend/src/Studio/Index/Table/StudioIndexTable.tsx
@@ -23,7 +23,7 @@ function StudioIndexTable({
   isSelectMode,
   columns,
   onSortPress,
-}: StudioIndexTableProps) {
+}: Readonly<StudioIndexTableProps>) {
   return (
     <Table
       columns={columns}

--- a/frontend/src/Studio/Index/Table/StudioIndexTable.tsx
+++ b/frontend/src/Studio/Index/Table/StudioIndexTable.tsx
@@ -13,7 +13,6 @@ interface StudioIndexTableProps {
   sortDirection?: SortDirection;
   isSelectMode: boolean;
   columns: Column[];
-  showMovieMonitorToggle: boolean;
   onSortPress?: (name: string, sortDirection?: SortDirection) => void;
 }
 
@@ -23,7 +22,6 @@ function StudioIndexTable({
   sortDirection,
   isSelectMode,
   columns,
-  showMovieMonitorToggle,
   onSortPress,
 }: StudioIndexTableProps) {
   return (
@@ -42,7 +40,6 @@ function StudioIndexTable({
               sortKey={sortKey}
               columns={columns}
               isSelectMode={isSelectMode}
-              showMovieMonitorToggle={showMovieMonitorToggle}
             />
           </TableRow>
         ))}


### PR DESCRIPTION
## Summary
- Hide the movie monitor toggle button when it cannot be used (e.g. no valid monitor configuration)
- Hide the Movie Menu when Metasource is set to None
- Refactored show-toggle logic into a dedicated hook for cleaner component code

partially authored by @sampulsar 

- Fixes whisparr/whisparr#1031