### PR TITLE
Fix: Improve the performance when adding Performers, Studios

### DIFF
--- a/src/NzbDrone.Core/Movies/Performers/AddPerformerService.cs
+++ b/src/NzbDrone.Core/Movies/Performers/AddPerformerService.cs
@@ -68,6 +68,18 @@ namespace NzbDrone.Core.Movies.Performers
             {
                 try
                 {
+                    if (existingPerformerForeignIds.Any(f => f == m.ForeignId))
+                    {
+                        _logger.Debug("Foreign ID {0} was not added due to validation failure: Performer already exists in database", m.ForeignId);
+                        continue;
+                    }
+
+                    if (performersToAdd.Any(f => f.ForeignId == m.ForeignId))
+                    {
+                        _logger.Debug("Foreign ID {0} was not added due to validation failure: Performer already exists on list", m.ForeignId);
+                        continue;
+                    }
+
                     var performer = AddSkyhookData(m);
                     performer = SetPropertiesAndValidate(performer);
 

--- a/src/NzbDrone.Core/Movies/Performers/AddPerformerService.cs
+++ b/src/NzbDrone.Core/Movies/Performers/AddPerformerService.cs
@@ -62,13 +62,13 @@ namespace NzbDrone.Core.Movies.Performers
         {
             var added = DateTime.UtcNow;
             var performersToAdd = new List<Performer>();
-            var existingPerformerForeignIds = _performerService.AllPerformerForeignIds();
+            var existingPerformerForeignIds = new HashSet<string>(_performerService.AllPerformerForeignIds());
 
             foreach (var m in newPerformers)
             {
                 try
                 {
-                    if (existingPerformerForeignIds.Any(f => f == m.ForeignId))
+                    if (existingPerformerForeignIds.Contains(m.ForeignId))
                     {
                         _logger.Debug("Foreign ID {0} was not added due to validation failure: Performer already exists in database", m.ForeignId);
                         continue;
@@ -84,18 +84,6 @@ namespace NzbDrone.Core.Movies.Performers
                     performer = SetPropertiesAndValidate(performer);
 
                     performer.Added = added;
-
-                    if (existingPerformerForeignIds.Any(f => f == performer.ForeignId))
-                    {
-                        _logger.Debug("Foreign ID {0} was not added due to validation failure: Performer already exists in database", m.ForeignId);
-                        continue;
-                    }
-
-                    if (performersToAdd.Any(f => f.ForeignId == performer.ForeignId))
-                    {
-                        _logger.Debug("Foreign ID {0} was not added due to validation failure: Performer already exists on list", m.ForeignId);
-                        continue;
-                    }
 
                     _logger.Info("Adding Performer {0}", performer.Name);
 

--- a/src/NzbDrone.Core/Movies/Performers/PerformerService.cs
+++ b/src/NzbDrone.Core/Movies/Performers/PerformerService.cs
@@ -67,6 +67,11 @@ namespace NzbDrone.Core.Movies.Performers
 
         public List<Performer> AddPerformers(List<Performer> performers)
         {
+            if (performers.Count == 0)
+            {
+                return performers;
+            }
+
             var allPerformers = _performerRepo.All();
 
             performers = performers.Where(p => p.ForeignId.IsNotNullOrWhiteSpace()).ToList();

--- a/src/NzbDrone.Core/Movies/Performers/PerformerService.cs
+++ b/src/NzbDrone.Core/Movies/Performers/PerformerService.cs
@@ -67,7 +67,7 @@ namespace NzbDrone.Core.Movies.Performers
 
         public List<Performer> AddPerformers(List<Performer> performers)
         {
-            if (performers.Count == 0)
+            if (!performers.Any())
             {
                 return performers;
             }

--- a/src/NzbDrone.Core/Movies/Performers/PerformerService.cs
+++ b/src/NzbDrone.Core/Movies/Performers/PerformerService.cs
@@ -72,12 +72,12 @@ namespace NzbDrone.Core.Movies.Performers
                 return performers;
             }
 
-            var allPerformers = _performerRepo.All();
+            var allPerformerForeignIds = new HashSet<string>(_performerRepo.AllPerformerForeignIds());
 
             performers = performers.Where(p => p.ForeignId.IsNotNullOrWhiteSpace()).ToList();
 
-            var existing = allPerformers.Where(x => performers.Any(a => a.ForeignId == x.ForeignId));
-            var performersToAdd = performers.Where(x => !allPerformers.Any(a => a.ForeignId == x.ForeignId)).ToList();
+            var existing = performers.Where(p => allPerformerForeignIds.Contains(p.ForeignId)).ToList();
+            var performersToAdd = performers.Where(p => !allPerformerForeignIds.Contains(p.ForeignId)).ToList();
 
             _performerRepo.InsertMany(performersToAdd);
 

--- a/src/NzbDrone.Core/Movies/Studios/AddStudioService.cs
+++ b/src/NzbDrone.Core/Movies/Studios/AddStudioService.cs
@@ -77,6 +77,18 @@ namespace NzbDrone.Core.Movies.Studios
 
                 try
                 {
+                    if (existingStudioForeignIds.Any(f => f == m.ForeignId))
+                    {
+                        _logger.Debug("Foreign ID {0} was not added due to validation failure: Studio already exists in database", m.ForeignId);
+                        continue;
+                    }
+
+                    if (studiosToAdd.Any(f => f.ForeignId == m.ForeignId))
+                    {
+                        _logger.Debug("Foreign ID {0} was not added due to validation failure: Studio already exists on list", m.ForeignId);
+                        continue;
+                    }
+
                     var studio = AddSkyhookData(m);
                     studio = SetPropertiesAndValidate(studio);
 

--- a/src/NzbDrone.Core/Movies/Studios/AddStudioService.cs
+++ b/src/NzbDrone.Core/Movies/Studios/AddStudioService.cs
@@ -69,7 +69,7 @@ namespace NzbDrone.Core.Movies.Studios
         {
             var added = DateTime.UtcNow;
             var studiosToAdd = new List<Studio>();
-            var existingStudioForeignIds = _studioService.AllStudioForeignIds();
+            var existingStudioForeignIds = new HashSet<string>(_studioService.AllStudioForeignIds());
 
             foreach (var m in newStudios)
             {
@@ -77,7 +77,7 @@ namespace NzbDrone.Core.Movies.Studios
 
                 try
                 {
-                    if (existingStudioForeignIds.Any(f => f == m.ForeignId))
+                    if (existingStudioForeignIds.Contains(m.ForeignId))
                     {
                         _logger.Debug("Foreign ID {0} was not added due to validation failure: Studio already exists in database", m.ForeignId);
                         continue;
@@ -93,18 +93,6 @@ namespace NzbDrone.Core.Movies.Studios
                     studio = SetPropertiesAndValidate(studio);
 
                     studio.Added = added;
-
-                    if (existingStudioForeignIds.Any(f => f == studio.ForeignId))
-                    {
-                        _logger.Debug("Foreign ID {0} was not added due to validation failure: Studio already exists in database", m.ForeignId);
-                        continue;
-                    }
-
-                    if (studiosToAdd.Any(f => f.ForeignId == studio.ForeignId))
-                    {
-                        _logger.Debug("Foreign ID {0} was not added due to validation failure: Studio already exists on list", m.ForeignId);
-                        continue;
-                    }
 
                     studiosToAdd.Add(studio);
                 }


### PR DESCRIPTION
#### Database Migration

NO

#### Description

Alter the Adding of new performers, so it is faster when no performers need to be added.

Check if the performer/studio exists before getting the data from skyhook.

The changes are to stop any processes that may take a long time 100ms, eg large database calls, Skyhook calls, when they are not required. 

#### Screenshot(s) (if UI related)

<details>
<!-- paste screenshots below here.-->

<!-- paste screenshots above here.  MAKE SURE THE ARE SFW -->
</details>

#### Todos

- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)

#### Issues Fixed or Closed by this PR

<!-- If multiple, put each on a separate line -->

- Fixes whisparr/whisparr#XXXX
