### PR TITLE
Fix: Scheduled movie/scene  refresh fixes

### DIFF
--- a/src/NzbDrone.Core/Movies/RefreshMovieService.cs
+++ b/src/NzbDrone.Core/Movies/RefreshMovieService.cs
@@ -418,9 +418,11 @@ namespace NzbDrone.Core.Movies
                         var isScene = movie.MovieMetadata.Value.ItemType == ItemType.Scene;
                         var inChangedList = isScene ? updatedScenes.Contains(movie.ForeignId) : updatedMovies.Contains(movie.ForeignId);
                         var noChangedList = isScene ? updatedScenes.Count == 0 : updatedMovies.Count == 0;
-                        if ((noChangedList && _checkIfMovieShouldBeRefreshed.ShouldRefresh(movie.MovieMetadata)) ||
-                            inChangedList ||
-                            message.Trigger == CommandTrigger.Manual)
+                        if ((
+                            noChangedList
+                            && _checkIfMovieShouldBeRefreshed.ShouldRefresh(movie.MovieMetadata))
+                            || inChangedList
+                            || message.Trigger == CommandTrigger.Manual)
                         {
                             try
                             {
@@ -428,7 +430,7 @@ namespace NzbDrone.Core.Movies
                             }
                             catch (MovieNotFoundException)
                             {
-                                _logger.Error("Item '{0}' (ForeignId {1}) was not found, it may have been removed from The Movie Database.", movieLocal.Title, movieLocal.ForeignId);
+                                _logger.Error("Item '{0}' (ForeignId {1}) was not found, it may have been removed from the metadata source.", movieLocal.Title, movieLocal.ForeignId);
                                 continue;
                             }
                             catch (Exception e)
@@ -442,8 +444,6 @@ namespace NzbDrone.Core.Movies
                         else
                         {
                             _logger.Debug("Skipping refresh of movie: {0}", movieLocal.Title);
-                            UpdateTags(movie, false);
-                            RescanMovie(movieLocal, false, trigger);
                         }
                     }
                 }

--- a/src/NzbDrone.Core/Movies/RefreshMovieService.cs
+++ b/src/NzbDrone.Core/Movies/RefreshMovieService.cs
@@ -415,9 +415,11 @@ namespace NzbDrone.Core.Movies
                     foreach (var movie in allMovie)
                     {
                         var movieLocal = movie;
-                        if ((updatedMovies.Count == 0 && _checkIfMovieShouldBeRefreshed.ShouldRefresh(movie.MovieMetadata)) ||
-                            updatedMovies.Contains(movie.ForeignId) ||
-                            updatedScenes.Contains(movie.ForeignId) ||
+                        var isScene = movie.MovieMetadata.Value.ItemType == ItemType.Scene;
+                        var inChangedList = isScene ? updatedScenes.Contains(movie.ForeignId) : updatedMovies.Contains(movie.ForeignId);
+                        var noChangedList = isScene ? updatedScenes.Count == 0 : updatedMovies.Count == 0;
+                        if ((noChangedList && _checkIfMovieShouldBeRefreshed.ShouldRefresh(movie.MovieMetadata)) ||
+                            inChangedList ||
                             message.Trigger == CommandTrigger.Manual)
                         {
                             try


### PR DESCRIPTION
#### Database Migration

<!-- If you update database schema, the migration number must be noted here -->

NO

#### Description

Fixes two issues
- For scenes, logic would not work properly if a single movie was updated in the same interval
- If nothing was in-scope for a refresh, it was still doing a disk scan and tag refresh for every item.  This is expensive for large libraries.  Manual refresh can stil trigger these, if needed.


Logic, as of this PR:
1. If in the changed feed (and last run was within 14 days) → refresh
2. If the changed feed path isn't used (no LastStartTime, or last run was >14 days ago), fall back to ShouldRefresh(), which has its own rules:
a. Last synced > 60 days ago → refresh
b. Last synced < 12 hours ago → skip
Status is Announced or InCinemas → refresh
c. Released within the last 30 days → refresh
d. Otherwise → skip

Neither condition met → log skip

The 14 days is about how long ago the last scheduled run started, not about the item's own last-updated time. And ShouldRefresh only runs as a fallback when the changed feed isn't consulted at all.

#### Screenshot(s) (if UI related)

<details>
<!-- paste screenshots below here.-->

<!-- paste screenshots above here.  MAKE SURE THE ARE SFW -->
</details>

#### Todos

- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)

#### Issues Fixed or Closed by this PR

<!-- If multiple, put each on a separate line -->

- Fixes whisparr/whisparr#XXXX
