### PR TITLE
Chore: Allow dotnet roll-forward policy on CI runners

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,5 +1,6 @@
 {
     "sdk": {
-        "version": "10.0.101"
+        "version": "10.0.101",
+        "rollForward": "latestFeature"
     }
 }


### PR DESCRIPTION
#### Database Migration

<!-- If you update database schema, the migration number must be noted here -->

NO

#### Description

GH workflows that use setup-dotnet have to install the SDK on every run if the runer doesn't have our specific SDK version pre-installed (they don't), because our policy pinned to a specific patch number like 10.0.101.  This change allows the runner to use any pre-installed 10.0.xxx variant, which saves on workflow run times at roughly 30-60s per-run, per-worker, since the runners do have 10.0.xxx pre-installed.

#### Screenshot(s) (if UI related)

<details>
<!-- paste screenshots below here.-->

<!-- paste screenshots above here.  MAKE SURE THE ARE SFW -->
</details>

#### Todos

- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)

#### Issues Fixed or Closed by this PR

<!-- If multiple, put each on a separate line -->

- Fixes whisparr/whisparr#XXXX
