### PR TITLE
Fix: Header search incorrect images

### DIFF
--- a/frontend/src/Components/Page/Header/MovieSearchInput.tsx
+++ b/frontend/src/Components/Page/Header/MovieSearchInput.tsx
@@ -71,6 +71,7 @@ interface Section {
 
 function moviesToSuggestions(movies: Movie[]): MovieSuggestion[] {
   return movies.map((m, i) => ({
+    key: m.id,
     title: m.title,
     indices: [],
     item: {


### PR DESCRIPTION
#### Database Migration

<!-- If you update database schema, the migration number must be noted here -->

NO

#### Description

After moving the header search to React Query, the results were not reliably showing the correct image for the first item during typeahead/refresh.

#### Screenshot(s) (if UI related)

<details>
<!-- paste screenshots below here.-->

<!-- paste screenshots above here.  MAKE SURE THE ARE SFW -->
</details>

#### Todos

- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)

#### Issues Fixed or Closed by this PR

<!-- If multiple, put each on a separate line -->

- Fixes whisparr/whisparr#XXXX
