### PR TITLE
Fix: Movie file deletion behavior

### DIFF
--- a/frontend/src/InteractiveImport/Interactive/InteractiveImportModalContent.tsx
+++ b/frontend/src/InteractiveImport/Interactive/InteractiveImportModalContent.tsx
@@ -22,7 +22,6 @@ import ModalHeader from 'Components/Modal/ModalHeader';
 import Column from 'Components/Table/Column';
 import Table from 'Components/Table/Table';
 import TableBody from 'Components/Table/TableBody';
-import usePrevious from 'Helpers/Hooks/usePrevious';
 import useSelectState from 'Helpers/Hooks/useSelectState';
 import { align, icons, kinds } from 'Helpers/Props';
 import { BOTH } from 'Helpers/Props/scrollDirections';
@@ -38,6 +37,7 @@ import SelectReleaseGroupModal from 'InteractiveImport/ReleaseGroup/SelectReleas
 import Language from 'Language/Language';
 import Movie from 'Movie/Movie';
 import { MovieFile } from 'MovieFile/MovieFile';
+import { useDeleteMovieFiles } from 'MovieFile/useMovieFile';
 import { QualityModel } from 'Quality/Quality';
 import { executeCommand } from 'Store/Actions/commandActions';
 import {
@@ -48,10 +48,7 @@ import {
   setInteractiveImportSort,
   updateInteractiveImportItems,
 } from 'Store/Actions/interactiveImportActions';
-import {
-  deleteMovieFiles,
-  updateMovieFiles,
-} from 'Store/Actions/movieFileActions';
+import { updateMovieFiles } from 'Store/Actions/movieFileActions';
 import createClientSideCollectionSelector from 'Store/Selectors/createClientSideCollectionSelector';
 import { SortCallback } from 'typings/callbacks';
 import { CheckInputChanged } from 'typings/inputs';
@@ -173,17 +170,6 @@ function isSameMovieFile(
   return true;
 }
 
-const movieFilesInfoSelector = createSelector(
-  (state: AppState) => state.movieFiles.isDeleting,
-  (state: AppState) => state.movieFiles.deleteError,
-  (isDeleting, deleteError) => {
-    return {
-      isDeleting,
-      deleteError,
-    };
-  }
-);
-
 const importModeSelector = createSelector(
   (state: AppState) => state.interactiveImport.importMode,
   (importMode) => {
@@ -242,8 +228,9 @@ function InteractiveImportModalContent(
     createClientSideCollectionSelector('interactiveImport')
   );
 
-  const { isDeleting, deleteError } = useSelector(movieFilesInfoSelector);
   const importMode = useSelector(importModeSelector);
+  const { mutate: deleteMovieFilesMutate, isPending: isDeleting } =
+    useDeleteMovieFiles();
 
   const [invalidRowsSelected, setInvalidRowsSelected] = useState<number[]>([]);
   const [withoutMovieFileIdRowsSelected, setWithoutMovieFileIdRowsSelected] =
@@ -258,7 +245,6 @@ function InteractiveImportModalContent(
     useState<string | null>(null);
   const [selectState, setSelectState] = useSelectState();
   const { allSelected, allUnselected, selectedState } = selectState;
-  const previousIsDeleting = usePrevious(isDeleting);
   const dispatch = useDispatch();
 
   const columns: Column[] = useMemo(() => {
@@ -357,12 +343,6 @@ function InteractiveImportModalContent(
     []
   );
 
-  useEffect(() => {
-    if (!isDeleting && previousIsDeleting && !deleteError) {
-      onModalClose();
-    }
-  }, [previousIsDeleting, isDeleting, deleteError, onModalClose]);
-
   const onSelectAllChange = useCallback(
     ({ value }: CheckInputChanged) => {
       setSelectState({ type: value ? 'selectAll' : 'unselectAll', items });
@@ -420,8 +400,8 @@ function InteractiveImportModalContent(
       return acc;
     }, []);
 
-    dispatch(deleteMovieFiles({ movieFileIds }));
-  }, [items, selectedIds, setIsConfirmDeleteModalOpen, dispatch]);
+    deleteMovieFilesMutate({ movieFileIds }, { onSuccess: onModalClose });
+  }, [items, selectedIds, deleteMovieFilesMutate, onModalClose]);
 
   const onConfirmDeleteModalClose = useCallback(() => {
     setIsConfirmDeleteModalOpen(false);

--- a/frontend/src/Movie/Details/MovieDetails.tsx
+++ b/frontend/src/Movie/Details/MovieDetails.tsx
@@ -527,6 +527,7 @@ function MovieDetails(props: Readonly<Partial<Props>>) {
         <InteractiveImportModal
           isOpen={isInteractiveImportModalOpen}
           movie={movie}
+          movieId={movieId}
           title={title}
           folder={path}
           initialSortKey="relativePath"

--- a/frontend/src/MovieFile/Editor/MovieFileEditorRow.tsx
+++ b/frontend/src/MovieFile/Editor/MovieFileEditorRow.tsx
@@ -76,6 +76,10 @@ function MovieFileEditorRow(props: MovieFileEditorRowProps) {
   const [isFileEditModalOpen, setIsFileEditModalOpen] =
     useState<boolean>(false);
 
+  const handleDeletePress = useCallback(() => {
+    setIsConfirmDeleteModalOpen(true);
+  }, []);
+
   const handleConfirmDelete = useCallback(() => {
     setIsConfirmDeleteModalOpen(false);
     onDeletePress(id);
@@ -229,7 +233,6 @@ function MovieFileEditorRow(props: MovieFileEditorRowProps) {
         }
 
         if (name === 'indexerFlags') {
-          console.log('[MovieFileEditorRow] indexerFlags:', indexerFlags);
           return (
             <TableRowCell key={name} className={styles.indexerFlags}>
               {indexerFlags ? (
@@ -278,7 +281,7 @@ function MovieFileEditorRow(props: MovieFileEditorRowProps) {
               <IconButton
                 title={translate('DeleteFile')}
                 name={icons.REMOVE}
-                onPress={handleConfirmDelete}
+                onPress={handleDeletePress}
               />
             </TableRowCell>
           );

--- a/frontend/src/MovieFile/Editor/MovieFileEditorRow.tsx
+++ b/frontend/src/MovieFile/Editor/MovieFileEditorRow.tsx
@@ -280,7 +280,7 @@ function MovieFileEditorRow(props: MovieFileEditorRowProps) {
               />
               <IconButton
                 title={translate('DeleteFile')}
-                name={icons.REMOVE}
+                name={icons.DELETE}
                 onPress={handleDeletePress}
               />
             </TableRowCell>

--- a/frontend/src/MovieFile/useMovieFile.ts
+++ b/frontend/src/MovieFile/useMovieFile.ts
@@ -1,3 +1,5 @@
+import { useQueryClient } from '@tanstack/react-query';
+import useApiMutation from 'Helpers/Hooks/useApiMutation';
 import useApiQuery from 'Helpers/Hooks/useApiQuery';
 import { UnmappedFile } from '../UnmappedFiles/UnmappedFilesTable';
 import { MovieFile } from './MovieFile';
@@ -37,6 +39,19 @@ export function useMovieFilesByIds(movieFileIds: number[] | undefined) {
     path: `${PATH}/list`,
     queryOptions: { enabled: !!movieFileIds && movieFileIds.length > 0 },
     queryParams: { ids: idsParam },
+  });
+}
+
+export function useDeleteMovieFiles() {
+  const queryClient = useQueryClient();
+  return useApiMutation<void, { movieFileIds: number[] }>({
+    path: `${PATH}/bulk`,
+    method: 'DELETE',
+    mutationOptions: {
+      onSuccess: () => {
+        queryClient.invalidateQueries({ queryKey: [PATH] });
+      },
+    },
   });
 }
 


### PR DESCRIPTION
#### Database Migration

<!-- If you update database schema, the migration number must be noted here -->

NO

#### Description

- Fix: Unable to delete selected movie via Manage Files modal
- Fix: Delete "x" button in movie files table has no confirmation modal
- Chore: Change moviefile delete icon to trash can to match other "delete" icons in app.

#### Screenshot(s) (if UI related)

<details>
<!-- paste screenshots below here.-->

<!-- paste screenshots above here.  MAKE SURE THE ARE SFW -->
</details>

#### Todos

- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)

#### Issues Fixed or Closed by this PR

<!-- If multiple, put each on a separate line -->

- Fixes whisparr/whisparr#1060
