### PR TITLE
Fix: Studio details does not render every year on long-running studios

### DIFF
--- a/frontend/src/Studio/Details/StudioDetails.tsx
+++ b/frontend/src/Studio/Details/StudioDetails.tsx
@@ -1,5 +1,11 @@
 import _ from 'lodash';
-import React, { useCallback, useEffect, useMemo, useRef } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { useDispatch } from 'react-redux';
 import { useParams } from 'react-router-dom';
 import {
@@ -57,6 +63,11 @@ function StudioDetails() {
 
   const { data: allWorks = [], isFetching: isWorksFetching } =
     useStudioDetailsWorks(studioForeignId as string);
+
+  const [scrollContainer, setScrollContainer] = useState<Element | null>(null);
+  const contentBodyRef = useCallback((el: HTMLDivElement | null) => {
+    setScrollContainer(el);
+  }, []);
 
   const listRef = useRef<List>(null);
   const cacheRef = useRef(
@@ -277,7 +288,10 @@ function StudioDetails() {
       </PageToolbar>
 
       {/* MAIN PAGE CONTENT */}
-      <PageContentBody innerClassName={styles.innerContentBody}>
+      <PageContentBody
+        ref={contentBodyRef}
+        innerClassName={styles.innerContentBody}
+      >
         <div className={styles.header}>
           <div
             className={styles.backdrop}
@@ -494,7 +508,7 @@ function StudioDetails() {
           {/* WORKS BY YEAR */}
           {isPopulated && (studio.hasMovies || studio.hasScenes) && (
             <FieldSet legend={translate('Works')}>
-              <WindowScroller>
+              <WindowScroller scrollElement={scrollContainer ?? undefined}>
                 {({
                   height,
                   isScrolling,

--- a/frontend/src/Studio/Details/StudioDetailsYear.tsx
+++ b/frontend/src/Studio/Details/StudioDetailsYear.tsx
@@ -168,11 +168,7 @@ function StudioDetailsYear(props: StudioDetailsYearProps) {
           {!isSmallScreen && <span>&nbsp;</span>}
         </Link>
         {isSmallScreen ? (
-          <Menu
-            className={styles.actionsMenu}
-            alignMenu={align.RIGHT}
-            enforceMaxHeight={false}
-          >
+          <Menu className={styles.actionsMenu} alignMenu={align.RIGHT}>
             <MenuButton>
               <Icon name={icons.ACTIONS} size={22} />
             </MenuButton>

--- a/frontend/src/Studio/Details/StudioDetailsYear.tsx
+++ b/frontend/src/Studio/Details/StudioDetailsYear.tsx
@@ -71,15 +71,8 @@ function StudioDetailsYear(props: StudioDetailsYearProps) {
     onYearRefreshPress,
   } = props;
 
-  const {
-    items,
-    studioMonitored,
-    isSmallScreen,
-    isSearching,
-    columns,
-    sortKey,
-    sortDirection,
-  } = useStudioDetailsYearData(studioId, works);
+  const { items, isSmallScreen, isSearching, columns, sortKey, sortDirection } =
+    useStudioDetailsYearData(works);
 
   const totalMovieCount = works.length;
   const monitoredMovieCount = works.filter((m) => m.monitored).length;
@@ -189,9 +182,7 @@ function StudioDetailsYear(props: StudioDetailsYearProps) {
                 {translate('Refresh')}
               </MenuItem>
               <MenuItem
-                isDisabled={
-                  isSearching || monitoredMovieCount === 0 || !studioMonitored
-                }
+                isDisabled={isSearching || monitoredMovieCount === 0}
                 onPress={onSearchPress}
               >
                 <SpinnerIcon
@@ -218,15 +209,13 @@ function StudioDetailsYear(props: StudioDetailsYearProps) {
               className={styles.actionButton}
               name={icons.SEARCH}
               title={
-                monitoredMovieCount > 0 && studioMonitored
+                monitoredMovieCount > 0
                   ? translate('SearchForMonitoredMoviesYear')
                   : translate('NoMonitoredMoviesYear')
               }
               size={24}
               isSpinning={isSearching}
-              isDisabled={
-                isSearching || monitoredMovieCount === 0 || !studioMonitored
-              }
+              isDisabled={isSearching || monitoredMovieCount === 0}
               onPress={onSearchPress}
             />
           </div>

--- a/frontend/src/Studio/Details/useStudioDetailsYear.ts
+++ b/frontend/src/Studio/Details/useStudioDetailsYear.ts
@@ -14,12 +14,10 @@ import {
   setStudioScenesTableOption,
 } from 'Store/Actions/studioScenesActions';
 import createDimensionsSelector from 'Store/Selectors/createDimensionsSelector';
-import Studio from 'Studio/Studio';
 import { TableOptionsChangePayload } from 'typings/Table';
 
 interface StudioDetailsYearState {
   items: Movie[];
-  studioMonitored: boolean;
   isSmallScreen: boolean;
   isSearching: boolean;
   columns: Column[];
@@ -102,12 +100,8 @@ function sort(items: Movie[], state: StudioScenesState) {
 }
 
 export function useStudioDetailsYearData(
-  studioId: number,
   items: Movie[]
 ): StudioDetailsYearState {
-  const studio = useSelector((state: AppState) =>
-    state.studios.items.find((s: Studio) => s.id === studioId)
-  );
   const studioScenes = useSelector(
     (state: AppState & { studioScenes: StudioScenesState }) =>
       state.studioScenes
@@ -118,7 +112,6 @@ export function useStudioDetailsYearData(
 
   return {
     items: sortedItems,
-    studioMonitored: studio?.monitored ?? false,
     isSmallScreen: dimensions.isSmallScreen,
     isSearching: false,
     columns: studioScenes.columns,


### PR DESCRIPTION
#### Database Migration

<!-- If you update database schema, the migration number must be noted here -->

NO

#### Description

- Fix year rendering for long-running studios
- Fix year search button to allow search if any works item is monitored
- Fix year action menu on mobile not expanding

I did a repro on the studio noted in the linked issue, and had no issue scrolling to the earliest year, 1998, on desktop and mobile.

#### Screenshot(s) (if UI related)

<details>
<!-- paste screenshots below here.-->
<img width="1280" height="634" alt="image" src="https://github.com/user-attachments/assets/0fef700b-090e-48c2-887c-ec39e95b9c0c" />

<!-- paste screenshots above here.  MAKE SURE THE ARE SFW -->
</details>

#### Todos

- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)

#### Issues Fixed or Closed by this PR

<!-- If multiple, put each on a separate line -->

- Fixes whisparr/whisparr#1059
