### PR TITLE
Fix: Performer error triggered by Stasharr

### DIFF
--- a/src/Whisparr.Api.V3/Performers/PerformerController.cs
+++ b/src/Whisparr.Api.V3/Performers/PerformerController.cs
@@ -333,10 +333,20 @@ namespace Whisparr.Api.V3.Performers
         private PerformerResource GetCachedPerformerResource(string performerForeignId)
         {
             var performerResource = _performerResourceCache.Find(performerForeignId);
-            if (performerResource == null)
+            if (performerResource != null)
             {
-                performerResource = MapToResource(_performerService.FindByForeignId(performerForeignId));
+                return performerResource;
             }
+
+            var performer = _performerService.FindByForeignId(performerForeignId);
+            if (performer == null)
+            {
+                return null;
+            }
+
+            performerResource = performer.ToResource();
+            _coverMapper.ConvertToLocalPerformerUrls(performerResource.Id, performerResource.Images);
+            _performerResourceCache.Set(performerForeignId, performerResource);
 
             return performerResource;
         }
@@ -349,14 +359,18 @@ namespace Whisparr.Api.V3.Performers
                 var performerResource = _performerResourceCache.Find(id);
                 if (performerResource == null)
                 {
-                    performerResource = _performerService.FindByForeignId(id).ToResource();
+                    var performer = _performerService.FindByForeignId(id);
+                    if (performer == null)
+                    {
+                        continue;
+                    }
+
+                    performerResource = performer.ToResource();
+                    _coverMapper.ConvertToLocalPerformerUrls(performerResource.Id, performerResource.Images);
+                    _performerResourceCache.Set(id, performerResource);
                 }
 
-                if (performerResource != null)
-                {
-                    _coverMapper.ConvertToLocalPerformerUrls(performerResource.Id, performerResource.Images);
-                    performerResources.Add(performerResource);
-                }
+                performerResources.Add(performerResource);
             }
 
             return performerResources;


### PR DESCRIPTION
#### Database Migration

<!-- If you update database schema, the migration number must be noted here -->

NO

#### Description

Stasharr does a query when viewing a performer on StashDB.  If that performer wasn't in Whisparr, it'd throw a null reference exception.  This fixes it so a 404 is returned instead, bringing the code in line with Studio.

#### Screenshot(s) (if UI related)

<details>
<!-- paste screenshots below here.-->

<!-- paste screenshots above here.  MAKE SURE THE ARE SFW -->
</details>

#### Todos

- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)

#### Issues Fixed or Closed by this PR

<!-- If multiple, put each on a separate line -->

- Fixes whisparr/whisparr#XXXX
