### PR TITLE
Fix: Check that file still exists before processing the manual import

### DIFF
--- a/src/NzbDrone.Core/MediaFiles/MovieImport/Manual/ManualImportService.cs
+++ b/src/NzbDrone.Core/MediaFiles/MovieImport/Manual/ManualImportService.cs
@@ -454,6 +454,12 @@ namespace NzbDrone.Core.MediaFiles.MovieImport.Manual
                 var file = message.Files[i];
                 try
                 {
+                    if (!_diskProvider.FileExists(file.Path))
+                    {
+                        _logger.Warn("File does not exist: {0}", file.Path);
+                        continue;
+                    }
+
                     var movie = _movieService.GetMovie(file.MovieId);
                     var fileMovieInfo = Parser.Parser.ParseMoviePath(file.Path) ?? new ParsedMovieInfo();
                     var existingFile = movie.Path.IsParentPath(file.Path);


### PR DESCRIPTION
#### Database Migration

NO

#### Description

Check that the file being imported still exists before wasting time processing. 

_aggregationService.Augment will eventually error if the files does not exist by better to check early in the process.

#### Screenshot(s) (if UI related)

<details>
<!-- paste screenshots below here.-->

<!-- paste screenshots above here.  MAKE SURE THE ARE SFW -->
</details>

#### Todos

- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)

#### Issues Fixed or Closed by this PR

<!-- If multiple, put each on a separate line -->

- Fixes whisparr/whisparr#XXXX
