### PR TITLE
Fix: Header search stale images

### DIFF
--- a/frontend/src/Components/Page/Header/MovieSearchInput.tsx
+++ b/frontend/src/Components/Page/Header/MovieSearchInput.tsx
@@ -17,7 +17,7 @@ import LoadingIndicator from 'Components/Loading/LoadingIndicator';
 import useKeyboardShortcuts from 'Helpers/Hooks/useKeyboardShortcuts';
 import { icons } from 'Helpers/Props';
 import Movie from 'Movie/Movie';
-import { useSearchMovie } from 'Movie/useMovie';
+import { useSearchMovieUncached } from 'Movie/useMovie';
 import translate from 'Utilities/String/translate';
 import MovieSearchResult from './MovieSearchResult';
 import styles from './MovieSearchInput.css';
@@ -89,7 +89,8 @@ function MovieSearchInput() {
   const [value, setValue] = useState('');
   const [debouncedValue] = useDebounce(value, 250);
 
-  const { data: movies = [], isLoading } = useSearchMovie(debouncedValue);
+  const { data: movies = [], isLoading } =
+    useSearchMovieUncached(debouncedValue);
 
   const { bindShortcut, unbindShortcut } = useKeyboardShortcuts();
   const autosuggestRef = useRef<Autosuggest>(null);

--- a/frontend/src/Movie/useMovie.ts
+++ b/frontend/src/Movie/useMovie.ts
@@ -94,4 +94,15 @@ export function useSearchMovie(query: string, limit: number = 10) {
   });
 }
 
+export function useSearchMovieUncached(query: string, limit: number = 10) {
+  return useApiQuery<Movie[]>({
+    path: `/movie/search`,
+    queryParams: { query, limit },
+    queryOptions: {
+      enabled: !!query && query.length > 2,
+      placeholderData: undefined,
+    },
+  });
+}
+
 export default useMovie;


### PR DESCRIPTION
#### Database Migration

<!-- If you update database schema, the migration number must be noted here -->

NO

#### Description

#158 wasn't completely successful in fixing this.  I have removed the "hold previous data while query is fetching" logic from this component's implementation of React Query, so this is avoided.

I opted to clone the function to avoid unexpected behavior in any other potential usage of useSearchMovie now or in the future.

#### Screenshot(s) (if UI related)

<details>
<!-- paste screenshots below here.-->

<!-- paste screenshots above here.  MAKE SURE THE ARE SFW -->
</details>

#### Todos

- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)

#### Issues Fixed or Closed by this PR

<!-- If multiple, put each on a separate line -->

- Refs: #158
