### PR TITLE
New: Refresh the Movies by oldest to newest info sync

### DIFF
--- a/src/NzbDrone.Core/Movies/MovieRepository.cs
+++ b/src/NzbDrone.Core/Movies/MovieRepository.cs
@@ -36,6 +36,7 @@ namespace NzbDrone.Core.Movies
         Movie FindByPath(string path);
         Dictionary<int, string> AllMoviePaths();
         List<int> AllMovieIds();
+        List<int> AllMovieIdsOrderByLastInfoSync();
         List<int> AllMovieTmdbIds();
         List<string> AllMovieTpdbIds();
         List<string> AllMovieStashIds();
@@ -428,6 +429,14 @@ namespace NzbDrone.Core.Movies
             using (var conn = _database.OpenConnection())
             {
                 return conn.Query<int>("SELECT \"Id\" FROM \"Movies\" ").ToList();
+            }
+        }
+
+        public List<int> AllMovieIdsOrderByLastInfoSync()
+        {
+            using (var conn = _database.OpenConnection())
+            {
+                return conn.Query<int>("SELECT \"Movies\".\"Id\" FROM \"Movies\" JOIN \"MovieMetadata\" ON \"Movies\".\"MovieMetadataId\" = \"MovieMetadata\".\"Id\" ORDER BY \"MovieMetadata\".\"LastInfoSync\" ASC").ToList();
             }
         }
 

--- a/src/NzbDrone.Core/Movies/MovieService.cs
+++ b/src/NzbDrone.Core/Movies/MovieService.cs
@@ -46,6 +46,7 @@ namespace NzbDrone.Core.Movies
         Movie FindByPath(string path);
         Dictionary<int, string> AllMoviePaths();
         List<int> AllMovieIds();
+        List<int> AllMovieIdsOrderByLastInfoSync();
         List<int> AllMovieTmdbIds();
         List<string> AllMovieTpdbIds();
         List<string> AllMovieStashIds();
@@ -320,6 +321,13 @@ namespace NzbDrone.Core.Movies
         public List<int> AllMovieIds()
         {
             return _movieRepository.AllMovieIds();
+        }
+
+        /// <summary> Get a list of all movie IDs in the repository. Order by yLastInfoSyn</summary>
+        /// <returns>A list of all movie IDs.</returns>
+        public List<int> AllMovieIdsOrderByLastInfoSync()
+        {
+            return _movieRepository.AllMovieIdsOrderByLastInfoSync();
         }
 
         /// <summary> Get a list of all TMDB IDs for movies in the repository. </summary>

--- a/src/NzbDrone.Core/Movies/RefreshMovieService.cs
+++ b/src/NzbDrone.Core/Movies/RefreshMovieService.cs
@@ -407,44 +407,40 @@ namespace NzbDrone.Core.Movies
                     updatedScenes = _movieInfo.GetChangedScenes(message.LastStartTime.Value);
                 }
 
-                var movieLists = _movieService.AllMovieIds().Chunk(1000);
-                foreach (var movieList in movieLists)
+                var allMovie = _movieService.GetAllMovies().OrderBy(m => m.MovieMetadata.Value.LastInfoSync).ToList();
+
+                foreach (var movie in allMovie)
                 {
-                    var allMovie = _movieService.GetMovies(movieList).ToList();
-
-                    foreach (var movie in allMovie)
+                    var movieLocal = movie;
+                    var isScene = movie.MovieMetadata.Value.ItemType == ItemType.Scene;
+                    var inChangedList = isScene ? updatedScenes.Contains(movie.ForeignId) : updatedMovies.Contains(movie.ForeignId);
+                    var noChangedList = isScene ? updatedScenes.Count == 0 : updatedMovies.Count == 0;
+                    if ((
+                        noChangedList
+                        && _checkIfMovieShouldBeRefreshed.ShouldRefresh(movie.MovieMetadata))
+                        || inChangedList
+                        || message.Trigger == CommandTrigger.Manual)
                     {
-                        var movieLocal = movie;
-                        var isScene = movie.MovieMetadata.Value.ItemType == ItemType.Scene;
-                        var inChangedList = isScene ? updatedScenes.Contains(movie.ForeignId) : updatedMovies.Contains(movie.ForeignId);
-                        var noChangedList = isScene ? updatedScenes.Count == 0 : updatedMovies.Count == 0;
-                        if ((
-                            noChangedList
-                            && _checkIfMovieShouldBeRefreshed.ShouldRefresh(movie.MovieMetadata))
-                            || inChangedList
-                            || message.Trigger == CommandTrigger.Manual)
+                        try
                         {
-                            try
-                            {
-                                movieLocal = RefreshMovieInfo(movieLocal.Id);
-                            }
-                            catch (MovieNotFoundException)
-                            {
-                                _logger.Error("Item '{0}' (ForeignId {1}) was not found, it may have been removed from the metadata source.", movieLocal.Title, movieLocal.ForeignId);
-                                continue;
-                            }
-                            catch (Exception e)
-                            {
-                                _logger.Error(e, "Couldn't refresh info for {0}", movieLocal);
-                            }
+                            movieLocal = RefreshMovieInfo(movieLocal.Id);
+                        }
+                        catch (MovieNotFoundException)
+                        {
+                            _logger.Error("Item '{0}' (ForeignId {1}) was not found, it may have been removed from the metadata source.", movieLocal.Title, movieLocal.ForeignId);
+                            continue;
+                        }
+                        catch (Exception e)
+                        {
+                            _logger.Error(e, "Couldn't refresh info for {0}", movieLocal);
+                        }
 
-                            UpdateTags(movie, false);
-                            RescanMovie(movieLocal, false, trigger);
-                        }
-                        else
-                        {
-                            _logger.Debug("Skipping refresh of movie: {0}", movieLocal.Title);
-                        }
+                        UpdateTags(movie, false);
+                        RescanMovie(movieLocal, false, trigger);
+                    }
+                    else
+                    {
+                        _logger.Debug("Skipping refresh of movie: {0}", movieLocal.Title);
                     }
                 }
             }

--- a/src/NzbDrone.Core/Movies/RefreshMovieService.cs
+++ b/src/NzbDrone.Core/Movies/RefreshMovieService.cs
@@ -407,40 +407,44 @@ namespace NzbDrone.Core.Movies
                     updatedScenes = _movieInfo.GetChangedScenes(message.LastStartTime.Value);
                 }
 
-                var allMovie = _movieService.GetAllMovies().OrderBy(m => m.MovieMetadata.Value.LastInfoSync).ToList();
-
-                foreach (var movie in allMovie)
+                var movieLists = _movieService.AllMovieIdsOrderByLastInfoSync().Chunk(1000);
+                foreach (var movieList in movieLists)
                 {
-                    var movieLocal = movie;
-                    var isScene = movie.MovieMetadata.Value.ItemType == ItemType.Scene;
-                    var inChangedList = isScene ? updatedScenes.Contains(movie.ForeignId) : updatedMovies.Contains(movie.ForeignId);
-                    var noChangedList = isScene ? updatedScenes.Count == 0 : updatedMovies.Count == 0;
-                    if ((
-                        noChangedList
-                        && _checkIfMovieShouldBeRefreshed.ShouldRefresh(movie.MovieMetadata))
-                        || inChangedList
-                        || message.Trigger == CommandTrigger.Manual)
-                    {
-                        try
-                        {
-                            movieLocal = RefreshMovieInfo(movieLocal.Id);
-                        }
-                        catch (MovieNotFoundException)
-                        {
-                            _logger.Error("Item '{0}' (ForeignId {1}) was not found, it may have been removed from the metadata source.", movieLocal.Title, movieLocal.ForeignId);
-                            continue;
-                        }
-                        catch (Exception e)
-                        {
-                            _logger.Error(e, "Couldn't refresh info for {0}", movieLocal);
-                        }
+                    var allMovie = _movieService.GetMovies(movieList).ToList();
 
-                        UpdateTags(movie, false);
-                        RescanMovie(movieLocal, false, trigger);
-                    }
-                    else
+                    foreach (var movie in allMovie)
                     {
-                        _logger.Debug("Skipping refresh of movie: {0}", movieLocal.Title);
+                        var movieLocal = movie;
+                        var isScene = movie.MovieMetadata.Value.ItemType == ItemType.Scene;
+                        var inChangedList = isScene ? updatedScenes.Contains(movie.ForeignId) : updatedMovies.Contains(movie.ForeignId);
+                        var noChangedList = isScene ? updatedScenes.Count == 0 : updatedMovies.Count == 0;
+                        if ((
+                            noChangedList
+                            && _checkIfMovieShouldBeRefreshed.ShouldRefresh(movie.MovieMetadata))
+                            || inChangedList
+                            || message.Trigger == CommandTrigger.Manual)
+                        {
+                            try
+                            {
+                                movieLocal = RefreshMovieInfo(movieLocal.Id);
+                            }
+                            catch (MovieNotFoundException)
+                            {
+                                _logger.Error("Item '{0}' (ForeignId {1}) was not found, it may have been removed from the metadata source.", movieLocal.Title, movieLocal.ForeignId);
+                                continue;
+                            }
+                            catch (Exception e)
+                            {
+                                _logger.Error(e, "Couldn't refresh info for {0}", movieLocal);
+                            }
+
+                            UpdateTags(movie, false);
+                            RescanMovie(movieLocal, false, trigger);
+                        }
+                        else
+                        {
+                            _logger.Debug("Skipping refresh of movie: {0}", movieLocal.Title);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
#### Database Migration

NO

#### Description

Alter Refresh movie so that it will start where it left off like Studio and Performers.

The manual refresh will start at the first id every time meaning that the same items are refreshed.

Change to read by LastInfoSync

#### Screenshot(s) (if UI related)

<details>
<!-- paste screenshots below here.-->

<!-- paste screenshots above here.  MAKE SURE THE ARE SFW -->
</details>

#### Todos

- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)

#### Issues Fixed or Closed by this PR

<!-- If multiple, put each on a separate line -->

- Fixes whisparr/whisparr#XXXX
