### PR TITLE
Chore: Use Number static methods

### DIFF
--- a/frontend/src/Activity/History/Details/HistoryDetails.tsx
+++ b/frontend/src/Activity/History/Details/HistoryDetails.tsx
@@ -104,7 +104,7 @@ function HistoryDetails(props: HistoryDetailsProps) {
         {customFormatScore && customFormatScore !== '0' ? (
           <DescriptionListItem
             title={translate('CustomFormatScore')}
-            data={formatCustomFormatScore(parseInt(customFormatScore))}
+            data={formatCustomFormatScore(Number.parseInt(customFormatScore))}
           />
         ) : null}
 
@@ -230,7 +230,7 @@ function HistoryDetails(props: HistoryDetailsProps) {
         {customFormatScore && customFormatScore !== '0' ? (
           <DescriptionListItem
             title={translate('CustomFormatScore')}
-            data={formatCustomFormatScore(parseInt(customFormatScore))}
+            data={formatCustomFormatScore(Number.parseInt(customFormatScore))}
           />
         ) : null}
 
@@ -301,7 +301,7 @@ function HistoryDetails(props: HistoryDetailsProps) {
         {customFormatScore && customFormatScore !== '0' ? (
           <DescriptionListItem
             title={translate('CustomFormatScore')}
-            data={formatCustomFormatScore(parseInt(customFormatScore))}
+            data={formatCustomFormatScore(Number.parseInt(customFormatScore))}
           />
         ) : null}
 

--- a/frontend/src/Collection/Collection.js
+++ b/frontend/src/Collection/Collection.js
@@ -132,7 +132,7 @@ class Collection extends Component {
       (acc, item) => {
         let char = item.sortTitle.charAt(0);
 
-        if (!Number.isNaN(char)) {
+        if (!Number.isNaN(Number(char))) {
           char = '#';
         }
 

--- a/frontend/src/Collection/Overview/CollectionOverview.js
+++ b/frontend/src/Collection/Overview/CollectionOverview.js
@@ -23,12 +23,12 @@ import styles from './CollectionOverview.css';
 import 'swiper/css';
 import 'swiper/css/navigation';
 
-const columnPadding = parseInt(dimensions.movieIndexColumnPadding);
-const columnPaddingSmallScreen = parseInt(
+const columnPadding = Number.parseInt(dimensions.movieIndexColumnPadding);
+const columnPaddingSmallScreen = Number.parseInt(
   dimensions.movieIndexColumnPaddingSmallScreen
 );
-const defaultFontSize = parseInt(fonts.defaultFontSize);
-const lineHeight = parseFloat(fonts.lineHeight);
+const defaultFontSize = Number.parseInt(fonts.defaultFontSize);
+const lineHeight = Number.parseFloat(fonts.lineHeight);
 
 // Hardcoded height beased on line-height of 32 + bottom margin of 10. 19 + 5 for List Row
 // Less side-effecty than using react-measure.

--- a/frontend/src/Collection/Overview/CollectionOverviews.js
+++ b/frontend/src/Collection/Overview/CollectionOverviews.js
@@ -10,8 +10,8 @@ import CollectionOverviewConnector from './CollectionOverviewConnector';
 import styles from './CollectionOverviews.css';
 
 // Poster container dimensions
-const columnPadding = parseInt(dimensions.movieIndexColumnPadding);
-const columnPaddingSmallScreen = parseInt(
+const columnPadding = Number.parseInt(dimensions.movieIndexColumnPadding);
+const columnPaddingSmallScreen = Number.parseInt(
   dimensions.movieIndexColumnPaddingSmallScreen
 );
 

--- a/frontend/src/Components/Filter/Builder/FilterBuilderRowValue.js
+++ b/frontend/src/Components/Filter/Builder/FilterBuilderRowValue.js
@@ -54,7 +54,7 @@ function getValue(input, selectedFilterBuilderProp) {
         case 'tib':
           return convertToBytes(value, 4, true);
         default:
-          return parseInt(value);
+          return Number.parseInt(value);
       }
     }
   }

--- a/frontend/src/Components/Form/NumberInput.tsx
+++ b/frontend/src/Components/Form/NumberInput.tsx
@@ -13,7 +13,7 @@ function parseValue(
     return null;
   }
 
-  let newValue = isFloat ? parseFloat(value) : parseInt(value);
+  let newValue = isFloat ? Number.parseFloat(value) : Number.parseInt(value);
 
   if (min != null && newValue != null && newValue < min) {
     newValue = min;
@@ -84,8 +84,7 @@ function NumberInput({
 
   useEffect(() => {
     if (
-      // @ts-expect-error inputValue may be null
-      !isNaN(inputValue) &&
+      !Number.isNaN(Number(inputValue)) &&
       inputValue !== previousValue &&
       !isFocused.current
     ) {

--- a/frontend/src/Components/Form/Select/UMaskInput.tsx
+++ b/frontend/src/Components/Form/Select/UMaskInput.tsx
@@ -77,7 +77,7 @@ export interface UMaskInputProps {
 }
 
 function UMaskInput({ name, value, onChange }: UMaskInputProps) {
-  const valueNum = parseInt(value, 8);
+  const valueNum = Number.parseInt(value, 8);
   const umaskNum = 0o777 & ~valueNum;
   const umask = umaskNum.toString(8).padStart(4, '0');
   const folderNum = 0o777 & ~umaskNum;

--- a/frontend/src/Components/Page/PageJumpBar.tsx
+++ b/frontend/src/Components/Page/PageJumpBar.tsx
@@ -4,7 +4,7 @@ import dimensions from 'Styles/Variables/dimensions';
 import PageJumpBarItem, { PageJumpBarItemProps } from './PageJumpBarItem';
 import styles from './PageJumpBar.css';
 
-const ITEM_HEIGHT = parseInt(dimensions.jumpBarItemHeight);
+const ITEM_HEIGHT = Number.parseInt(dimensions.jumpBarItemHeight);
 
 export interface PageJumpBarItems {
   characters: Record<string, number>;

--- a/frontend/src/Components/Page/Sidebar/PageSidebar.tsx
+++ b/frontend/src/Components/Page/Sidebar/PageSidebar.tsx
@@ -24,8 +24,8 @@ import Messages from './Messages/Messages';
 import PageSidebarItem from './PageSidebarItem';
 import styles from './PageSidebar.css';
 
-const HEADER_HEIGHT = parseInt(dimensions.headerHeight);
-const SIDEBAR_WIDTH = parseInt(dimensions.sidebarWidth);
+const HEADER_HEIGHT = Number.parseInt(dimensions.headerHeight);
+const SIDEBAR_WIDTH = Number.parseInt(dimensions.sidebarWidth);
 
 interface SidebarItem {
   iconName?: IconName;

--- a/frontend/src/Components/Page/Toolbar/PageToolbarSection.tsx
+++ b/frontend/src/Components/Page/Toolbar/PageToolbarSection.tsx
@@ -12,8 +12,8 @@ import { PageToolbarButtonProps } from './PageToolbarButton';
 import PageToolbarOverflowMenuItem from './PageToolbarOverflowMenuItem';
 import styles from './PageToolbarSection.css';
 
-const BUTTON_WIDTH = parseInt(dimensions.toolbarButtonWidth);
-const SEPARATOR_MARGIN = parseInt(dimensions.toolbarSeparatorMargin);
+const BUTTON_WIDTH = Number.parseInt(dimensions.toolbarButtonWidth);
+const SEPARATOR_MARGIN = Number.parseInt(dimensions.toolbarSeparatorMargin);
 const SEPARATOR_WIDTH = 2 * SEPARATOR_MARGIN + 1;
 
 export interface PageToolbarSectionProps {

--- a/frontend/src/Components/Table/TableOptions/TableOptionsColumnDragPreview.js
+++ b/frontend/src/Components/Table/TableOptions/TableOptionsColumnDragPreview.js
@@ -7,12 +7,12 @@ import dimensions from 'Styles/Variables/dimensions.js';
 import TableOptionsColumn from './TableOptionsColumn';
 import styles from './TableOptionsColumnDragPreview.css';
 
-const formGroupSmallWidth = parseInt(dimensions.formGroupSmallWidth);
-const formLabelLargeWidth = parseInt(dimensions.formLabelLargeWidth);
-const formLabelRightMarginWidth = parseInt(
+const formGroupSmallWidth = Number.parseInt(dimensions.formGroupSmallWidth);
+const formLabelLargeWidth = Number.parseInt(dimensions.formLabelLargeWidth);
+const formLabelRightMarginWidth = Number.parseInt(
   dimensions.formLabelRightMarginWidth
 );
-const dragHandleWidth = parseInt(dimensions.dragHandleWidth);
+const dragHandleWidth = Number.parseInt(dimensions.dragHandleWidth);
 
 function TableOptionsColumnDragPreview() {
   const { item, itemType, currentOffset } = useDragLayer((monitor) => ({

--- a/frontend/src/InteractiveImport/Language/SelectLanguageModalContent.tsx
+++ b/frontend/src/InteractiveImport/Language/SelectLanguageModalContent.tsx
@@ -56,7 +56,7 @@ function SelectLanguageModalContent(props: SelectLanguageModalContentProps) {
 
   const onLanguageChange = useCallback(
     ({ name, value }: { name: string; value: boolean }) => {
-      const changedId = parseInt(name);
+      const changedId = Number.parseInt(name);
 
       let newLanguages = [...languageIds];
 

--- a/frontend/src/Movie/Details/Credits/MovieCreditPosters.tsx
+++ b/frontend/src/Movie/Details/Credits/MovieCreditPosters.tsx
@@ -10,8 +10,10 @@ import styles from './MovieCreditPosters.css';
 import 'swiper/css';
 import 'swiper/css/navigation';
 
-const columnPadding = parseFloat(dimensions.movieIndexColumnPadding as string);
-const columnPaddingSmallScreen = parseFloat(
+const columnPadding = Number.parseFloat(
+  dimensions.movieIndexColumnPadding as string
+);
+const columnPaddingSmallScreen = Number.parseFloat(
   dimensions.movieIndexColumnPaddingSmallScreen as string
 );
 

--- a/frontend/src/Movie/Index/Overview/MovieIndexOverview.tsx
+++ b/frontend/src/Movie/Index/Overview/MovieIndexOverview.tsx
@@ -27,12 +27,12 @@ import MovieIndexOverviewInfo from './MovieIndexOverviewInfo';
 import selectOverviewOptions from './selectOverviewOptions';
 import styles from './MovieIndexOverview.css';
 
-const columnPadding = parseInt(dimensions.movieIndexColumnPadding);
-const columnPaddingSmallScreen = parseInt(
+const columnPadding = Number.parseInt(dimensions.movieIndexColumnPadding);
+const columnPaddingSmallScreen = Number.parseInt(
   dimensions.movieIndexColumnPaddingSmallScreen
 );
-const defaultFontSize = parseInt(fonts.defaultFontSize);
-const lineHeight = parseFloat(fonts.lineHeight);
+const defaultFontSize = Number.parseInt(fonts.defaultFontSize);
+const lineHeight = Number.parseFloat(fonts.lineHeight);
 
 // Hardcoded height beased on line-height of 32 + bottom margin of 10.
 // Less side-effecty than using react-measure.

--- a/frontend/src/Movie/Index/Overview/MovieIndexOverviewInfo.tsx
+++ b/frontend/src/Movie/Index/Overview/MovieIndexOverviewInfo.tsx
@@ -41,7 +41,9 @@ interface MovieIndexOverviewInfoProps {
   sortKey: string;
 }
 
-const infoRowHeight = parseInt(dimensions.movieIndexOverviewInfoRowHeight);
+const infoRowHeight = Number.parseInt(
+  dimensions.movieIndexOverviewInfoRowHeight
+);
 
 const rows = [
   {

--- a/frontend/src/Movie/Index/Overview/MovieIndexOverviews.tsx
+++ b/frontend/src/Movie/Index/Overview/MovieIndexOverviews.tsx
@@ -5,12 +5,14 @@ import dimensions from 'Styles/Variables/dimensions';
 import MovieIndexOverview from './MovieIndexOverview';
 import selectOverviewOptions from './selectOverviewOptions';
 
-const columnPadding = parseInt(dimensions.movieIndexColumnPadding);
-const columnPaddingSmallScreen = parseInt(
+const columnPadding = Number.parseInt(dimensions.movieIndexColumnPadding);
+const columnPaddingSmallScreen = Number.parseInt(
   dimensions.movieIndexColumnPaddingSmallScreen
 );
-const progressBarHeight = parseInt(dimensions.progressBarSmallHeight);
-const detailedProgressBarHeight = parseInt(dimensions.progressBarMediumHeight);
+const progressBarHeight = Number.parseInt(dimensions.progressBarSmallHeight);
+const detailedProgressBarHeight = Number.parseInt(
+  dimensions.progressBarMediumHeight
+);
 
 interface MovieIndexOverviewsProps {
   items: Movie[];

--- a/frontend/src/Movie/Index/Posters/MovieIndexPosters.tsx
+++ b/frontend/src/Movie/Index/Posters/MovieIndexPosters.tsx
@@ -8,8 +8,8 @@ import Movie from 'Movie/Movie';
 import dimensions from 'Styles/Variables/dimensions';
 import MovieIndexPoster from './MovieIndexPoster';
 
-const columnPadding = parseInt(dimensions.movieIndexColumnPadding);
-const columnPaddingSmallScreen = parseInt(
+const columnPadding = Number.parseInt(dimensions.movieIndexColumnPadding);
+const columnPaddingSmallScreen = Number.parseInt(
   dimensions.movieIndexColumnPaddingSmallScreen
 );
 

--- a/frontend/src/Movie/Index/useMovieIndexQuery.ts
+++ b/frontend/src/Movie/Index/useMovieIndexQuery.ts
@@ -31,7 +31,7 @@ export function useMovieIndexQuery(params: MovieIndexQueryParams) {
   if (
     selectedFilterKey !== undefined &&
     selectedFilterKey !== null &&
-    !isNaN(Number(selectedFilterKey))
+    !Number.isNaN(Number(selectedFilterKey))
   ) {
     // Numeric ID indicates a custom filter
     filterDef = customFilters.find(

--- a/frontend/src/MovieFile/Edit/FileEditModal.tsx
+++ b/frontend/src/MovieFile/Edit/FileEditModal.tsx
@@ -68,14 +68,16 @@ function FileEditModal({
       releaseGroup: string;
       indexerFlags: number;
     }) => {
-      const qualityIdNum = parseInt(payload.qualityId);
+      const qualityIdNum = Number.parseInt(payload.qualityId);
       const quality = qualities.find(
         (item: { id: number }) => item.id === qualityIdNum
       );
       const langs: Language[] = payload.languageIds
         .map((languageId) => {
           const id =
-            typeof languageId === 'string' ? parseInt(languageId) : languageId;
+            typeof languageId === 'string'
+              ? Number.parseInt(languageId)
+              : languageId;
           return filteredLanguages.find((item) => item.id === id);
         })
         .filter((lang): lang is Language => !!lang);

--- a/frontend/src/Performer/Details/PerformerDetails.tsx
+++ b/frontend/src/Performer/Details/PerformerDetails.tsx
@@ -205,11 +205,9 @@ function PerformerDetails() {
   const moviesError = performerDetailsError;
   const expandIcon = allExpandedYears ? icons.COLLAPSE : icons.EXPAND;
   const statusDetails = getPerformerStatusDetails(status);
-  const startYear = Number.isFinite(careerStart) ? careerStart : '';
-  const endYear =
-    typeof careerEnd === 'number' && Number.isFinite(careerEnd) && careerEnd > 0
-      ? careerEnd
-      : '';
+  const startYear =
+    careerStart && Number.isFinite(careerStart) ? careerStart : '';
+  const endYear = careerEnd && Number.isFinite(careerEnd) ? careerEnd : '';
   const runningYears = `${startYear}-${endYear}`;
   const fanartUrl = getFanartUrl(Array.isArray(images) ? images : []);
   const formatedAge = birthDate === '' ? age : `${birthDate} | ${age}`;

--- a/frontend/src/Performer/Details/SceneRow.tsx
+++ b/frontend/src/Performer/Details/SceneRow.tsx
@@ -59,7 +59,7 @@ export default function SceneRow(props: SceneRowProps) {
         ''
       )}`;
     }
-    if (parseInt(foreignId) > 0) {
+    if (Number.parseInt(foreignId) > 0) {
       return `https://www.themoviedb.org/movie/${foreignId.replace(
         'tmdbId:',
         ''

--- a/frontend/src/Performer/Index/Posters/PerformerIndexPosters.tsx
+++ b/frontend/src/Performer/Index/Posters/PerformerIndexPosters.tsx
@@ -11,16 +11,18 @@ import Performer from 'Performer/Performer';
 import dimensions from 'Styles/Variables/dimensions';
 import getIndexOfFirstCharacter from 'Utilities/Array/getIndexOfFirstCharacter';
 
-const bodyPadding = parseInt(dimensions.pageContentBodyPadding);
-const bodyPaddingSmallScreen = parseInt(
+const bodyPadding = Number.parseInt(dimensions.pageContentBodyPadding);
+const bodyPaddingSmallScreen = Number.parseInt(
   dimensions.pageContentBodyPaddingSmallScreen
 );
-const columnPadding = parseInt(dimensions.movieIndexColumnPadding);
-const columnPaddingSmallScreen = parseInt(
+const columnPadding = Number.parseInt(dimensions.movieIndexColumnPadding);
+const columnPaddingSmallScreen = Number.parseInt(
   dimensions.movieIndexColumnPaddingSmallScreen
 );
-const progressBarHeight = parseInt(dimensions.progressBarSmallHeight);
-const detailedProgressBarHeight = parseInt(dimensions.progressBarMediumHeight);
+const progressBarHeight = Number.parseInt(dimensions.progressBarSmallHeight);
+const detailedProgressBarHeight = Number.parseInt(
+  dimensions.progressBarMediumHeight
+);
 
 const ADDITIONAL_COLUMN_COUNT: Record<string, number> = {
   small: 3,

--- a/frontend/src/RootFolder/RootFolderRow.tsx
+++ b/frontend/src/RootFolder/RootFolderRow.tsx
@@ -70,7 +70,7 @@ function RootFolderRow(props: RootFolderRowProps) {
       </TableRowCell>
 
       <TableRowCell className={styles.freeSpace}>
-        {isUnavailable || isNaN(Number(freeSpace))
+        {isUnavailable || Number.isNaN(Number(freeSpace))
           ? '-'
           : formatBytes(freeSpace)}
       </TableRowCell>

--- a/frontend/src/Scene/Index/Overview/SceneIndexOverview.tsx
+++ b/frontend/src/Scene/Index/Overview/SceneIndexOverview.tsx
@@ -26,12 +26,12 @@ import SceneIndexOverviewInfo from './SceneIndexOverviewInfo';
 import selectOverviewOptions from './selectOverviewOptions';
 import styles from './SceneIndexOverview.css';
 
-const columnPadding = parseInt(dimensions.movieIndexColumnPadding);
-const columnPaddingSmallScreen = parseInt(
+const columnPadding = Number.parseInt(dimensions.movieIndexColumnPadding);
+const columnPaddingSmallScreen = Number.parseInt(
   dimensions.movieIndexColumnPaddingSmallScreen
 );
-const defaultFontSize = parseInt(fonts.defaultFontSize);
-const lineHeight = parseFloat(fonts.lineHeight);
+const defaultFontSize = Number.parseInt(fonts.defaultFontSize);
+const lineHeight = Number.parseFloat(fonts.lineHeight);
 
 // Hardcoded height beased on line-height of 32 + bottom margin of 10.
 // Less side-effecty than using react-measure.

--- a/frontend/src/Scene/Index/Overview/SceneIndexOverviewInfo.tsx
+++ b/frontend/src/Scene/Index/Overview/SceneIndexOverviewInfo.tsx
@@ -41,7 +41,9 @@ interface SceneIndexOverviewInfoProps {
   sortKey: string;
 }
 
-const infoRowHeight = parseInt(dimensions.movieIndexOverviewInfoRowHeight);
+const infoRowHeight = Number.parseInt(
+  dimensions.movieIndexOverviewInfoRowHeight
+);
 
 const rows = [
   {

--- a/frontend/src/Scene/Index/Overview/SceneIndexOverviews.tsx
+++ b/frontend/src/Scene/Index/Overview/SceneIndexOverviews.tsx
@@ -5,12 +5,14 @@ import dimensions from 'Styles/Variables/dimensions';
 import SceneIndexOverview from './SceneIndexOverview';
 import selectOverviewOptions from './selectOverviewOptions';
 
-const columnPadding = parseInt(dimensions.movieIndexColumnPadding);
-const columnPaddingSmallScreen = parseInt(
+const columnPadding = Number.parseInt(dimensions.movieIndexColumnPadding);
+const columnPaddingSmallScreen = Number.parseInt(
   dimensions.movieIndexColumnPaddingSmallScreen
 );
-const progressBarHeight = parseInt(dimensions.progressBarSmallHeight);
-const detailedProgressBarHeight = parseInt(dimensions.progressBarMediumHeight);
+const progressBarHeight = Number.parseInt(dimensions.progressBarSmallHeight);
+const detailedProgressBarHeight = Number.parseInt(
+  dimensions.progressBarMediumHeight
+);
 
 interface SceneIndexOverviewsProps {
   items: Movie[];

--- a/frontend/src/Scene/Index/Posters/SceneIndexPosters.tsx
+++ b/frontend/src/Scene/Index/Posters/SceneIndexPosters.tsx
@@ -8,8 +8,8 @@ import Movie from 'Movie/Movie';
 import dimensions from 'Styles/Variables/dimensions';
 import SceneIndexPoster from './SceneIndexPoster';
 
-const columnPadding = parseInt(dimensions.movieIndexColumnPadding);
-const columnPaddingSmallScreen = parseInt(
+const columnPadding = Number.parseInt(dimensions.movieIndexColumnPadding);
+const columnPaddingSmallScreen = Number.parseInt(
   dimensions.movieIndexColumnPaddingSmallScreen
 );
 

--- a/frontend/src/Scene/Index/useSceneIndexQuery.ts
+++ b/frontend/src/Scene/Index/useSceneIndexQuery.ts
@@ -31,7 +31,7 @@ export function useSceneIndexQuery(params: SceneIndexQueryParams) {
   if (
     selectedFilterKey !== undefined &&
     selectedFilterKey !== null &&
-    !isNaN(Number(selectedFilterKey))
+    !Number.isNaN(Number(selectedFilterKey))
   ) {
     // Numeric ID indicates a custom filter
     filterDef = customFilters.find(

--- a/frontend/src/Settings/Profiles/Delay/DelayProfileDragPreview.js
+++ b/frontend/src/Settings/Profiles/Delay/DelayProfileDragPreview.js
@@ -7,7 +7,7 @@ import dimensions from 'Styles/Variables/dimensions.js';
 import DelayProfile from './DelayProfile';
 import styles from './DelayProfileDragPreview.css';
 
-const dragHandleWidth = parseInt(dimensions.dragHandleWidth);
+const dragHandleWidth = Number.parseInt(dimensions.dragHandleWidth);
 
 function DelayProfileDragPreview({ width }) {
   const { item, itemType, currentOffset } = useDragLayer((monitor) => ({

--- a/frontend/src/Settings/Profiles/Quality/EditQualityProfileModalContent.js
+++ b/frontend/src/Settings/Profiles/Quality/EditQualityProfileModalContent.js
@@ -20,7 +20,7 @@ import QualityProfileFormatItems from './QualityProfileFormatItems';
 import QualityProfileItems from './QualityProfileItems';
 import styles from './EditQualityProfileModalContent.css';
 
-const MODAL_BODY_PADDING = parseInt(dimensions.modalBodyPadding);
+const MODAL_BODY_PADDING = Number.parseInt(dimensions.modalBodyPadding);
 
 function getCustomFormatRender(formatItems, otherProps) {
   return (

--- a/frontend/src/Settings/Profiles/Quality/EditQualityProfileModalContentConnector.js
+++ b/frontend/src/Settings/Profiles/Quality/EditQualityProfileModalContentConnector.js
@@ -26,10 +26,10 @@ function parseIndex(index) {
   const split = index.split('.');
 
   if (split.length === 1) {
-    return [null, parseInt(split[0]) - 1];
+    return [null, Number.parseInt(split[0]) - 1];
   }
 
-  return [parseInt(split[0]) - 1, parseInt(split[1]) - 1];
+  return [Number.parseInt(split[0]) - 1, Number.parseInt(split[1]) - 1];
 }
 
 function createQualitiesSelector() {
@@ -216,7 +216,7 @@ class EditQualityProfileModalContentConnector extends Component {
   };
 
   onCutoffChange = ({ name, value }) => {
-    const id = parseInt(value);
+    const id = Number.parseInt(value);
     const item = _.find(this.props.item.items.value, (i) => {
       if (i.quality) {
         return i.quality.id === id;
@@ -231,7 +231,7 @@ class EditQualityProfileModalContentConnector extends Component {
   };
 
   onLanguageChange = ({ name, value }) => {
-    const id = parseInt(value);
+    const id = Number.parseInt(value);
 
     const language = _.find(this.props.languages, (item) => item.key === id);
 

--- a/frontend/src/Settings/Profiles/Quality/QualityProfileItemDragPreview.js
+++ b/frontend/src/Settings/Profiles/Quality/QualityProfileItemDragPreview.js
@@ -6,12 +6,12 @@ import dimensions from 'Styles/Variables/dimensions.js';
 import QualityProfileItem from './QualityProfileItem';
 import styles from './QualityProfileItemDragPreview.css';
 
-const formGroupExtraSmallWidth = parseInt(dimensions.formGroupExtraSmallWidth);
-const formLabelSmallWidth = parseInt(dimensions.formLabelSmallWidth);
-const formLabelRightMarginWidth = parseInt(
+const formGroupExtraSmallWidth = Number.parseInt(dimensions.formGroupExtraSmallWidth);
+const formLabelSmallWidth = Number.parseInt(dimensions.formLabelSmallWidth);
+const formLabelRightMarginWidth = Number.parseInt(
   dimensions.formLabelRightMarginWidth
 );
-const dragHandleWidth = parseInt(dimensions.dragHandleWidth);
+const dragHandleWidth = Number.parseInt(dimensions.dragHandleWidth);
 
 function QualityProfileItemDragPreview() {
   const { item, itemType, currentOffset } = useDragLayer((monitor) => ({

--- a/frontend/src/Store/Actions/Creators/Reducers/createSetSettingValueReducer.js
+++ b/frontend/src/Store/Actions/Creators/Reducers/createSetSettingValueReducer.js
@@ -15,7 +15,7 @@ function createSetSettingValueReducer(section) {
       let parsedValue = null;
 
       if (_.isNumber(currentValue) && value != null) {
-        parsedValue = parseInt(value);
+        parsedValue = Number.parseInt(value);
       } else {
         parsedValue = value;
       }

--- a/frontend/src/Store/Actions/Settings/qualityDefinitions.js
+++ b/frontend/src/Store/Actions/Settings/qualityDefinitions.js
@@ -70,7 +70,7 @@ export default {
       const upatedDefinitions = Object.keys(
         qualityDefinitions.pendingChanges
       ).map((key) => {
-        const id = parseInt(key);
+        const id = Number.parseInt(key);
         const pendingChanges = qualityDefinitions.pendingChanges[id] || {};
         const item = _.find(qualityDefinitions.items, { id });
 

--- a/frontend/src/Studio/Index/Posters/StudioIndexPosters.tsx
+++ b/frontend/src/Studio/Index/Posters/StudioIndexPosters.tsx
@@ -10,16 +10,18 @@ import StudioIndexPoster from 'Studio/Index/Posters/StudioIndexPoster';
 import Studio from 'Studio/Studio';
 import dimensions from 'Styles/Variables/dimensions';
 
-const bodyPadding = parseInt(dimensions.pageContentBodyPadding);
-const bodyPaddingSmallScreen = parseInt(
+const bodyPadding = Number.parseInt(dimensions.pageContentBodyPadding);
+const bodyPaddingSmallScreen = Number.parseInt(
   dimensions.pageContentBodyPaddingSmallScreen
 );
-const columnPadding = parseInt(dimensions.movieIndexColumnPadding);
-const columnPaddingSmallScreen = parseInt(
+const columnPadding = Number.parseInt(dimensions.movieIndexColumnPadding);
+const columnPaddingSmallScreen = Number.parseInt(
   dimensions.movieIndexColumnPaddingSmallScreen
 );
-const progressBarHeight = parseInt(dimensions.progressBarSmallHeight);
-const detailedProgressBarHeight = parseInt(dimensions.progressBarMediumHeight);
+const progressBarHeight = Number.parseInt(dimensions.progressBarSmallHeight);
+const detailedProgressBarHeight = Number.parseInt(
+  dimensions.progressBarMediumHeight
+);
 
 const ADDITIONAL_COLUMN_COUNT: Record<string, number> = {
   small: 3,

--- a/frontend/src/Studio/Index/useStudioIndexQuery.ts
+++ b/frontend/src/Studio/Index/useStudioIndexQuery.ts
@@ -88,7 +88,7 @@ export function useStudioIndexQuery(
   if (
     selectedFilterKey !== undefined &&
     selectedFilterKey !== null &&
-    !Number.isNaN(selectedFilterKey)
+    !Number.isNaN(Number(selectedFilterKey))
   ) {
     // Numeric ID indicates a custom filter
     filterDef = customFilters.find(

--- a/frontend/src/System/Updates/Updates.tsx
+++ b/frontend/src/System/Updates/Updates.tsx
@@ -85,12 +85,12 @@ function Updates() {
   };
 
   const { isMajorUpdate, hasUpdateToInstall } = useMemo(() => {
-    const majorVersion = parseInt(
+    const majorVersion = Number.parseInt(
       currentVersion.match(VERSION_REGEX)?.[0] ?? '0'
     );
 
     const latestVersion = items[0]?.version;
-    const latestMajorVersion = parseInt(
+    const latestMajorVersion = Number.parseInt(
       latestVersion?.match(VERSION_REGEX)?.[0] ?? '0'
     );
 

--- a/frontend/src/UnmappedFiles/UnmappedFilesTable.tsx
+++ b/frontend/src/UnmappedFiles/UnmappedFilesTable.tsx
@@ -165,11 +165,11 @@ class UnmappedFilesTable extends Component<
         valA =
           typeof a[sortKey] === 'number'
             ? (a[sortKey] as number)
-            : parseFloat(String(a[sortKey])) || 0;
+            : Number.parseFloat(String(a[sortKey])) || 0;
         valB =
           typeof b[sortKey] === 'number'
             ? (b[sortKey] as number)
-            : parseFloat(String(b[sortKey])) || 0;
+            : Number.parseFloat(String(b[sortKey])) || 0;
       } else {
         valA = a[sortKey]?.toString().toLowerCase?.() ?? '';
         valB = b[sortKey]?.toString().toLowerCase?.() ?? '';

--- a/frontend/src/Utilities/Array/getIndexOfFirstCharacter.js
+++ b/frontend/src/Utilities/Array/getIndexOfFirstCharacter.js
@@ -3,7 +3,7 @@ export default function getIndexOfFirstCharacter(items, character) {
     const firstCharacter = item.sortTitle.charAt(0);
 
     if (character === '#') {
-      return !isNaN(firstCharacter);
+      return !Number.isNaN(Number(firstCharacter));
     }
 
     return firstCharacter === character;

--- a/frontend/src/Utilities/Number/convertToBytes.js
+++ b/frontend/src/Utilities/Number/convertToBytes.js
@@ -1,7 +1,7 @@
 function convertToBytes(input, power, binaryPrefix) {
   const size = Number(input);
 
-  if (isNaN(size)) {
+  if (Number.isNaN(Number(size))) {
     return '';
   }
 

--- a/frontend/src/Utilities/Number/formatAge.js
+++ b/frontend/src/Utilities/Number/formatAge.js
@@ -2,8 +2,8 @@ import translate from 'Utilities/String/translate';
 
 function formatAge(age, ageHours, ageMinutes) {
   age = Math.round(age);
-  ageHours = parseFloat(ageHours);
-  ageMinutes = ageMinutes && parseFloat(ageMinutes);
+  ageHours = Number.parseFloat(ageHours);
+  ageMinutes = ageMinutes && Number.parseFloat(ageMinutes);
 
   if (age < 2 && ageHours) {
     if (ageHours < 2 && !!ageMinutes) {

--- a/frontend/src/Utilities/Number/formatBitrate.ts
+++ b/frontend/src/Utilities/Number/formatBitrate.ts
@@ -3,7 +3,7 @@ import { filesize } from 'filesize';
 function formatBitrate(input: string | number) {
   const size = Number(input);
 
-  if (isNaN(size)) {
+  if (Number.isNaN(Number(size))) {
     return '';
   }
 

--- a/frontend/src/Utilities/Number/formatBytes.ts
+++ b/frontend/src/Utilities/Number/formatBytes.ts
@@ -3,7 +3,7 @@ import { filesize } from 'filesize';
 function formatBytes(input: string | number) {
   const size = Number(input);
 
-  if (isNaN(size)) {
+  if (Number.isNaN(Number(size))) {
     return '';
   }
 

--- a/frontend/src/Utilities/Number/formatNumber.ts
+++ b/frontend/src/Utilities/Number/formatNumber.ts
@@ -1,7 +1,7 @@
 function formatNumber(input: string | number, minimumFractionDigits = 0) {
   const size = Number(input);
 
-  if (isNaN(size)) {
+  if (Number.isNaN(Number(size))) {
     return '';
   }
 

--- a/frontend/src/Utilities/Table/getSelectedIds.ts
+++ b/frontend/src/Utilities/Table/getSelectedIds.ts
@@ -6,7 +6,7 @@ function getSelectedIds(selectedState: SelectedState): number[] {
     selectedState,
     (result: number[], value, id) => {
       if (value) {
-        result.push(parseInt(id));
+        result.push(Number.parseInt(id));
       }
 
       return result;


### PR DESCRIPTION
#### Database Migration

<!-- If you update database schema, the migration number must be noted here -->

NO

#### Description

Sonar recommends using the `Number` static methods for number functions instead of the legacy global ones, to avoid unexpected behavior.

In this PR:

- isNaN -> Number.isNaN(Number(x))
- parseInt -> Number.parseInt
- parseFloat -> Number.parseFloat
- isFinite -> Number.isFinite (null check as well)

#### Screenshot(s) (if UI related)

<details>
<!-- paste screenshots below here.-->

<!-- paste screenshots above here.  MAKE SURE THE ARE SFW -->
</details>

#### Todos

- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)

#### Issues Fixed or Closed by this PR

<!-- If multiple, put each on a separate line -->

- Fixes whisparr/whisparr#XXXX
