### PR TITLE
Fix: Update modal is empty if all updates are maintenance-related

### DIFF
--- a/frontend/src/App/AppUpdatedModalContent.tsx
+++ b/frontend/src/App/AppUpdatedModalContent.tsx
@@ -111,30 +111,35 @@ function AppUpdatedModalContent(props: AppUpdatedModalContentProps) {
           />
         </div>
 
-        {isPopulated && !error && !!update ? (
+        {isPopulated && !error ? (
           <div>
             {(() => {
-              if (typeof update.changes === 'string' && update.changes) {
-                return <MarkdownRenderer>{update.changes}</MarkdownRenderer>;
-              }
-              if (update.changes && typeof update.changes === 'object') {
+              if (!update?.changes) {
+                const branch = update?.branch ?? items[0]?.branch;
                 return (
-                  <div>
-                    <div className={styles.changes}>
-                      {translate('WhatsNew')}
-                    </div>
-                    <UpdateChanges
-                      title={translate('New')}
-                      changes={update.changes.new}
-                    />
-                    <UpdateChanges
-                      title={translate('Fixed')}
-                      changes={update.changes.fixed}
-                    />
-                  </div>
+                  <InlineMarkdown
+                    data={translate('MaintenanceReleaseWithLink', {
+                      url: `https://github.com/Whisparr/Whisparr-Eros/commits/${branch}`,
+                    })}
+                  />
                 );
               }
-              return null;
+              if (typeof update.changes === 'string') {
+                return <MarkdownRenderer>{update.changes}</MarkdownRenderer>;
+              }
+              return (
+                <div>
+                  <div className={styles.changes}>{translate('WhatsNew')}</div>
+                  <UpdateChanges
+                    title={translate('New')}
+                    changes={update.changes.new}
+                  />
+                  <UpdateChanges
+                    title={translate('Fixed')}
+                    changes={update.changes.fixed}
+                  />
+                </div>
+              );
             })()}
           </div>
         ) : null}


### PR DESCRIPTION
#### Database Migration

<!-- If you update database schema, the migration number must be noted here -->

NO

#### Description

Copied general maintenance update message from Updates page to modal.  This shows if all updates are not Fix/New prefixed.

#### Screenshot(s) (if UI related)

<details>
<!-- paste screenshots below here.-->

<!-- paste screenshots above here.  MAKE SURE THE ARE SFW -->
</details>

#### Todos

- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)

#### Issues Fixed or Closed by this PR

<!-- If multiple, put each on a separate line -->

- Fixes whisparr/whisparr#985
