### PR TITLE
New: Refresh performance optimization on performers, studios

### DIFF
--- a/src/NzbDrone.Core/Movies/Performers/IPerformerRepository.cs
+++ b/src/NzbDrone.Core/Movies/Performers/IPerformerRepository.cs
@@ -9,5 +9,6 @@ namespace NzbDrone.Core.Movies.Performers
         List<Performer> FindByForeignIds(List<string> foreignIds);
         List<Performer> SearchPerformers(string cleanName, string foreignId);
         List<string> AllPerformerForeignIds();
+        List<int> AllPerformerIdsByLastInfoSync();
     }
 }

--- a/src/NzbDrone.Core/Movies/Performers/PerformerRepository.cs
+++ b/src/NzbDrone.Core/Movies/Performers/PerformerRepository.cs
@@ -36,6 +36,14 @@ namespace NzbDrone.Core.Movies.Performers
             }
         }
 
+        public List<int> AllPerformerIdsByLastInfoSync()
+        {
+            using (var conn = _database.OpenConnection())
+            {
+                return conn.Query<int>("SELECT \"Id\" FROM \"Performers\" ORDER BY \"LastInfoSync\"").ToList();
+            }
+        }
+
         public override PagingSpec<Performer> GetPaged(PagingSpec<Performer> pagingSpec)
         {
             return base.GetPaged(pagingSpec);

--- a/src/NzbDrone.Core/Movies/Performers/PerformerService.cs
+++ b/src/NzbDrone.Core/Movies/Performers/PerformerService.cs
@@ -57,13 +57,13 @@ namespace NzbDrone.Core.Movies.Performers
             _cacheName = "Whisparr.Api.V3.Performers.PerformerResource_performerResources";
         }
 
-        public Performer AddPerformer(Performer newPerformer)
+        public Performer AddPerformer(Performer performer)
         {
-            var performer = _performerRepo.Insert(newPerformer);
+            var newPerformer = _performerRepo.Insert(performer);
 
-            _eventAggregator.PublishEvent(new PerformerAddedEvent(GetById(performer.Id)));
+            _eventAggregator.PublishEvent(new PerformerAddedEvent(newPerformer));
 
-            return performer;
+            return newPerformer;
         }
 
         public List<Performer> AddPerformers(List<Performer> performers)

--- a/src/NzbDrone.Core/Movies/Performers/PerformerService.cs
+++ b/src/NzbDrone.Core/Movies/Performers/PerformerService.cs
@@ -22,6 +22,7 @@ namespace NzbDrone.Core.Movies.Performers
         List<Performer> SearchPerformers(string query);
         List<Performer> GetAllPerformers();
         List<string> AllPerformerForeignIds();
+        List<int> AllPerformerIdsByLastInfoSync();
         Performer Update(Performer performer);
         List<Performer> Update(List<Performer> performers);
         void RemovePerformer(Performer performer);
@@ -159,6 +160,11 @@ namespace NzbDrone.Core.Movies.Performers
         public List<string> AllPerformerForeignIds()
         {
             return _performerRepo.AllPerformerForeignIds();
+        }
+
+        public List<int> AllPerformerIdsByLastInfoSync()
+        {
+            return _performerRepo.AllPerformerIdsByLastInfoSync();
         }
 
         public PagingSpec<Performer> Paged(PagingSpec<Performer> pagingSpec)

--- a/src/NzbDrone.Core/Movies/Performers/RefreshPerformerService.cs
+++ b/src/NzbDrone.Core/Movies/Performers/RefreshPerformerService.cs
@@ -69,13 +69,13 @@ namespace NzbDrone.Core.Movies.Performers
             {
                 performerInfo = _movieInfo.GetPerformerInfo(performer.ForeignId);
             }
-            catch (MovieNotFoundException)
+            catch (MovieNotFoundException ex)
             {
                 if (performer.Status != PerformerStatus.Deleted)
                 {
                     performer.Status = PerformerStatus.Deleted;
                     _performerService.Update(performer);
-                    _logger.Debug("Performer not found on StashDB for {0}", performer);
+                    _logger.Debug(ex, "Performer not found on StashDB for {0}", performer);
                     _eventAggregator.PublishEvent(new PerformerUpdatedEvent(performer));
                 }
 
@@ -338,8 +338,7 @@ namespace NzbDrone.Core.Movies.Performers
             }
             else
             {
-                var allPerformers = _performerService.GetAllPerformers().OrderBy(c => c.LastInfoSync).ToList();
-
+                var performerIdChunks = _performerService.AllPerformerIdsByLastInfoSync().Chunk(1000);
                 var updatePerformers = new HashSet<string>();
 
                 if (message.LastStartTime.HasValue && message.LastStartTime.Value.AddDays(14) > DateTime.UtcNow)
@@ -347,24 +346,25 @@ namespace NzbDrone.Core.Movies.Performers
                     updatePerformers = _movieInfo.GetChangedPerformers(message.LastStartTime.Value);
                 }
 
-                foreach (var performer in allPerformers)
+                foreach (var chunk in performerIdChunks)
                 {
-                    var performerLocal = performer;
-
-                    try
+                    foreach (var performer in _performerService.GetPerformers(chunk))
                     {
-                        if ((updatePerformers.Count == 0 && performer.LastInfoSync < DateTime.UtcNow.AddDays(-14)) ||
-                            updatePerformers.Contains(performer.ForeignId) ||
-                            message.Trigger == CommandTrigger.Manual)
+                        try
                         {
-                            performerLocal = RefreshPerformerInfo(performerLocal.Id);
-                        }
+                            if ((updatePerformers.Count == 0 && performer.LastInfoSync < DateTime.UtcNow.AddDays(-14)) ||
+                                updatePerformers.Contains(performer.ForeignId) ||
+                                message.Trigger == CommandTrigger.Manual)
+                            {
+                                RefreshPerformerInfo(performer.Id);
+                            }
 
-                        SyncPerformerItems(performer);
-                    }
-                    catch (MovieNotFoundException)
-                    {
-                        _logger.Error("Performer '{0}' (StashDb {1}) was not found, it may have been removed from The Movie Database.", performer.Name, performer.ForeignId);
+                            SyncPerformerItems(performer);
+                        }
+                        catch (MovieNotFoundException ex)
+                        {
+                            _logger.Error(ex, "Performer '{0}' (StashDb {1}) was not found, it may have been removed from The Movie Database.", performer.Name, performer.ForeignId);
+                        }
                     }
                 }
             }

--- a/src/NzbDrone.Core/Movies/Studios/RefreshStudioService.cs
+++ b/src/NzbDrone.Core/Movies/Studios/RefreshStudioService.cs
@@ -296,7 +296,7 @@ namespace NzbDrone.Core.Movies.Studios
             }
             else
             {
-                var allStudios = _studioService.GetAllStudios().OrderBy(c => c.LastInfoSync).ToList();
+                var studioIdChunks = _studioService.AllStudioIdsByLastInfoSync().Chunk(1000);
 
                 var updatedStudios = new HashSet<string>();
 
@@ -305,24 +305,25 @@ namespace NzbDrone.Core.Movies.Studios
                     updatedStudios = _movieInfo.GetChangedStudios(message.LastStartTime.Value);
                 }
 
-                foreach (var studio in allStudios)
+                foreach (var chunk in studioIdChunks)
                 {
-                    var studioLocal = studio;
-
-                    try
+                    foreach (var studio in _studioService.GetStudios(chunk))
                     {
-                        if ((updatedStudios.Count == 0 && studio.LastInfoSync < DateTime.UtcNow.AddDays(-14)) ||
-                            updatedStudios.Contains(studio.ForeignId) ||
-                            message.Trigger == CommandTrigger.Manual)
+                        try
                         {
-                            studioLocal = RefreshStudioInfo(studioLocal.Id);
-                        }
+                            if ((updatedStudios.Count == 0 && studio.LastInfoSync < DateTime.UtcNow.AddDays(-14)) ||
+                                updatedStudios.Contains(studio.ForeignId) ||
+                                message.Trigger == CommandTrigger.Manual)
+                            {
+                                RefreshStudioInfo(studio.Id);
+                            }
 
-                        SyncStudioItems(studio);
-                    }
-                    catch (MovieNotFoundException)
-                    {
-                        _logger.Error("Studio '{0}' (StashDb {1}) was not found, it may have been removed from The Movie Database.", studio.Title, studio.ForeignId);
+                            SyncStudioItems(studio);
+                        }
+                        catch (MovieNotFoundException)
+                        {
+                            _logger.Error("Studio '{0}' (StashDb {1}) was not found, it may have been removed from The Movie Database.", studio.Title, studio.ForeignId);
+                        }
                     }
                 }
             }

--- a/src/NzbDrone.Core/Movies/Studios/StudioRepository.cs
+++ b/src/NzbDrone.Core/Movies/Studios/StudioRepository.cs
@@ -15,6 +15,7 @@ namespace NzbDrone.Core.Movies.Studios
         List<Studio> SearchStudios(string cleanTitle, string foreignId);
         List<Studio> FindAllByTitle(string title);
         List<string> AllStudioForeignIds();
+        List<int> AllStudioIdsByLastInfoSync();
     }
 
     public class StudioRepository : BasicRepository<Studio>, IStudioRepository
@@ -54,6 +55,14 @@ namespace NzbDrone.Core.Movies.Studios
             using (var conn = _database.OpenConnection())
             {
                 return conn.Query<string>("SELECT \"ForeignId\" FROM \"Studios\"").ToList();
+            }
+        }
+
+        public List<int> AllStudioIdsByLastInfoSync()
+        {
+            using (var conn = _database.OpenConnection())
+            {
+                return conn.Query<int>("SELECT \"Id\" FROM \"Studios\" ORDER BY \"LastInfoSync\" ASC").ToList();
             }
         }
 

--- a/src/NzbDrone.Core/Movies/Studios/StudioService.cs
+++ b/src/NzbDrone.Core/Movies/Studios/StudioService.cs
@@ -20,6 +20,7 @@ namespace NzbDrone.Core.Movies.Studios
         List<Studio> SearchStudios(string query);
         List<Studio> GetAllStudios();
         List<string> AllStudioForeignIds();
+        List<int> AllStudioIdsByLastInfoSync();
         Studio Update(Studio performer);
         List<Studio> Update(List<Studio> studios);
         Studio FindByTitle(string title);
@@ -158,6 +159,11 @@ namespace NzbDrone.Core.Movies.Studios
         public List<string> AllStudioForeignIds()
         {
             return _studioRepo.AllStudioForeignIds();
+        }
+
+        public List<int> AllStudioIdsByLastInfoSync()
+        {
+            return _studioRepo.AllStudioIdsByLastInfoSync();
         }
 
         public PagingSpec<Studio> Paged(PagingSpec<Studio> pagingSpec)

--- a/src/NzbDrone.Core/Movies/Studios/StudioService.cs
+++ b/src/NzbDrone.Core/Movies/Studios/StudioService.cs
@@ -54,13 +54,13 @@ namespace NzbDrone.Core.Movies.Studios
             _cacheName = "Whisparr.Api.V3.Studios.StudioResource_studioResources";
         }
 
-        public Studio AddStudio(Studio newStudio)
+        public Studio AddStudio(Studio studio)
         {
-            var studio = _studioRepo.Insert(newStudio);
+            var newStudio = _studioRepo.Insert(studio);
 
-            _eventAggregator.PublishEvent(new StudioAddedEvent(GetById(studio.Id)));
+            _eventAggregator.PublishEvent(new StudioAddedEvent(newStudio));
 
-            return studio;
+            return newStudio;
         }
 
         public List<Studio> AddStudios(List<Studio> studios)


### PR DESCRIPTION
#### Database Migration

<!-- If you update database schema, the migration number must be noted here -->

NO

#### Description

Changes the refresh loop to do so by `LastInfoSync` so older items are refreshed earlier. Also fixed a bug in each service class where it would insert the record and then immediately query for it, which wasn't needed since the insert returns the record.

This is mostly a memory optimization, so we're only pulling 1000 full objects at a time, not the whole table.  I don't foresee any huge gains on these two tables, but it will make them consistent with how this works on the movie table's refresh task.

#### Screenshot(s) (if UI related)

<details>
<!-- paste screenshots below here.-->

<!-- paste screenshots above here.  MAKE SURE THE ARE SFW -->
</details>

#### Todos

- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)

#### Issues Fixed or Closed by this PR

<!-- If multiple, put each on a separate line -->

- Refs #212 
