### PR TITLE
Fix: Parser approving mutiple releases with WhisparrAutoMatchOnDate enabled

### DIFF
--- a/src/NzbDrone.Core.Test/MovieTests/MovieServiceTests/MatchOnStudioDateFixture.cs
+++ b/src/NzbDrone.Core.Test/MovieTests/MovieServiceTests/MatchOnStudioDateFixture.cs
@@ -68,6 +68,54 @@ namespace NzbDrone.Core.Test.MovieTests.MovieServiceTests
 
             Assert.That(result, Is.Null);
         }
+
+        [Test]
+        public void Should_not_match_release_with_different_date_via_studio_fallback_when_WhisparrAutoMatchOnDate_enabled()
+        {
+            // Regression: searching for a movie by date returns releases from the same studio with
+            // different dates. The studio has only one library movie, so GetByStudioForeignId returns
+            // a single result. WhisparrAutoMatchOnDate must NOT fire here because the date query
+            // itself found nothing — we fell back to the studio-only query (verifyDate=true).
+            var studioId = "studio-1";
+            var libraryMovieDate = "2022-11-16";
+            var releaseDateNotInLibrary = "2022-11-30";
+
+            var libraryMovie = new Movie { Id = 1 };
+            libraryMovie.MovieMetadata.Value.StudioForeignId = studioId;
+            libraryMovie.MovieMetadata.Value.ReleaseDate = libraryMovieDate;
+
+            _movieRepositoryMock.Setup(r => r.FindByStudioAndDate(studioId, releaseDateNotInLibrary))
+                .Returns(new List<Movie>());
+            _movieRepositoryMock.Setup(r => r.GetByStudioForeignId(studioId))
+                .Returns(new List<Movie> { libraryMovie });
+            _configServiceMock.SetupGet(c => c.WhisparrAutoMatchOnDate).Returns(true);
+
+            var result = _movieService.InvokeFindByStudioAndReleaseDate(studioId, releaseDateNotInLibrary, "", "", "");
+
+            Assert.That(result, Is.Null);
+        }
+
+        [Test]
+        public void Should_still_match_when_date_query_finds_exactly_one_movie_and_WhisparrAutoMatchOnDate_enabled()
+        {
+            // The date query itself returns the one matching movie — WhisparrAutoMatchOnDate
+            // should still fire in this case (verifyDate=false, genuine date match).
+            var studioId = "studio-1";
+            var releaseDate = "2022-11-16";
+
+            var movie = new Movie { Id = 1 };
+            movie.MovieMetadata.Value.StudioForeignId = studioId;
+            movie.MovieMetadata.Value.ReleaseDate = releaseDate;
+
+            _movieRepositoryMock.Setup(r => r.FindByStudioAndDate(studioId, releaseDate))
+                .Returns(new List<Movie> { movie });
+            _configServiceMock.SetupGet(c => c.WhisparrAutoMatchOnDate).Returns(true);
+
+            var result = _movieService.InvokeFindByStudioAndReleaseDate(studioId, releaseDate, "", "", "");
+
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result.Id, Is.EqualTo(movie.Id));
+        }
     }
 
     public static class MovieServiceTestExtensions

--- a/src/NzbDrone.Core/Movies/MovieService.cs
+++ b/src/NzbDrone.Core/Movies/MovieService.cs
@@ -835,7 +835,8 @@ namespace NzbDrone.Core.Movies
                 }
 
                 // WhisparrAutoMatchOnDate enabled and only one match, return it
-                if (_configService.WhisparrAutoMatchOnDate && movies.Count == 1)
+                // Only applies when the date query itself found the match (verifyDate=false means we didn't fall back to studio-only)
+                if (_configService.WhisparrAutoMatchOnDate && movies.Count == 1 && !verifyDate)
                 {
                     _logger.Debug("{0}: WhisparrAutoMatchOnDate enabled, returning single movie match by studio and date.", methodName);
                     return movies.First();


### PR DESCRIPTION
#### Database Migration

<!-- If you update database schema, the migration number must be noted here -->

NO

#### Description

Fixes a bug when WhisparrAutoMatchOnDate is enabled and indexer returns multiple non-matching (by date) releases for a query.  It was approving all of them, as the results themselves were overly loose and the original testing wasn't expecting that.  Mostly seen on NZB indexers.


Scenario | Before | After
-- | -- | --
Date query finds 1 match → verifyDate=false | Returns it ✓ | Returns it ✓
Date query finds 0 → fallback to studio, 1 movie → verifyDate=true | Returns it WRONG | Falls through to MatchMovies with verifyDate=true, which enforces date check ✓
Date query finds multiple | Falls through | Falls through (unchanged)


For the user reporting bogus matches on 22.11.16, the 22.11.30, 22.11.28, etc. releases would now reach `MatchMovies` with `verifyDate=true`, where the date mismatch check at line 1099 of `MovieService` will reject them.

#### Screenshot(s) (if UI related)

<details>
<!-- paste screenshots below here.-->

<!-- paste screenshots above here.  MAKE SURE THE ARE SFW -->
</details>

#### Todos

- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)

#### Issues Fixed or Closed by this PR

<!-- If multiple, put each on a separate line -->

- Fixes whisparr/whisparr#1045
