### PR TITLE
Chore: Fix failing test

### DIFF
--- a/.github/workflows/build_v3.yml
+++ b/.github/workflows/build_v3.yml
@@ -24,8 +24,8 @@ env:
   FRAMEWORK: net10.0
   RAW_BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
   WHISPARR_MAJOR_VERSION: 3
-  VERSION: 3.3.0
-  WHISPARR_ASSEMBLY_VERSION: 3.3.0.${{ github.run_number }}
+  VERSION: 3.3.1
+  WHISPARR_ASSEMBLY_VERSION: 3.3.1.${{ github.run_number }}
 
 jobs:
   prepare:

--- a/src/NzbDrone.Integration.Test/HttpLogFixture.cs
+++ b/src/NzbDrone.Integration.Test/HttpLogFixture.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Linq;
 using FluentAssertions;
 using NUnit.Framework;
 
@@ -15,16 +13,13 @@ namespace NzbDrone.Integration.Test
             config.LogLevel = "Trace";
             HostConfig.Put(config);
 
-            var resultGet = Movies.All();
+            Movies.All();
 
             var logFile = "whisparr.trace.txt";
-            var logLines = Logs.GetLogFileLines(logFile);
 
             Movies.InvalidPost(new Whisparr.Api.V3.Movies.MovieResource());
 
-            // Skip 2 and 1 to ignore the logs endpoint
-            logLines = Logs.GetLogFileLines(logFile).Skip(logLines.Length + 2).ToArray();
-            Array.Resize(ref logLines, logLines.Length - 1);
+            var logLines = Logs.GetLogFileLines(logFile);
 
             logLines.Should().Contain(v => v.Contains("|Trace|Http|Req") && v.Contains("/api/v3/movie/"));
             logLines.Should().Contain(v => v.Contains("|Trace|Http|Res") && v.Contains("/api/v3/movie/: 400.BadRequest"));

--- a/src/NzbDrone.Integration.Test/HttpLogFixture.cs
+++ b/src/NzbDrone.Integration.Test/HttpLogFixture.cs
@@ -20,14 +20,7 @@ namespace NzbDrone.Integration.Test
             var logFile = "whisparr.trace.txt";
             var logLines = Logs.GetLogFileLines(logFile);
 
-            try
-            {
-                Movies.InvalidPost(new Whisparr.Api.V3.Movies.MovieResource());
-            }
-            catch
-            {
-                // swallow, we are just validating logging
-            }
+            Movies.InvalidPost(new Whisparr.Api.V3.Movies.MovieResource());
 
             // Skip 2 and 1 to ignore the logs endpoint
             logLines = Logs.GetLogFileLines(logFile).Skip(logLines.Length + 2).ToArray();


### PR DESCRIPTION
#### Database Migration

<!-- If you update database schema, the migration number must be noted here -->

NO

#### Description

This one is failing frequently in CI.  The base HTTP client should be handling exceptions, so checking for error logs should be tertiary.  I removed a workaround that was in place prior to the RestSharp upgrade, which now handles the exception throwing consistently.

#### Screenshot(s) (if UI related)

<details>
<!-- paste screenshots below here.-->

<!-- paste screenshots above here.  MAKE SURE THE ARE SFW -->
</details>

#### Todos

- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)

#### Issues Fixed or Closed by this PR

<!-- If multiple, put each on a separate line -->

- Fixes whisparr/whisparr#XXXX
