### PR TITLE
Feat: Add posters view to PerformerDetails page

### DIFF
--- a/frontend/src/App/State/AppState.ts
+++ b/frontend/src/App/State/AppState.ts
@@ -100,6 +100,12 @@ interface AppState {
   movieIndex: MovieIndexAppState;
   movieSearch: MovieSearchAppState;
   sceneIndex: MovieIndexAppState;
+  performerScenes: {
+    view: string;
+    posterOptions: {
+      size: string;
+    };
+  };
   performers: PerformersAppState;
   studios: StudiosAppState;
   movies: MoviesAppState;

--- a/frontend/src/Performer/Details/PerformerDetails.tsx
+++ b/frontend/src/Performer/Details/PerformerDetails.tsx
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 import React, { useState } from 'react';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { useParams } from 'react-router-dom';
 import Flag from 'react-world-flags';
 import AppState from 'App/State/AppState';
@@ -9,6 +9,9 @@ import FieldSet from 'Components/FieldSet';
 import Icon from 'Components/Icon';
 import Label from 'Components/Label';
 import LoadingIndicator from 'Components/Loading/LoadingIndicator';
+import MenuContent from 'Components/Menu/MenuContent';
+import ViewMenu from 'Components/Menu/ViewMenu';
+import ViewMenuItem from 'Components/Menu/ViewMenuItem';
 import MonitorToggleButton from 'Components/MonitorToggleButton';
 import PageContent from 'Components/Page/PageContent';
 import PageContentBody from 'Components/Page/PageContentBody';
@@ -29,6 +32,10 @@ import DeletePerformerModal from 'Performer/Delete/DeletePerformerModal';
 import PerformerGenderIcon from 'Performer/PerformerGenderIcon';
 import { getPerformerStatusDetails } from 'Performer/PerformerStatus';
 import QualityProfileName from 'Settings/Profiles/Quality/QualityProfileName';
+import {
+  setPerformerScenesPosterOption,
+  setPerformerScenesView,
+} from 'Store/Actions/performerScenesActions';
 import createUISettingsSelector from 'Store/Selectors/createUISettingsSelector';
 import formatDate from 'Utilities/Date/formatDate';
 import formatBytes from 'Utilities/Number/formatBytes';
@@ -37,7 +44,9 @@ import firstCharToUpper from 'Utilities/String/firstCharToUpper';
 import translate from 'Utilities/String/translate';
 import EditPerformerModal from '../Edit/EditPerformerModal';
 import PerformerDetailsLinks from './PerformerDetailsLinks';
+import PerformerDetailsPosters from './PerformerDetailsPosters';
 import PerformerDetailsYear from './PerformerDetailsYear';
+import PerformerPosterOptionsModal from './PerformerPosterOptionsModal';
 import PerformerTags from './PerformerTags';
 import {
   usePerformerDetails,
@@ -79,8 +88,17 @@ function PerformerDetails() {
   ).sort((a, b) => b - a);
   const currentYear = new Date().getFullYear();
 
+  const dispatch = useDispatch();
+
+  const { view, posterOptions } = useSelector(
+    (state: AppState) => state.performerScenes
+  );
+  const posterSize = posterOptions.size as 'small' | 'medium' | 'large';
+
   const [isEditMovieModalOpen, setIsEditMovieModalOpen] = useState(false);
   const [isDeleteMovieModalOpen, setIsDeleteMovieModalOpen] = useState(false);
+  const [isPosterOptionsModalOpen, setIsPosterOptionsModalOpen] =
+    useState(false);
   const [allExpandedYears, setAllExpandedYears] = useState<boolean>(false);
 
   // Initialize expandedYears so current year is expanded by default
@@ -120,6 +138,12 @@ function PerformerDetails() {
       newExpanded[year] = nextAllExpanded;
     });
     setExpandedYears(newExpanded);
+  }
+
+  function handleViewChange(newView: string) {
+    if (newView === 'table' || newView === 'posters') {
+      dispatch(setPerformerScenesView({ view: newView }));
+    }
   }
 
   // Table columns for studios (from Redux, matches legacy connector)
@@ -217,6 +241,9 @@ function PerformerDetails() {
     movies: movies.filter((m) => m.year === year),
   }));
 
+  const scenes = movies.filter((m) => m.itemType === 'scene');
+  const featureMovies = movies.filter((m) => m.itemType === 'movie');
+
   // Handlers
   function handleDeleteMovieModalClose() {
     setIsDeleteMovieModalOpen(false);
@@ -229,6 +256,15 @@ function PerformerDetails() {
   }
   function handleDeleteMoviePress() {
     setIsDeleteMovieModalOpen(true);
+  }
+  function handlePosterOptionsPress() {
+    setIsPosterOptionsModalOpen(true);
+  }
+  function handlePosterOptionsModalClose() {
+    setIsPosterOptionsModalOpen(false);
+  }
+  function handlePosterSizeChange(size: string) {
+    dispatch(setPerformerScenesPosterOption({ size }));
   }
   function handleRefreshPress() {
     onRefreshPress();
@@ -278,11 +314,41 @@ function PerformerDetails() {
           onPress={handleDeleteMoviePress}
         />
         <PageToolbarSection alignContent="right">
-          <PageToolbarButton
-            label="Expand All"
-            iconName={expandIcon}
-            onPress={handleExpandAllPress}
-          />
+          {view === 'table' ? (
+            <PageToolbarButton
+              label="Expand All"
+              iconName={expandIcon}
+              onPress={handleExpandAllPress}
+            />
+          ) : null}
+
+          {view === 'posters' ? (
+            <PageToolbarButton
+              label={translate('Options')}
+              iconName={icons.POSTER}
+              onPress={handlePosterOptionsPress}
+            />
+          ) : null}
+
+          <ViewMenu alignMenu="right">
+            <MenuContent>
+              <ViewMenuItem
+                name="table"
+                selectedView={view}
+                onPress={handleViewChange}
+              >
+                {translate('Table')}
+              </ViewMenuItem>
+
+              <ViewMenuItem
+                name="posters"
+                selectedView={view}
+                onPress={handleViewChange}
+              >
+                {translate('Posters')}
+              </ViewMenuItem>
+            </MenuContent>
+          </ViewMenu>
         </PageToolbarSection>
       </PageToolbar>
       <PageContentBody innerClassName={styles.innerContentBody}>
@@ -527,7 +593,7 @@ function PerformerDetails() {
             </Alert>
           ) : null}
           {/* Studios section (delayed render for each studio) */}
-          {movies.length > 0 && (
+          {movies.length > 0 && view === 'table' && (
             <FieldSet legend={translate('Works')}>
               {moviesByYear.map(({ year, movies: yearMovies }) => (
                 <PerformerDetailsYear
@@ -548,6 +614,28 @@ function PerformerDetails() {
               ))}
             </FieldSet>
           )}
+          {scenes.length > 0 && view === 'posters' && (
+            <FieldSet legend={translate('Scenes')}>
+              <PerformerDetailsPosters
+                items={scenes}
+                itemType="scene"
+                sortKey={sortKey}
+                sortDirection={sortDirection}
+                posterSize={posterSize}
+              />
+            </FieldSet>
+          )}
+          {featureMovies.length > 0 && view === 'posters' && (
+            <FieldSet legend={translate('Movies')}>
+              <PerformerDetailsPosters
+                items={featureMovies}
+                itemType="movie"
+                sortKey={sortKey}
+                sortDirection={sortDirection}
+                posterSize={posterSize}
+              />
+            </FieldSet>
+          )}
         </div>
         <DeletePerformerModal
           isOpen={isDeleteMovieModalOpen}
@@ -559,6 +647,12 @@ function PerformerDetails() {
           performer={performer}
           showMovieMonitor={showMovieMonitorToggle}
           onModalClose={handleEditMovieModalClose}
+        />
+        <PerformerPosterOptionsModal
+          isOpen={isPosterOptionsModalOpen}
+          size={posterSize}
+          onSizeChange={handlePosterSizeChange}
+          onModalClose={handlePosterOptionsModalClose}
         />
       </PageContentBody>
     </PageContent>

--- a/frontend/src/Performer/Details/PerformerDetailsPosters.tsx
+++ b/frontend/src/Performer/Details/PerformerDetailsPosters.tsx
@@ -1,0 +1,131 @@
+import React, { useMemo } from 'react';
+import { SelectProvider } from 'App/SelectContext';
+import useMeasure from 'Helpers/Hooks/useMeasure';
+import { SortDirection } from 'Helpers/Props/sortDirections';
+import MovieIndexPoster from 'Movie/Index/Posters/MovieIndexPoster';
+import Movie from 'Movie/Movie';
+import SceneIndexPoster from 'Scene/Index/Posters/SceneIndexPoster';
+import dimensions from 'Styles/Variables/dimensions';
+
+type PosterSize = 'small' | 'medium' | 'large';
+
+interface PerformerDetailsPostersProps {
+  items: Movie[];
+  itemType: 'scene' | 'movie';
+  sortKey: string;
+  sortDirection: SortDirection;
+  posterSize?: PosterSize;
+}
+
+const columnPadding = Number.parseInt(dimensions.movieIndexColumnPadding);
+
+const ADDITIONAL_COLUMN_COUNT: Record<PosterSize, number> = {
+  small: 3,
+  medium: 2,
+  large: 1,
+};
+
+const CONFIG = {
+  scene: {
+    maximumColumnWidth: 310,
+    aspectRatio: 170 / 300,
+  },
+  movie: {
+    maximumColumnWidth: 182,
+    aspectRatio: 250 / 170,
+  },
+};
+
+function getSortValue(movie: Movie, sortKey: string) {
+  switch (sortKey) {
+    case 'releaseDate':
+      return movie.releaseDate ?? '';
+    case 'title':
+    case 'sortTitle':
+      return movie.sortTitle ?? movie.title ?? '';
+    case 'studioTitle':
+      return movie.studioTitle ?? '';
+    default:
+      return movie.releaseDate ?? '';
+  }
+}
+
+function PerformerDetailsPosters(props: PerformerDetailsPostersProps) {
+  const {
+    items,
+    itemType,
+    sortKey,
+    sortDirection,
+    posterSize = 'large',
+  } = props;
+  const [measureRef, bounds] = useMeasure();
+
+  const { maximumColumnWidth, aspectRatio } = CONFIG[itemType];
+
+  const columnWidth = useMemo(() => {
+    const width = bounds.width || 0;
+    if (!width) return maximumColumnWidth;
+    const columns = Math.floor(width / maximumColumnWidth);
+    const remainder = width % maximumColumnWidth;
+    return remainder === 0
+      ? maximumColumnWidth
+      : Math.floor(width / (columns + ADDITIONAL_COLUMN_COUNT[posterSize]));
+  }, [maximumColumnWidth, posterSize, bounds]);
+
+  const posterWidth = columnWidth - columnPadding * 2;
+  const posterHeight = Math.ceil(aspectRatio * posterWidth);
+
+  const sorted = [...items].sort((a, b) => {
+    const aVal = getSortValue(a, sortKey);
+    const bVal = getSortValue(b, sortKey);
+
+    let cmp = 0;
+    if (aVal < bVal) cmp = -1;
+    else if (aVal > bVal) cmp = 1;
+
+    return sortDirection === 'ascending' ? cmp : -cmp;
+  });
+
+  const grid = (
+    <div ref={measureRef}>
+      <div style={{ display: 'flex', flexWrap: 'wrap' }}>
+        {sorted.map((item) => (
+          <div
+            key={item.id}
+            style={{
+              width: columnWidth,
+              padding: columnPadding,
+              boxSizing: 'border-box',
+            }}
+          >
+            {itemType === 'scene' ? (
+              <SceneIndexPoster
+                scene={item}
+                sortKey={sortKey}
+                isSelectMode={false}
+                posterWidth={posterWidth}
+                posterHeight={posterHeight}
+              />
+            ) : (
+              <MovieIndexPoster
+                movie={item}
+                sortKey={sortKey}
+                isSelectMode={false}
+                posterWidth={posterWidth}
+                posterHeight={posterHeight}
+              />
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+
+  return itemType === 'movie' ? (
+    <SelectProvider items={sorted}>{grid}</SelectProvider>
+  ) : (
+    grid
+  );
+}
+
+export default PerformerDetailsPosters;

--- a/frontend/src/Performer/Details/PerformerPosterOptionsModal.tsx
+++ b/frontend/src/Performer/Details/PerformerPosterOptionsModal.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import Modal from 'Components/Modal/Modal';
+import PerformerPosterOptionsModalContent from './PerformerPosterOptionsModalContent';
+
+interface PerformerPosterOptionsModalProps {
+  isOpen: boolean;
+  size: string;
+  onSizeChange(size: string): void;
+  onModalClose(...args: unknown[]): unknown;
+}
+
+function PerformerPosterOptionsModal({
+  isOpen,
+  size,
+  onSizeChange,
+  onModalClose,
+}: PerformerPosterOptionsModalProps) {
+  return (
+    <Modal isOpen={isOpen} onModalClose={onModalClose}>
+      <PerformerPosterOptionsModalContent
+        size={size}
+        onSizeChange={onSizeChange}
+        onModalClose={onModalClose}
+      />
+    </Modal>
+  );
+}
+
+export default PerformerPosterOptionsModal;

--- a/frontend/src/Performer/Details/PerformerPosterOptionsModalContent.tsx
+++ b/frontend/src/Performer/Details/PerformerPosterOptionsModalContent.tsx
@@ -1,0 +1,80 @@
+import React, { useCallback } from 'react';
+import Form from 'Components/Form/Form';
+import FormGroup from 'Components/Form/FormGroup';
+import FormInputGroup from 'Components/Form/FormInputGroup';
+import FormLabel from 'Components/Form/FormLabel';
+import Button from 'Components/Link/Button';
+import ModalBody from 'Components/Modal/ModalBody';
+import ModalContent from 'Components/Modal/ModalContent';
+import ModalFooter from 'Components/Modal/ModalFooter';
+import ModalHeader from 'Components/Modal/ModalHeader';
+import { inputTypes } from 'Helpers/Props';
+import translate from 'Utilities/String/translate';
+
+const posterSizeOptions = [
+  {
+    key: 'small',
+    get value() {
+      return translate('Small');
+    },
+  },
+  {
+    key: 'medium',
+    get value() {
+      return translate('Medium');
+    },
+  },
+  {
+    key: 'large',
+    get value() {
+      return translate('Large');
+    },
+  },
+];
+
+interface PerformerPosterOptionsModalContentProps {
+  size: string;
+  onSizeChange(size: string): void;
+  onModalClose(...args: unknown[]): unknown;
+}
+
+function PerformerPosterOptionsModalContent(
+  props: PerformerPosterOptionsModalContentProps
+) {
+  const { size, onSizeChange, onModalClose } = props;
+
+  const onPosterOptionChange = useCallback(
+    ({ value }: { name: string; value: string }) => {
+      onSizeChange(value);
+    },
+    [onSizeChange]
+  );
+
+  return (
+    <ModalContent onModalClose={onModalClose}>
+      <ModalHeader>{translate('PosterOptions')}</ModalHeader>
+
+      <ModalBody>
+        <Form>
+          <FormGroup>
+            <FormLabel>{translate('PosterSize')}</FormLabel>
+
+            <FormInputGroup
+              type={inputTypes.SELECT}
+              name="size"
+              value={size}
+              values={posterSizeOptions}
+              onChange={onPosterOptionChange}
+            />
+          </FormGroup>
+        </Form>
+      </ModalBody>
+
+      <ModalFooter>
+        <Button onPress={onModalClose}>{translate('Close')}</Button>
+      </ModalFooter>
+    </ModalContent>
+  );
+}
+
+export default PerformerPosterOptionsModalContent;

--- a/frontend/src/Store/Actions/performerScenesActions.js
+++ b/frontend/src/Store/Actions/performerScenesActions.js
@@ -18,6 +18,11 @@ export const defaultState = {
   sortDirection: sortDirections.DESCENDING,
   secondarySortKey: 'title',
   secondarySortDirection: sortDirections.ASCENDING,
+  view: 'table',
+
+  posterOptions: {
+    size: 'large',
+  },
 
   columns: [
     {
@@ -97,6 +102,8 @@ export const persistState = [
   'performerScenes.sortDirection',
   'performerScenes.columns',
   'performerScenes.tableOptions',
+  'performerScenes.view',
+  'performerScenes.posterOptions',
 ];
 
 //
@@ -106,6 +113,10 @@ export const SET_PERFORMER_SCENES_SORT =
   'performerScenes/setPerformerScenesSort';
 export const SET_PERFORMER_SCENES_TABLE_OPTION =
   'performerScenes/setPerformerScenesTableOption';
+export const SET_PERFORMER_SCENES_VIEW =
+  'performerScenes/setPerformerScenesView';
+export const SET_PERFORMER_SCENES_POSTER_OPTION =
+  'performerScenes/setPerformerScenesPosterOption';
 
 //
 // Action Creators
@@ -113,6 +124,10 @@ export const SET_PERFORMER_SCENES_TABLE_OPTION =
 export const setPerformerScenesSort = createAction(SET_PERFORMER_SCENES_SORT);
 export const setPerformerScenesTableOption = createAction(
   SET_PERFORMER_SCENES_TABLE_OPTION
+);
+export const setPerformerScenesView = createAction(SET_PERFORMER_SCENES_VIEW);
+export const setPerformerScenesPosterOption = createAction(
+  SET_PERFORMER_SCENES_POSTER_OPTION
 );
 
 //
@@ -124,6 +139,20 @@ export const reducers = createHandleActions(
       createSetClientSideCollectionSortReducer(section),
 
     [SET_PERFORMER_SCENES_TABLE_OPTION]: createSetTableOptionReducer(section),
+
+    [SET_PERFORMER_SCENES_VIEW]: function (state, { payload }) {
+      return { ...state, view: payload.view };
+    },
+
+    [SET_PERFORMER_SCENES_POSTER_OPTION]: function (state, { payload }) {
+      return {
+        ...state,
+        posterOptions: {
+          ...state.posterOptions,
+          ...payload,
+        },
+      };
+    },
   },
   defaultState,
   section


### PR DESCRIPTION
#### Database Migration

<!-- If you update database schema, the migration number must be noted here -->

NO

#### Description

Added PerformerDetailsPosters component which uses ScenePoster and MoviePoster to render poster views of all the performers works similar to SceneIndexPosters and MovieIndexPosters views. 

This is my second attempt pushing this change. I've reworked it to reuse the existing components as discussed and personally vetted and tested the code better. I did make sure to update the app state to include whatever view settings are set by the user. I'm not super familiar with typescript so a second set of eyes is definitely needed.

I made the decision to place movies below scenes rather than have them mixed in and force them to use the scene poster thumbnail aspect ratio, but I'm open to suggestions on better ways to deal with this.

#### Screenshot(s) (if UI related)

<details>
<!-- paste screenshots below here.-->

<img width="1824" height="2160" alt="20260329_15h21m01s_grim" src="https://github.com/user-attachments/assets/42dd4633-090a-42d1-af39-a6e2c7fea681" />
<img width="1848" height="2076" alt="20260329_15h21m16s_grim" src="https://github.com/user-attachments/assets/7a311ca5-31ab-41c3-82ab-002f9ffeb3f3" />

<!-- paste screenshots above here.  MAKE SURE THE ARE SFW -->
</details>

#### Todos

- [x] Tested locally
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] Consider making scenes/movies collapsible or toggleable. Right now movies are shown after scenes
- [ ] Consider making pageable like SceneIndex

#### Issues Fixed or Closed by this PR

<!-- If multiple, put each on a separate line -->

- Fixes whisparr/whisparr#284

Note: not an exact fix. This change doesn't allow filtering by multiple performers (useful for performing bulk actions for multiple performers' scenes at once) but does allow viewing posters for one performer at a time (useful for browsing and deciding what to download).