### PR TITLE
Fix: Restore Genres filtering

### DIFF
--- a/frontend/src/Store/Actions/movieIndexActions.js
+++ b/frontend/src/Store/Actions/movieIndexActions.js
@@ -271,21 +271,7 @@ export const defaultState = {
     {
       name: 'genres',
       label: () => translate('Genres'),
-      type: filterBuilderTypes.ARRAY,
-      optionsSelector: function(items) {
-        const genreList = items.reduce((acc, movie) => {
-          movie.genres.forEach((genre) => {
-            acc.push({
-              id: genre,
-              name: genre
-            });
-          });
-
-          return acc;
-        }, []);
-
-        return genreList.sort(sortByProp('name'));
-      }
+      type: filterBuilderTypes.STRING
     },
     {
       name: 'tags',

--- a/frontend/src/Store/Actions/sceneIndexActions.js
+++ b/frontend/src/Store/Actions/sceneIndexActions.js
@@ -186,6 +186,11 @@ export const defaultState = {
       type: filterBuilderTypes.STRING
     },
     {
+      name: 'genres',
+      label: () => translate('Genres'),
+      type: filterBuilderTypes.STRING
+    },
+    {
       name: 'status',
       label: () => translate('ReleaseStatus'),
       type: filterBuilderTypes.EXACT,

--- a/src/NzbDrone.Core.Test/Datastore/WhereBuilderPostgresFixture.cs
+++ b/src/NzbDrone.Core.Test/Datastore/WhereBuilderPostgresFixture.cs
@@ -224,5 +224,25 @@ namespace NzbDrone.Core.Test.Datastore
 
             _subject.ToString().Should().Be($"NOT (\"MovieMetadata\".\"CleanTitle\" = ANY (@Clause1_P1))");
         }
+
+        [Test]
+        public void postgres_where_json_string_list_column_contains_value()
+        {
+            var genre = "Red Hair";
+            _subject = WhereMeta(x => x.Genres.Contains(genre));
+
+            _subject.ToString().Should().Be($"(\"MovieMetadata\".\"Genres\" ILIKE '%\"' || @Clause1_P1 || '\"%')");
+            _subject.Parameters.Get<string>("Clause1_P1").Should().Be(genre);
+        }
+
+        [Test]
+        public void postgres_where_json_string_list_column_not_contains_value()
+        {
+            var genre = "Red Hair";
+            _subject = WhereMeta(x => !x.Genres.Contains(genre));
+
+            _subject.ToString().Should().Be($"NOT (\"MovieMetadata\".\"Genres\" ILIKE '%\"' || @Clause1_P1 || '\"%')");
+            _subject.Parameters.Get<string>("Clause1_P1").Should().Be(genre);
+        }
     }
 }

--- a/src/NzbDrone.Core.Test/Datastore/WhereBuilderSqliteFixture.cs
+++ b/src/NzbDrone.Core.Test/Datastore/WhereBuilderSqliteFixture.cs
@@ -228,5 +228,25 @@ namespace NzbDrone.Core.Test.Datastore
 
             _subject.ToString().Should().Be($"NOT (\"MovieMetadata\".\"CleanTitle\" IN @Clause1_P1)");
         }
+
+        [Test]
+        public void where_json_string_list_column_contains_value()
+        {
+            var genre = "Red Hair";
+            _subject = WhereMeta(x => x.Genres.Contains(genre));
+
+            _subject.ToString().Should().Be($"(\"MovieMetadata\".\"Genres\" LIKE '%\"' || @Clause1_P1 || '\"%')");
+            _subject.Parameters.Get<string>("Clause1_P1").Should().Be(genre);
+        }
+
+        [Test]
+        public void where_json_string_list_column_not_contains_value()
+        {
+            var genre = "Red Hair";
+            _subject = WhereMeta(x => !x.Genres.Contains(genre));
+
+            _subject.ToString().Should().Be($"NOT (\"MovieMetadata\".\"Genres\" LIKE '%\"' || @Clause1_P1 || '\"%')");
+            _subject.Parameters.Get<string>("Clause1_P1").Should().Be(genre);
+        }
     }
 }

--- a/src/NzbDrone.Core/Datastore/PagedFilters/StringArrayFilter.cs
+++ b/src/NzbDrone.Core/Datastore/PagedFilters/StringArrayFilter.cs
@@ -11,7 +11,7 @@ namespace NzbDrone.Core.Datastore.PagedFilters
             PagingSpec<T> pageSpec,
             JsonElement element,
             string operation,
-            Expression<Func<T, string>> propertySelector)
+            Expression<Func<T, List<string>>> propertySelector)
         {
             // Parse array of strings or a single string
             var values = new List<string>();
@@ -47,10 +47,11 @@ namespace NzbDrone.Core.Datastore.PagedFilters
             var param = propertySelector.Parameters[0];
             var property = propertySelector.Body;
 
-            // property != null
-            var notNull = Expression.NotEqual(property, Expression.Constant(null, typeof(string)));
+            // property IS NOT NULL
+            var notNull = Expression.NotEqual(property, Expression.Constant(null, property.Type));
 
-            var containsMethod = typeof(string).GetMethod("Contains", new[] { typeof(string) });
+            // List<string>.Contains(string) — WhereBuilderSqlite translates this to a LIKE '%"value"%' clause
+            var containsMethod = typeof(List<string>).GetMethod("Contains", new[] { typeof(string) });
 
             // Build OR chain: contains ANY
             Expression BuildOr()

--- a/src/NzbDrone.Core/Datastore/WhereBuilderPostgres.cs
+++ b/src/NzbDrone.Core/Datastore/WhereBuilderPostgres.cs
@@ -290,13 +290,37 @@ namespace NzbDrone.Core.Datastore
         {
             var list = expression.Object;
 
-            if (list != null && (list.Type == typeof(string)))
+            if (list != null && list.Type == typeof(string))
             {
                 ParseStringContains(expression);
                 return;
             }
 
+            // List<string> DB column stores JSON (e.g. Genres: ["Foo","Bar"]) — use ILIKE for membership test.
+            // Only applies when the object is a DB column (not resolvable as a concrete value).
+            // A resolvable List<string> is a captured filter variable and should fall through to ParseEnumerableContains.
+            if (list != null && list.Type == typeof(List<string>) && !TryGetRightValue(list, out _))
+            {
+                ParseJsonStringListContains(expression);
+                return;
+            }
+
             ParseEnumerableContains(expression);
+        }
+
+        // Generates: ("column" ILIKE '%"' || @param || '"%')
+        // Matches a quoted JSON array element, e.g. ["Foo","Bar"] contains "Foo"
+        private void ParseJsonStringListContains(MethodCallExpression body)
+        {
+            _sb.Append('(');
+
+            Visit(body.Object);
+
+            _sb.Append(" ILIKE '%\"' || ");
+
+            Visit(body.Arguments[0]);
+
+            _sb.Append(" || '\"%')");
         }
 
         private void ParseEnumerableContains(MethodCallExpression body)

--- a/src/NzbDrone.Core/Datastore/WhereBuilderSqlite.cs
+++ b/src/NzbDrone.Core/Datastore/WhereBuilderSqlite.cs
@@ -290,13 +290,37 @@ namespace NzbDrone.Core.Datastore
         {
             var list = expression.Object;
 
-            if (list != null && (list.Type == typeof(string)))
+            if (list != null && list.Type == typeof(string))
             {
                 ParseStringContains(expression);
                 return;
             }
 
+            // List<string> DB column stores JSON (e.g. Genres: ["Foo","Bar"]) — use LIKE for membership test.
+            // Only applies when the object is a DB column (not resolvable as a concrete value).
+            // A resolvable List<string> is a captured filter variable and should fall through to ParseEnumerableContains.
+            if (list != null && list.Type == typeof(List<string>) && !TryGetRightValue(list, out _))
+            {
+                ParseJsonStringListContains(expression);
+                return;
+            }
+
             ParseEnumerableContains(expression);
+        }
+
+        // Generates: ("column" LIKE '%"' || @param || '"%')
+        // Matches a quoted JSON array element, e.g. ["Foo","Bar"] contains "Foo"
+        private void ParseJsonStringListContains(MethodCallExpression body)
+        {
+            _sb.Append('(');
+
+            Visit(body.Object);
+
+            _sb.Append(" LIKE '%\"' || ");
+
+            Visit(body.Arguments[0]);
+
+            _sb.Append(" || '\"%')");
         }
 
         private void ParseEnumerableContains(MethodCallExpression body)

--- a/src/Whisparr.Api.V3/Movies/Helpers/Paging.cs
+++ b/src/Whisparr.Api.V3/Movies/Helpers/Paging.cs
@@ -33,6 +33,10 @@ namespace Whisparr.Api.V3.Movies.Helpers
                         DateFilter.Apply(pageSpec, jsonElement, op, p => p.Added);
                         break;
 
+                    case "genres":
+                        StringArrayFilter.Apply(pageSpec, jsonElement, op, p => p.MovieMetadata.Value.Genres);
+                        break;
+
                     case "itemtype":
                         EnumFilterLazy.Apply(pageSpec, jsonElement, op, p => p.MovieMetadata.Value.ItemType);
 


### PR DESCRIPTION
#### Database Migration

<!-- If you update database schema, the migration number must be noted here -->

NO

#### Description

Restores the ability to filter movies and scenes by genres.  TMDB Movie genres are not heavily populated, so YMMV.  

I left this as contains/does not contain, due to the way these are stores as a JSON array in SQL.

#### Screenshot(s) (if UI related)

<details>
<!-- paste screenshots below here.-->

<!-- paste screenshots above here.  MAKE SURE THE ARE SFW -->
</details>

#### Todos

- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)

#### Issues Fixed or Closed by this PR

<!-- If multiple, put each on a separate line -->

- Fixes whisparr/whisparr#1055
