### PR TITLE
Fix: String filter only works with a single value

### DIFF
--- a/src/NzbDrone.Core.Test/Datastore/PagedFilters/StringArrayFilterFixture.cs
+++ b/src/NzbDrone.Core.Test/Datastore/PagedFilters/StringArrayFilterFixture.cs
@@ -1,0 +1,158 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using FluentAssertions;
+using NUnit.Framework;
+using NzbDrone.Core.Datastore;
+using NzbDrone.Core.Datastore.PagedFilters;
+
+namespace NzbDrone.Core.Test.Datastore.PagedFilters
+{
+    [TestFixture]
+    public class StringArrayFilterFixture
+    {
+        private class TestModel
+        {
+            public List<string> Tags { get; set; }
+        }
+
+        private static bool Evaluate(PagingSpec<TestModel> spec, TestModel model)
+        {
+            return spec.FilterExpressions.All(expr => expr.Compile()(model));
+        }
+
+        private static PagingSpec<TestModel> Apply(string jsonValue, string operation)
+        {
+            var spec = new PagingSpec<TestModel>();
+            var element = JsonDocument.Parse(jsonValue).RootElement;
+            StringArrayFilter.Apply(spec, element, operation, m => m.Tags);
+            return spec;
+        }
+
+        // ── contains (any) ────────────────────────────────────────────────────
+
+        [Test]
+        public void contains_single_value_matches_when_list_has_value()
+        {
+            var spec = Apply("\"rock\"", "contains");
+            Evaluate(spec, new TestModel { Tags = new List<string> { "rock", "pop" } }).Should().BeTrue();
+        }
+
+        [Test]
+        public void contains_single_value_no_match()
+        {
+            var spec = Apply("\"jazz\"", "contains");
+            Evaluate(spec, new TestModel { Tags = new List<string> { "rock", "pop" } }).Should().BeFalse();
+        }
+
+        [Test]
+        public void contains_multi_value_matches_when_any_present()
+        {
+            var spec = Apply("[\"rock\",\"jazz\"]", "contains");
+
+            // list has "rock" → matches
+            Evaluate(spec, new TestModel { Tags = new List<string> { "rock" } }).Should().BeTrue();
+
+            // list has "jazz" → matches
+            Evaluate(spec, new TestModel { Tags = new List<string> { "jazz" } }).Should().BeTrue();
+
+            // list has neither → no match
+            Evaluate(spec, new TestModel { Tags = new List<string> { "pop" } }).Should().BeFalse();
+        }
+
+        [Test]
+        public void contains_multi_value_produces_single_expression()
+        {
+            var spec = Apply("[\"rock\",\"jazz\"]", "contains");
+            spec.FilterExpressions.Should().HaveCount(1);
+        }
+
+        [Test]
+        public void containsany_alias_behaves_same_as_contains()
+        {
+            var spec = Apply("[\"rock\",\"jazz\"]", "containsany");
+            Evaluate(spec, new TestModel { Tags = new List<string> { "jazz" } }).Should().BeTrue();
+            Evaluate(spec, new TestModel { Tags = new List<string> { "pop" } }).Should().BeFalse();
+        }
+
+        [Test]
+        public void contains_null_list_does_not_match()
+        {
+            var spec = Apply("\"rock\"", "contains");
+            Evaluate(spec, new TestModel { Tags = null }).Should().BeFalse();
+        }
+
+        // ── containsall ───────────────────────────────────────────────────────
+
+        [Test]
+        public void containsall_requires_all_values_present()
+        {
+            var spec = Apply("[\"rock\",\"pop\"]", "containsall");
+            Evaluate(spec, new TestModel { Tags = new List<string> { "rock", "pop", "jazz" } }).Should().BeTrue();
+            Evaluate(spec, new TestModel { Tags = new List<string> { "rock" } }).Should().BeFalse();
+            Evaluate(spec, new TestModel { Tags = new List<string> { "jazz" } }).Should().BeFalse();
+        }
+
+        [Test]
+        public void containsall_null_list_does_not_match()
+        {
+            var spec = Apply("[\"rock\"]", "containsall");
+            Evaluate(spec, new TestModel { Tags = null }).Should().BeFalse();
+        }
+
+        // ── doesnotcontain ────────────────────────────────────────────────────
+
+        [Test]
+        public void doesnotcontain_single_value_excludes_match()
+        {
+            var spec = Apply("\"rock\"", "doesnotcontain");
+            Evaluate(spec, new TestModel { Tags = new List<string> { "rock", "pop" } }).Should().BeFalse();
+            Evaluate(spec, new TestModel { Tags = new List<string> { "jazz" } }).Should().BeTrue();
+        }
+
+        [Test]
+        public void doesnotcontain_multi_value_excludes_when_any_present()
+        {
+            var spec = Apply("[\"rock\",\"jazz\"]", "doesnotcontain");
+
+            // list has "rock" → excluded
+            Evaluate(spec, new TestModel { Tags = new List<string> { "rock" } }).Should().BeFalse();
+
+            // list has "jazz" → excluded
+            Evaluate(spec, new TestModel { Tags = new List<string> { "jazz" } }).Should().BeFalse();
+
+            // list has neither → passes
+            Evaluate(spec, new TestModel { Tags = new List<string> { "pop" } }).Should().BeTrue();
+        }
+
+        [Test]
+        public void doesnotcontain_null_list_passes()
+        {
+            var spec = Apply("\"rock\"", "doesnotcontain");
+            Evaluate(spec, new TestModel { Tags = null }).Should().BeTrue();
+        }
+
+        // ── edge cases ────────────────────────────────────────────────────────
+
+        [Test]
+        public void empty_array_produces_no_expressions()
+        {
+            var spec = Apply("[]", "contains");
+            spec.FilterExpressions.Should().BeEmpty();
+        }
+
+        [Test]
+        public void whitespace_only_values_are_ignored()
+        {
+            var spec = Apply("[\"  \",\"\"]", "contains");
+            spec.FilterExpressions.Should().BeEmpty();
+        }
+
+        [Test]
+        public void unknown_operation_produces_no_expressions()
+        {
+            var spec = Apply("\"rock\"", "unknown");
+            spec.FilterExpressions.Should().BeEmpty();
+        }
+    }
+}

--- a/src/NzbDrone.Core.Test/Datastore/PagedFilters/StringFilterFixture.cs
+++ b/src/NzbDrone.Core.Test/Datastore/PagedFilters/StringFilterFixture.cs
@@ -1,0 +1,236 @@
+using System.Linq;
+using System.Text.Json;
+using FluentAssertions;
+using NUnit.Framework;
+using NzbDrone.Core.Datastore;
+using NzbDrone.Core.Datastore.PagedFilters;
+
+namespace NzbDrone.Core.Test.Datastore.PagedFilters
+{
+    [TestFixture]
+    public class StringFilterFixture
+    {
+        private class TestModel
+        {
+            public string Title { get; set; }
+        }
+
+        private static bool Evaluate(PagingSpec<TestModel> spec, TestModel model)
+        {
+            return spec.FilterExpressions.All(expr => expr.Compile()(model));
+        }
+
+        private static PagingSpec<TestModel> Apply(string jsonValue, string operation)
+        {
+            var spec = new PagingSpec<TestModel>();
+            var element = JsonDocument.Parse(jsonValue).RootElement;
+            StringFilter.Apply(spec, element, operation, m => m.Title);
+            return spec;
+        }
+
+        // ── contains ──────────────────────────────────────────────────────────
+
+        [Test]
+        public void contains_single_value_matches()
+        {
+            var spec = Apply("\"Taboo\"", "contains");
+            Evaluate(spec, new TestModel { Title = "My Taboo" }).Should().BeTrue();
+        }
+
+        [Test]
+        public void contains_single_value_no_match()
+        {
+            var spec = Apply("\"Taboo\"", "contains");
+            Evaluate(spec, new TestModel { Title = "Another Title" }).Should().BeFalse();
+        }
+
+        [Test]
+        public void contains_multi_value_matches_any()
+        {
+            var spec = Apply("[\"Taboo\",\"Affair\"]", "contains");
+
+            // matches first term
+            Evaluate(spec, new TestModel { Title = "My Taboo" }).Should().BeTrue();
+
+            // matches second term
+            Evaluate(spec, new TestModel { Title = "Big Affair" }).Should().BeTrue();
+
+            // matches neither
+            Evaluate(spec, new TestModel { Title = "Unrelated" }).Should().BeFalse();
+        }
+
+        [Test]
+        public void contains_multi_value_produces_single_expression()
+        {
+            var spec = Apply("[\"Taboo\",\"Affair\"]", "contains");
+            spec.FilterExpressions.Should().HaveCount(1);
+        }
+
+        [Test]
+        public void contains_null_title_does_not_match()
+        {
+            var spec = Apply("\"Taboo\"", "contains");
+            Evaluate(spec, new TestModel { Title = null }).Should().BeFalse();
+        }
+
+        // ── notcontains ───────────────────────────────────────────────────────
+
+        [Test]
+        public void notcontains_single_value_excludes_match()
+        {
+            var spec = Apply("\"Taboo\"", "notcontains");
+            Evaluate(spec, new TestModel { Title = "My Taboo" }).Should().BeFalse();
+            Evaluate(spec, new TestModel { Title = "Another Title" }).Should().BeTrue();
+        }
+
+        [Test]
+        public void notcontains_multi_value_and_semantics()
+        {
+            var spec = Apply("[\"Taboo\",\"Affair\"]", "notcontains");
+
+            // both terms absent → passes
+            Evaluate(spec, new TestModel { Title = "Unrelated" }).Should().BeTrue();
+
+            // first term present → fails
+            Evaluate(spec, new TestModel { Title = "My Taboo" }).Should().BeFalse();
+
+            // second term present → fails
+            Evaluate(spec, new TestModel { Title = "Big Affair" }).Should().BeFalse();
+        }
+
+        [Test]
+        public void notcontains_multi_value_produces_one_expression_per_term()
+        {
+            var spec = Apply("[\"Taboo\",\"Affair\"]", "notcontains");
+            spec.FilterExpressions.Should().HaveCount(2);
+        }
+
+        [Test]
+        public void notcontains_null_title_passes()
+        {
+            var spec = Apply("\"Taboo\"", "notcontains");
+            Evaluate(spec, new TestModel { Title = null }).Should().BeTrue();
+        }
+
+        // ── equal ─────────────────────────────────────────────────────────────
+
+        [Test]
+        public void equal_single_value_matches_exactly()
+        {
+            var spec = Apply("\"Taboo\"", "equal");
+            Evaluate(spec, new TestModel { Title = "Taboo" }).Should().BeTrue();
+            Evaluate(spec, new TestModel { Title = "My Taboo" }).Should().BeFalse();
+        }
+
+        [Test]
+        public void equal_multi_value_matches_any()
+        {
+            var spec = Apply("[\"Taboo\",\"Affair\"]", "equal");
+            Evaluate(spec, new TestModel { Title = "Taboo" }).Should().BeTrue();
+            Evaluate(spec, new TestModel { Title = "Affair" }).Should().BeTrue();
+            Evaluate(spec, new TestModel { Title = "Other" }).Should().BeFalse();
+        }
+
+        // ── notequal ──────────────────────────────────────────────────────────
+
+        [Test]
+        public void notequal_single_value_excludes_exact_match()
+        {
+            var spec = Apply("\"Taboo\"", "notequal");
+            Evaluate(spec, new TestModel { Title = "Taboo" }).Should().BeFalse();
+            Evaluate(spec, new TestModel { Title = "Other" }).Should().BeTrue();
+        }
+
+        [Test]
+        public void notequal_multi_value_and_semantics()
+        {
+            var spec = Apply("[\"Taboo\",\"Affair\"]", "notequal");
+            Evaluate(spec, new TestModel { Title = "Other" }).Should().BeTrue();
+            Evaluate(spec, new TestModel { Title = "Taboo" }).Should().BeFalse();
+            Evaluate(spec, new TestModel { Title = "Affair" }).Should().BeFalse();
+        }
+
+        // ── startswith ────────────────────────────────────────────────────────
+
+        [Test]
+        public void startswith_single_value_matches()
+        {
+            var spec = Apply("\"My\"", "startswith");
+            Evaluate(spec, new TestModel { Title = "My Taboo" }).Should().BeTrue();
+            Evaluate(spec, new TestModel { Title = "Big Affair" }).Should().BeFalse();
+        }
+
+        [Test]
+        public void startswith_multi_value_matches_any()
+        {
+            var spec = Apply("[\"My\",\"Big\"]", "startswith");
+            Evaluate(spec, new TestModel { Title = "My Taboo" }).Should().BeTrue();
+            Evaluate(spec, new TestModel { Title = "Big Affair" }).Should().BeTrue();
+            Evaluate(spec, new TestModel { Title = "Other" }).Should().BeFalse();
+        }
+
+        // ── notstartswith ─────────────────────────────────────────────────────
+
+        [Test]
+        public void notstartswith_multi_value_and_semantics()
+        {
+            var spec = Apply("[\"My\",\"Big\"]", "notstartswith");
+            Evaluate(spec, new TestModel { Title = "Other" }).Should().BeTrue();
+            Evaluate(spec, new TestModel { Title = "My Taboo" }).Should().BeFalse();
+            Evaluate(spec, new TestModel { Title = "Big Affair" }).Should().BeFalse();
+        }
+
+        // ── endswith ──────────────────────────────────────────────────────────
+
+        [Test]
+        public void endswith_single_value_matches()
+        {
+            var spec = Apply("\"Taboo\"", "endswith");
+            Evaluate(spec, new TestModel { Title = "My Taboo" }).Should().BeTrue();
+            Evaluate(spec, new TestModel { Title = "Big Affair" }).Should().BeFalse();
+        }
+
+        [Test]
+        public void endswith_multi_value_matches_any()
+        {
+            var spec = Apply("[\"Taboo\",\"Affair\"]", "endswith");
+            Evaluate(spec, new TestModel { Title = "My Taboo" }).Should().BeTrue();
+            Evaluate(spec, new TestModel { Title = "Big Affair" }).Should().BeTrue();
+            Evaluate(spec, new TestModel { Title = "Unrelated" }).Should().BeFalse();
+        }
+
+        // ── notendswith ───────────────────────────────────────────────────────
+
+        [Test]
+        public void notendswith_multi_value_and_semantics()
+        {
+            var spec = Apply("[\"Taboo\",\"Affair\"]", "notendswith");
+            Evaluate(spec, new TestModel { Title = "Unrelated" }).Should().BeTrue();
+            Evaluate(spec, new TestModel { Title = "My Taboo" }).Should().BeFalse();
+            Evaluate(spec, new TestModel { Title = "Big Affair" }).Should().BeFalse();
+        }
+
+        // ── edge cases ────────────────────────────────────────────────────────
+
+        [Test]
+        public void empty_array_produces_no_expressions()
+        {
+            var spec = Apply("[]", "contains");
+            spec.FilterExpressions.Should().BeEmpty();
+        }
+
+        [Test]
+        public void whitespace_only_values_are_ignored()
+        {
+            var spec = Apply("[\"  \",\"\"]", "contains");
+            spec.FilterExpressions.Should().BeEmpty();
+        }
+
+        [Test]
+        public void unknown_operation_produces_no_expressions()
+        {
+            var spec = Apply("\"value\"", "unknown");
+            spec.FilterExpressions.Should().BeEmpty();
+        }
+    }
+}

--- a/src/NzbDrone.Core/Datastore/PagedFilters/StringFilter.cs
+++ b/src/NzbDrone.Core/Datastore/PagedFilters/StringFilter.cs
@@ -52,66 +52,82 @@ namespace NzbDrone.Core.Datastore.PagedFilters
             var endsWithMethod = typeof(string).GetMethod("EndsWith", new[] { typeof(string) });
             var nullConst = Expression.Constant(null, typeof(string));
 
-            // Each value produces one filter expression added to FilterExpressions (ANDed together).
-            // For positive ops (contains/startswith/endswith) multiple values mean "path matches ALL".
-            // For negative ops (notcontains/notstartswith/notendswith) multiple values mean "path matches NONE".
+            // Positive ops (contains/startswith/endswith/equal): multiple values are OR'd into one
+            // expression so that any matching value satisfies the filter.
+            // Negative ops (notcontains/notstartswith/notendswith/notequal): each value adds a separate
+            // expression (ANDed) so that none of the values may match.
+            var perValueExpressions = new List<Expression>();
+
             foreach (var value in values)
             {
                 var valueConst = Expression.Constant(value);
                 var notNull = Expression.NotEqual(property, nullConst);
-                Expression final;
+                Expression perValue;
 
                 switch (operation)
                 {
                     case "contains":
                         var containsCall = Expression.Call(property, containsMethod, valueConst);
-                        final = Expression.AndAlso(notNull, containsCall);
+                        perValue = Expression.AndAlso(notNull, containsCall);
+                        perValueExpressions.Add(perValue);
                         break;
 
                     case "notcontains":
                         var notContainsCall = Expression.Call(property, containsMethod, valueConst);
-                        final = Expression.OrElse(
+                        perValue = Expression.OrElse(
                             Expression.Equal(property, nullConst),
                             Expression.Not(notContainsCall));
+                        pageSpec.FilterExpressions.Add(Expression.Lambda<Func<T, bool>>(perValue, param));
                         break;
 
                     case "equal":
-                        final = Expression.Equal(property, valueConst);
+                        perValue = Expression.Equal(property, valueConst);
+                        perValueExpressions.Add(perValue);
                         break;
 
                     case "notequal":
-                        final = Expression.NotEqual(property, valueConst);
+                        perValue = Expression.NotEqual(property, valueConst);
+                        pageSpec.FilterExpressions.Add(Expression.Lambda<Func<T, bool>>(perValue, param));
                         break;
 
                     case "startswith":
                         var startsWithCall = Expression.Call(property, startsWithMethod, valueConst);
-                        final = Expression.AndAlso(notNull, startsWithCall);
+                        perValue = Expression.AndAlso(notNull, startsWithCall);
+                        perValueExpressions.Add(perValue);
                         break;
 
                     case "notstartswith":
                         var notStartsWithCall = Expression.Call(property, startsWithMethod, valueConst);
-                        final = Expression.OrElse(
+                        perValue = Expression.OrElse(
                             Expression.Equal(property, nullConst),
                             Expression.Not(notStartsWithCall));
+                        pageSpec.FilterExpressions.Add(Expression.Lambda<Func<T, bool>>(perValue, param));
                         break;
 
                     case "endswith":
                         var endsWithCall = Expression.Call(property, endsWithMethod, valueConst);
-                        final = Expression.AndAlso(notNull, endsWithCall);
+                        perValue = Expression.AndAlso(notNull, endsWithCall);
+                        perValueExpressions.Add(perValue);
                         break;
 
                     case "notendswith":
                         var notEndsWithCall = Expression.Call(property, endsWithMethod, valueConst);
-                        final = Expression.OrElse(
+                        perValue = Expression.OrElse(
                             Expression.Equal(property, nullConst),
                             Expression.Not(notEndsWithCall));
+                        pageSpec.FilterExpressions.Add(Expression.Lambda<Func<T, bool>>(perValue, param));
                         break;
 
                     default:
                         return;
                 }
+            }
 
-                pageSpec.FilterExpressions.Add(Expression.Lambda<Func<T, bool>>(final, param));
+            // Combine positive-match expressions with OR so any term satisfies the filter.
+            if (perValueExpressions.Count > 0)
+            {
+                var combined = perValueExpressions.Aggregate(Expression.OrElse);
+                pageSpec.FilterExpressions.Add(Expression.Lambda<Func<T, bool>>(combined, param));
             }
         }
     }


### PR DESCRIPTION
#### Database Migration

<!-- If you update database schema, the migration number must be noted here -->

NO

#### Description

- FIxed the positive and begative matching ases
- Added unit tests to cover both string filter utility classes

#### Screenshot(s) (if UI related)

<details>
<!-- paste screenshots below here.-->

<!-- paste screenshots above here.  MAKE SURE THE ARE SFW -->
</details>

#### Todos

- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)

#### Issues Fixed or Closed by this PR

<!-- If multiple, put each on a separate line -->

- Fixes whisparr/whisparr#1061
