### PR TITLE
Chore: Additional tweaks for import view table visibility

### DIFF
--- a/frontend/src/AddMovie/ImportMovie/Import/ImportMovie.tsx
+++ b/frontend/src/AddMovie/ImportMovie/Import/ImportMovie.tsx
@@ -90,7 +90,7 @@ function ImportMovie() {
       state.settings.qualityProfiles.items
   );
 
-  const defaultMonitor = addMovieState.monitor;
+  const defaultMonitor = addMovieState.monitor ?? 'movieOnly';
   const defaultQualityProfileId = addMovieState.qualityProfileId;
 
   const rootFolder = rootFolderItems.find((rf) => rf.id === rootFolderId);

--- a/frontend/src/AddMovie/ImportMovie/Import/ImportMovieTable.css
+++ b/frontend/src/AddMovie/ImportMovie/Import/ImportMovieTable.css
@@ -6,6 +6,7 @@
 .row {
   display: flex;
   align-items: center;
+  min-height: 52px;
   border-top: 1px solid var(--borderColor);
   transition: background-color 500ms;
 

--- a/frontend/src/Store/Actions/addMovieActions.js
+++ b/frontend/src/Store/Actions/addMovieActions.js
@@ -32,6 +32,7 @@ export const defaultState = {
 
   movieDefaults: {
     rootFolderPath: '',
+    monitor: 'movieOnly',
     monitored: true,
     qualityProfileId: 0,
     searchForMovie: false,


### PR DESCRIPTION
#### Database Migration

<!-- If you update database schema, the migration number must be noted here -->

NO

#### Description

I was able to repro and fix this in other browsers, finally.  The issue was a quirk related to when the movieMonitor was changed to an enum, stale browser redux allowing me to bypass issues, and Firefox being permissive vs. other browsers.

#### Screenshot(s) (if UI related)

<details>
<!-- paste screenshots below here.-->

<!-- paste screenshots above here.  MAKE SURE THE ARE SFW -->
</details>

#### Todos

- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)

#### Issues Fixed or Closed by this PR

<!-- If multiple, put each on a separate line -->

- Fixes whisparr/whisparr#XXXX
