### PR TITLE
Fix: Correct the translate of Delete Files within the modals 

### DIFF
--- a/frontend/src/Movie/Index/Select/Delete/DeleteMovieModalContent.tsx
+++ b/frontend/src/Movie/Index/Select/Delete/DeleteMovieModalContent.tsx
@@ -59,7 +59,7 @@ export function DeleteMovieModalContent({
         </FormGroup>
         <FormGroup>
           <FormLabel>
-            {translate('DeleteFilesLabel', { name: translate('All') })}
+            {translate('DeleteFiles', { name: translate('All') })}
           </FormLabel>
           <FormInputGroup
             type={inputTypes.CHECK}

--- a/frontend/src/Performer/Index/Select/Delete/DeletePerformerModalContent.tsx
+++ b/frontend/src/Performer/Index/Select/Delete/DeletePerformerModalContent.tsx
@@ -59,7 +59,7 @@ export function DeletePerformerModalContent({
         </FormGroup>
         <FormGroup>
           <FormLabel>
-            {translate('DeleteFilesLabel', { name: translate('All') })}
+            {translate('DeleteFiles', { name: translate('All') })}
           </FormLabel>
           <FormInputGroup
             type={inputTypes.CHECK}

--- a/frontend/src/Scene/Delete/DeleteSceneModalContent.js
+++ b/frontend/src/Scene/Delete/DeleteSceneModalContent.js
@@ -60,7 +60,7 @@ class DeleteSceneModalContent extends Component {
 
     let deleteFilesLabel = hasFile
       ? translate('DeleteFileLabel', [1])
-      : translate('DeleteFilesLabel', [0]);
+      : translate('DeleteFiles', [0]);
     let deleteFilesHelpText = translate('DeleteFilesHelpText');
 
     if (!hasFile) {

--- a/frontend/src/Scene/Index/Select/Delete/DeleteSceneModalContent.tsx
+++ b/frontend/src/Scene/Index/Select/Delete/DeleteSceneModalContent.tsx
@@ -59,7 +59,7 @@ export function DeleteSceneModalContent({
         </FormGroup>
         <FormGroup>
           <FormLabel>
-            {translate('DeleteFilesLabel', { name: translate('All') })}
+            {translate('DeleteFiles', { name: translate('All') })}
           </FormLabel>
           <FormInputGroup
             type={inputTypes.CHECK}


### PR DESCRIPTION
#### Database Migration

NO

#### Description

The Delete Files label was not a valid translation as it is "DeleteFile" and there is no "DeleteFilesLabel"

Do a bulk edit of scenes select some and then click on delete

#### Screenshot(s) (if UI related)

<details>
<img width="696" height="325" alt="image" src="https://github.com/user-attachments/assets/e0ef239f-b6ca-4d0a-a815-a9c8fd18e9b0" />
</details>

#### Todos

- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)

#### Issues Fixed or Closed by this PR

<!-- If multiple, put each on a separate line -->

- Fixes whisparr/whisparr#XXXX
