### PR TITLE
refactor: modernize studio and performer lookups, nuke redux boilerplate

### DIFF
--- a/frontend/src/Performer/AddPerformer/AddNewPerformer.tsx
+++ b/frontend/src/Performer/AddPerformer/AddNewPerformer.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { Error } from 'App/State/AppSectionState';
 import Alert from 'Components/Alert';
 import TextInput from 'Components/Form/TextInput';
 import Icon from 'Components/Icon';
@@ -10,7 +9,6 @@ import PageContent from 'Components/Page/PageContent';
 import PageContentBody from 'Components/Page/PageContentBody';
 import { icons, kinds } from 'Helpers/Props';
 import Performer from 'Performer/Performer';
-import getErrorMessage from 'Utilities/Object/getErrorMessage';
 import translate from 'Utilities/String/translate';
 import AddNewPerformerSearchResult from './AddNewPerformerSearchResult';
 import useAddNewPerformer from './useAddNewPerformer';
@@ -66,7 +64,7 @@ function AddNewPerformer() {
               {translate('YouCanAlsoSearchPerformer')}
             </div>
             <Alert kind={kinds.WARNING}>
-              {getErrorMessage(error as Error)}
+              {error?.statusBody?.message ?? error?.message ?? ''}
             </Alert>
             <div>
               <Link to="https://wiki.servarr.com/whisparr/troubleshooting#invalid-response-received-from-tmdb">

--- a/frontend/src/Performer/AddPerformer/AddNewPerformerModal.tsx
+++ b/frontend/src/Performer/AddPerformer/AddNewPerformerModal.tsx
@@ -1,11 +1,13 @@
 import React from 'react';
 import Modal from 'Components/Modal/Modal';
 import { Image } from 'Movie/Movie';
+import Performer from 'Performer/Performer';
 import AddNewPerformerModalContent from './AddNewPerformerModalContent';
 
 interface AddNewPerformerModalProps {
   isOpen: boolean;
   onModalClose: () => void;
+  performer: Performer;
   foreignId: string;
   fullName: string;
   images: Image[];
@@ -14,6 +16,7 @@ interface AddNewPerformerModalProps {
 function AddNewPerformerModal({
   isOpen,
   onModalClose,
+  performer,
   foreignId,
   fullName,
   images,
@@ -21,6 +24,7 @@ function AddNewPerformerModal({
   return (
     <Modal isOpen={isOpen} onModalClose={onModalClose}>
       <AddNewPerformerModalContent
+        performer={performer}
         foreignId={foreignId}
         fullName={fullName}
         images={images}

--- a/frontend/src/Performer/AddPerformer/AddNewPerformerModalContent.tsx
+++ b/frontend/src/Performer/AddPerformer/AddNewPerformerModalContent.tsx
@@ -12,12 +12,14 @@ import ModalHeader from 'Components/Modal/ModalHeader';
 import { inputTypes, kinds } from 'Helpers/Props';
 import { Image } from 'Movie/Movie';
 import MovieHeadshot from 'Movie/MovieHeadshot';
+import Performer from 'Performer/Performer';
 import { EnhancedSelectInputChanged } from 'typings/inputs';
 import translate from 'Utilities/String/translate';
 import { useAddNewPerformerModalContent } from './useAddNewPerformer';
 import styles from './AddNewPerformerModalContent.css';
 
 interface AddNewPerformerModalContentProps {
+  performer: Performer;
   foreignId: string;
   fullName: string;
   images: Image[];
@@ -25,7 +27,7 @@ interface AddNewPerformerModalContentProps {
 }
 
 function AddNewPerformerModalContent({
-  foreignId,
+  performer,
   fullName,
   images,
   onModalClose,
@@ -38,7 +40,7 @@ function AddNewPerformerModalContent({
     settings,
     onInputChange,
     onAddPerformerPress,
-  } = useAddNewPerformerModalContent(foreignId);
+  } = useAddNewPerformerModalContent(performer);
 
   const {
     rootFolderPath,

--- a/frontend/src/Performer/AddPerformer/AddNewPerformerSearchResult.tsx
+++ b/frontend/src/Performer/AddPerformer/AddNewPerformerSearchResult.tsx
@@ -138,6 +138,7 @@ function AddNewPerformerSearchResult({
       </div>
       <AddNewPerformerModal
         isOpen={isNewAddPerformerModalOpen && !isExistingPerformer}
+        performer={performer}
         foreignId={foreignId}
         fullName={fullName}
         images={images || []}

--- a/frontend/src/Performer/AddPerformer/useAddNewPerformer.ts
+++ b/frontend/src/Performer/AddPerformer/useAddNewPerformer.ts
@@ -1,15 +1,15 @@
-import React, { useState } from 'react';
+import { useMutation } from '@tanstack/react-query';
+import { cloneDeep } from 'lodash';
+import React, { useRef, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { Error as AppError } from 'App/State/AppSectionState';
+import { queryClient } from 'App/queryClient';
 import AppState from 'App/State/AppState';
 import { ValidationMessage } from 'Components/Form/FormInputGroup';
+import useApiQuery from 'Helpers/Hooks/useApiQuery';
 import Performer from 'Performer/Performer';
 import {
-  addPerformer,
   clearAddPerformer,
-  lookupPerformer,
   setAddPerformerDefault,
-  setPerformersWithStatus,
 } from 'Store/Actions/addPerformerActions';
 import {
   clearQueueDetails,
@@ -21,18 +21,16 @@ import createSystemStatusSelector from 'Store/Selectors/createSystemStatusSelect
 import createUISettingsSelector from 'Store/Selectors/createUISettingsSelector';
 import selectSettings from 'Store/Selectors/selectSettings';
 import { InputChanged } from 'typings/inputs';
-import createAjaxRequest from 'Utilities/createAjaxRequest';
+import fetchJson, {
+  ApiError,
+  apiRoot,
+  urlBase,
+} from 'Utilities/Fetch/fetchJson';
+import getNewPerformer from 'Utilities/Performer/getNewPerformer';
 
 export interface PerformerWithExistingStatus {
   performer: Performer;
   isExistingPerformer: boolean;
-}
-
-interface LookupPerformerItem {
-  foreignId: string;
-  performer: Performer;
-  id: string;
-  internalId: number;
 }
 
 interface PerformerDefaults {
@@ -61,22 +59,6 @@ interface AddPerformerSettings {
   tags: SettingValue<number[]>;
 }
 
-interface AddPerformerState {
-  isPopulated: boolean;
-  error: AppError | null;
-  isAdding: boolean;
-  isFetching: boolean;
-  isAdded: boolean;
-  addError: AppError | null;
-  items: LookupPerformerItem[];
-  performersWithStatus: PerformerWithExistingStatus[];
-  performerDefaults: PerformerDefaults;
-}
-
-type RootState = AppState & {
-  addPerformer: AddPerformerState;
-};
-
 const defaultPerformerDefaults: PerformerDefaults = {
   rootFolderPath: '',
   monitored: true,
@@ -86,25 +68,39 @@ const defaultPerformerDefaults: PerformerDefaults = {
   tags: [],
 };
 
+const AUTH_HEADERS = {
+  'X-Api-Key': window.Whisparr.apiKey,
+  'X-Whisparr-Client': 'Whisparr',
+};
+
+function apiPost<T, TBody>(path: string, body: TBody): Promise<T> {
+  return fetchJson<T, TBody>({
+    path: `${urlBase}${apiRoot}${path}`,
+    method: 'POST',
+    body,
+    headers: AUTH_HEADERS,
+  });
+}
+
+interface SearchResource {
+  foreignId: string;
+  performer: Performer;
+  isExisting: boolean;
+}
+
 function useAddNewPerformer() {
   const dispatch = useDispatch();
-  const addPerformer = useSelector((state: RootState) => state.addPerformer);
   const uiSettings = useSelector(createUISettingsSelector());
-  const existingPerformersCount = useSelector(
-    (state: AppState) => state.performers.items.length
-  );
   const [term, setTerm] = useState('');
-
-  const performerLookupTimeout = React.useRef<ReturnType<
-    typeof setTimeout
-  > | null>(null);
+  const [debouncedTerm, setDebouncedTerm] = useState('');
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   React.useEffect(() => {
     dispatch(fetchRootFolders());
     dispatch(fetchQueueDetails());
     return () => {
-      if (performerLookupTimeout.current) {
-        clearTimeout(performerLookupTimeout.current);
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
       }
       dispatch(clearAddPerformer());
       dispatch(clearQueueDetails());
@@ -112,86 +108,28 @@ function useAddNewPerformer() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const lastRequestedIdsRef = React.useRef<string>('');
-  const hadNonEmptyItemsRef = React.useRef<boolean>(false);
-
-  // When lookup results change, check which performers already exist
-  React.useEffect(() => {
-    const items = addPerformer?.items;
-
-    if (items && items.length > 0) {
-      const foreignIds = items
-        .map((item: LookupPerformerItem) => item.performer.foreignId)
-        .filter((id: string | undefined): id is string => !!id);
-
-      if (foreignIds.length > 0) {
-        // cache key covers both the queried ids and the current performer count, so
-        // we re-fetch when either changes (e.g. user just added a performer)
-        const key = `${existingPerformersCount}|${foreignIds.slice().sort().join('|')}`;
-        if (key === lastRequestedIdsRef.current) {
-          return;
-        }
-        lastRequestedIdsRef.current = key;
-        hadNonEmptyItemsRef.current = true;
-
-        const { request } = createAjaxRequest({
-          url: '/performer/list',
-          method: 'POST',
-          contentType: 'application/json',
-          data: JSON.stringify(foreignIds),
-        });
-
-        request.done((existingPerformers: Performer[]) => {
-          // Create a map of foreignId to full performer object
-          const existingPerformerMap = new Map(
-            existingPerformers.map((p) => [p.foreignId, p])
-          );
-
-          // Map over lookup items, using full performer data if available
-          const mapped = items.map((item: LookupPerformerItem) => {
-            const fullPerformer = existingPerformerMap.get(
-              item.performer.foreignId
-            );
-            return {
-              performer: fullPerformer || item.performer,
-              isExistingPerformer: !!fullPerformer,
-            };
-          });
-
-          dispatch(setPerformersWithStatus(mapped));
-        });
-
-        request.fail(() => {
-          // If the request fails, assume none exist
-          const mapped = items.map(
-            (item: LookupPerformerItem) => ({
-              performer: item.performer,
-              isExistingPerformer: false,
-            })
-          );
-
-          dispatch(setPerformersWithStatus(mapped));
-        });
-      }
-    } else if (hadNonEmptyItemsRef.current) {
-      hadNonEmptyItemsRef.current = false;
-      lastRequestedIdsRef.current = '';
-      dispatch(setPerformersWithStatus([]));
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [addPerformer?.items, existingPerformersCount, dispatch]);
+  const {
+    data: searchResources = [],
+    isFetching,
+    error,
+  } = useApiQuery<SearchResource[]>({
+    path: '/lookup/performer',
+    queryParams: { term: debouncedTerm },
+    queryOptions: { enabled: !!debouncedTerm.trim() },
+  });
 
   const onPerformerLookupChange = React.useCallback(
     (value: string) => {
       setTerm(value);
-      if (performerLookupTimeout.current) {
-        clearTimeout(performerLookupTimeout.current);
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
       }
       if (value.trim() === '') {
+        setDebouncedTerm('');
         dispatch(clearAddPerformer());
       } else {
-        performerLookupTimeout.current = setTimeout(() => {
-          dispatch(lookupPerformer({ term: value }));
+        timeoutRef.current = setTimeout(() => {
+          setDebouncedTerm(value);
         }, 300);
       }
     },
@@ -200,18 +138,22 @@ function useAddNewPerformer() {
 
   const onClearPerformerLookupPress = React.useCallback(() => {
     setTerm('');
+    setDebouncedTerm('');
     dispatch(clearAddPerformer());
   }, [dispatch]);
 
   return {
-    isPopulated: addPerformer?.isPopulated || false,
-    error: addPerformer?.error,
-    isAdding: addPerformer?.isAdding || false,
-    isFetching: addPerformer?.isFetching || false,
-    isAdded: addPerformer?.isAdded || false,
-    addError: addPerformer?.addError,
-    items: addPerformer?.items || [],
-    performersWithStatus: addPerformer?.performersWithStatus || [],
+    isPopulated: !!debouncedTerm.trim() && !isFetching,
+    error,
+    isAdding: false,
+    isFetching: isFetching && !!debouncedTerm.trim(),
+    isAdded: false,
+    addError: null,
+    items: searchResources,
+    performersWithStatus: searchResources.map((r) => ({
+      performer: r.performer,
+      isExistingPerformer: r.isExisting,
+    })),
     term,
     colorImpairedMode: uiSettings.enableColorImpairedMode,
     onPerformerLookupChange,
@@ -231,27 +173,42 @@ export function useAddNewPerformerSearchResult() {
   };
 }
 
-export function useAddNewPerformerModalContent(foreignId: string) {
+export function useAddNewPerformerModalContent(performer: Performer) {
   const dispatch = useDispatch();
   const { isSmallScreen } = useSelector(createDimensionsSelector());
   const systemStatus = useSelector(createSystemStatusSelector());
   const safeForWorkMode = useSelector(
     (state: AppState) => state.settings.safeForWorkMode
   );
+
   const addPerformerState = useSelector(
-    (state: RootState) => state.addPerformer
+    (
+      state: AppState & {
+        addPerformer: {
+          performerDefaults: PerformerDefaults;
+          addError?: ApiError;
+        };
+      }
+    ) => state.addPerformer
   );
 
-  const {
-    isAdding = false,
-    addError,
-    performerDefaults = defaultPerformerDefaults,
-  } = addPerformerState || {};
+  const { performerDefaults = defaultPerformerDefaults } =
+    addPerformerState || {};
+
+  const mutation = useMutation<Performer, ApiError, Performer>({
+    mutationFn: (performerToAdd: Performer) => {
+      return apiPost<Performer, Performer>('/performer', performerToAdd);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['/performer/paged'] });
+      queryClient.invalidateQueries({ queryKey: ['/lookup/performer'] });
+    },
+  });
 
   const { settings, validationErrors, validationWarnings } = selectSettings(
     performerDefaults,
     {},
-    addError
+    mutation.error
   ) as {
     settings: AddPerformerSettings;
     validationErrors: unknown[];
@@ -266,22 +223,21 @@ export function useAddNewPerformerModalContent(foreignId: string) {
   );
 
   const onAddPerformerPress = React.useCallback(() => {
-    dispatch(
-      addPerformer({
-        foreignId,
-        rootFolderPath: settings.rootFolderPath.value,
-        monitored: settings.monitored.value === true,
-        moviesMonitored: settings.moviesMonitored.value === true,
-        qualityProfileId: settings.qualityProfileId.value,
-        searchForMovie: settings.searchForMovie.value,
-        tags: settings.tags.value,
-      })
-    );
-  }, [dispatch, foreignId, settings]);
+    const performerToAdd = getNewPerformer(cloneDeep(performer) as object, {
+      rootFolderPath: settings.rootFolderPath.value,
+      monitored: settings.monitored.value === true,
+      moviesMonitored: settings.moviesMonitored.value === true,
+      qualityProfileId: settings.qualityProfileId.value,
+      searchForMovie: settings.searchForMovie.value,
+      tags: settings.tags.value,
+    }) as Performer;
+    performerToAdd.id = 0;
+    mutation.mutate(performerToAdd);
+  }, [performer, settings, mutation]);
 
   return {
-    addError,
-    isAdding,
+    addError: mutation.error,
+    isAdding: mutation.isPending,
     isSmallScreen,
     isWindows: systemStatus.isWindows,
     safeForWorkMode,

--- a/frontend/src/Performer/AddPerformer/useAddNewPerformer.ts
+++ b/frontend/src/Performer/AddPerformer/useAddNewPerformer.ts
@@ -90,6 +90,9 @@ function useAddNewPerformer() {
   const dispatch = useDispatch();
   const addPerformer = useSelector((state: RootState) => state.addPerformer);
   const uiSettings = useSelector(createUISettingsSelector());
+  const existingPerformersCount = useSelector(
+    (state: AppState) => state.performers.items.length
+  );
   const [term, setTerm] = useState('');
 
   const performerLookupTimeout = React.useRef<ReturnType<
@@ -109,14 +112,28 @@ function useAddNewPerformer() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  const lastRequestedIdsRef = React.useRef<string>('');
+  const hadNonEmptyItemsRef = React.useRef<boolean>(false);
+
   // When lookup results change, check which performers already exist
   React.useEffect(() => {
-    if (addPerformer?.items && addPerformer.items.length > 0) {
-      const foreignIds = addPerformer.items
+    const items = addPerformer?.items;
+
+    if (items && items.length > 0) {
+      const foreignIds = items
         .map((item: LookupPerformerItem) => item.performer.foreignId)
-        .filter((id: string | undefined) => id);
+        .filter((id: string | undefined): id is string => !!id);
 
       if (foreignIds.length > 0) {
+        // cache key covers both the queried ids and the current performer count, so
+        // we re-fetch when either changes (e.g. user just added a performer)
+        const key = `${existingPerformersCount}|${foreignIds.slice().sort().join('|')}`;
+        if (key === lastRequestedIdsRef.current) {
+          return;
+        }
+        lastRequestedIdsRef.current = key;
+        hadNonEmptyItemsRef.current = true;
+
         const { request } = createAjaxRequest({
           url: '/performer/list',
           method: 'POST',
@@ -131,7 +148,7 @@ function useAddNewPerformer() {
           );
 
           // Map over lookup items, using full performer data if available
-          const mapped = addPerformer.items.map((item: LookupPerformerItem) => {
+          const mapped = items.map((item: LookupPerformerItem) => {
             const fullPerformer = existingPerformerMap.get(
               item.performer.foreignId
             );
@@ -146,7 +163,7 @@ function useAddNewPerformer() {
 
         request.fail(() => {
           // If the request fails, assume none exist
-          const mapped = addPerformer.items.map(
+          const mapped = items.map(
             (item: LookupPerformerItem) => ({
               performer: item.performer,
               isExistingPerformer: false,
@@ -156,10 +173,13 @@ function useAddNewPerformer() {
           dispatch(setPerformersWithStatus(mapped));
         });
       }
-    } else {
+    } else if (hadNonEmptyItemsRef.current) {
+      hadNonEmptyItemsRef.current = false;
+      lastRequestedIdsRef.current = '';
       dispatch(setPerformersWithStatus([]));
     }
-  }, [addPerformer?.items, addPerformer, dispatch]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [addPerformer?.items, existingPerformersCount, dispatch]);
 
   const onPerformerLookupChange = React.useCallback(
     (value: string) => {

--- a/frontend/src/Performer/AddPerformer/useAddNewPerformer.ts
+++ b/frontend/src/Performer/AddPerformer/useAddNewPerformer.ts
@@ -8,7 +8,6 @@ import { ValidationMessage } from 'Components/Form/FormInputGroup';
 import useApiQuery from 'Helpers/Hooks/useApiQuery';
 import Performer from 'Performer/Performer';
 import {
-  clearAddPerformer,
   setAddPerformerDefault,
 } from 'Store/Actions/addPerformerActions';
 import {
@@ -102,7 +101,6 @@ function useAddNewPerformer() {
       if (timeoutRef.current) {
         clearTimeout(timeoutRef.current);
       }
-      dispatch(clearAddPerformer());
       dispatch(clearQueueDetails());
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -126,7 +124,6 @@ function useAddNewPerformer() {
       }
       if (value.trim() === '') {
         setDebouncedTerm('');
-        dispatch(clearAddPerformer());
       } else {
         timeoutRef.current = setTimeout(() => {
           setDebouncedTerm(value);
@@ -139,8 +136,7 @@ function useAddNewPerformer() {
   const onClearPerformerLookupPress = React.useCallback(() => {
     setTerm('');
     setDebouncedTerm('');
-    dispatch(clearAddPerformer());
-  }, [dispatch]);
+  }, []);
 
   return {
     isPopulated: !!debouncedTerm.trim() && !isFetching,

--- a/frontend/src/Store/Actions/addMovieActions.js
+++ b/frontend/src/Store/Actions/addMovieActions.js
@@ -1,35 +1,20 @@
-import _ from 'lodash';
 import { createAction } from 'redux-actions';
-import { batchActions } from 'redux-batched-actions';
-import { createThunk, handleThunks } from 'Store/thunks';
-import createAjaxRequest from 'Utilities/createAjaxRequest';
-import getNewPerformer from 'Utilities/Performer/getNewPerformer';
 import getSectionState from 'Utilities/State/getSectionState';
 import updateSectionState from 'Utilities/State/updateSectionState';
-import getNewStudio from 'Utilities/Studio/getNewStudio';
-import { set, update, updateItem } from './baseActions';
 import createHandleActions from './Creators/createHandleActions';
 import createSetSettingValueReducer from './Creators/Reducers/createSetSettingValueReducer';
 
 //
 // Variables
+//
 
 export const section = 'addMovie';
-let abortCurrentRequest = null;
 
 //
 // State
+//
 
 export const defaultState = {
-  isFetching: false,
-  isPopulated: false,
-  error: null,
-  isAdding: false,
-  isAdded: false,
-  addError: null,
-  items: [],
-  studiosWithStatus: [],
-
   movieDefaults: {
     rootFolderPath: '',
     monitor: 'movieOnly',
@@ -64,32 +49,22 @@ export const persistState = [
 
 //
 // Actions Types
+//
 
-export const LOOKUP_STUDIO = 'addMovie/lookupStudio';
-export const LOOKUP_PERFORMER = 'addMovie/lookupPerformer';
-export const ADD_PERFORMER = 'addMovie/addPerformer';
-export const ADD_STUDIO = 'addMovie/addStudio';
 export const SET_ADD_MOVIE_VALUE = 'addMovie/setAddMovieValue';
 export const SET_ADD_PERFORMER_VALUE = 'addMovie/setAddPerformerValue';
 export const SET_ADD_STUDIO_VALUE = 'addMovie/setAddStudioValue';
-export const CLEAR_ADD_MOVIE = 'addMovie/clearAddMovie';
 export const SET_ADD_MOVIE_DEFAULT = 'addMovie/setAddMovieDefault';
 export const SET_ADD_PERFORMER_DEFAULT = 'addMovie/setAddPerformerDefault';
 export const SET_ADD_STUDIO_DEFAULT = 'addMovie/setAddStudioDefault';
-export const SET_STUDIOS_WITH_STATUS = 'addMovie/setStudiosWithStatus';
 
 //
 // Action Creators
+//
 
-export const lookupStudio = createThunk(LOOKUP_STUDIO);
-export const lookupPerformer = createThunk(LOOKUP_PERFORMER);
-export const addPerformer = createThunk(ADD_PERFORMER);
-export const addStudio = createThunk(ADD_STUDIO);
-export const clearAddMovie = createAction(CLEAR_ADD_MOVIE);
 export const setAddMovieDefault = createAction(SET_ADD_MOVIE_DEFAULT);
 export const setAddPerformerDefault = createAction(SET_ADD_PERFORMER_DEFAULT);
 export const setAddStudioDefault = createAction(SET_ADD_STUDIO_DEFAULT);
-export const setStudiosWithStatus = createAction(SET_STUDIOS_WITH_STATUS);
 
 export const setAddMovieValue = createAction(SET_ADD_MOVIE_VALUE, (payload) => {
   return {
@@ -115,214 +90,10 @@ export const setAddStudioValue = createAction(
     };
   }
 );
-//
-// Action Handlers
-
-export const actionHandlers = handleThunks({
-  [LOOKUP_STUDIO]: function (getState, payload, dispatch) {
-    dispatch(set({ section, isFetching: true }));
-
-    if (abortCurrentRequest) {
-      abortCurrentRequest();
-    }
-
-    const { request, abortRequest } = createAjaxRequest({
-      url: '/lookup/studio',
-      data: {
-        term: payload.term,
-      },
-    });
-
-    abortCurrentRequest = abortRequest;
-
-    request.done((data) => {
-      data = data.map((movie) => ({
-        ...movie,
-        internalId: movie.id,
-        id: movie.foreignId,
-      }));
-
-      dispatch(
-        batchActions([
-          update({ section, data }),
-
-          set({
-            section,
-            isFetching: false,
-            isPopulated: true,
-            error: null,
-          }),
-        ])
-      );
-    });
-
-    request.fail((xhr) => {
-      dispatch(
-        set({
-          section,
-          isFetching: false,
-          isPopulated: false,
-          error: xhr.aborted ? null : xhr,
-        })
-      );
-    });
-  },
-
-  [LOOKUP_PERFORMER]: function (getState, payload, dispatch) {
-    dispatch(set({ section, isFetching: true }));
-
-    if (abortCurrentRequest) {
-      abortCurrentRequest();
-    }
-
-    const { request, abortRequest } = createAjaxRequest({
-      url: '/lookup/performer',
-      data: {
-        term: payload.term,
-      },
-    });
-
-    abortCurrentRequest = abortRequest;
-
-    request.done((data) => {
-      data = data.map((movie) => ({
-        ...movie,
-        internalId: movie.id,
-        id: movie.foreignId,
-      }));
-
-      dispatch(
-        batchActions([
-          update({ section, data }),
-
-          set({
-            section,
-            isFetching: false,
-            isPopulated: true,
-            error: null,
-          }),
-        ])
-      );
-    });
-
-    request.fail((xhr) => {
-      dispatch(
-        set({
-          section,
-          isFetching: false,
-          isPopulated: false,
-          error: xhr.aborted ? null : xhr,
-        })
-      );
-    });
-  },
-
-  [ADD_PERFORMER]: function (getState, payload, dispatch) {
-    dispatch(set({ section, isAdding: true }));
-
-    const foreignId = payload.foreignId;
-    const items = getState().addMovie.items;
-    const itemToAdd = _.find(items, { foreignId });
-    const newPerformer = getNewPerformer(
-      _.cloneDeep(itemToAdd.performer),
-      payload
-    );
-    newPerformer.id = 0;
-
-    const promise = createAjaxRequest({
-      url: '/performer',
-      method: 'POST',
-      dataType: 'json',
-      contentType: 'application/json',
-      data: JSON.stringify(newPerformer),
-    }).request;
-
-    promise.done((data) => {
-      const updatedItem = _.cloneDeep(data);
-      updatedItem.internalId = updatedItem.id;
-      updatedItem.id = updatedItem.foreignId;
-      delete updatedItem.images;
-
-      const actions = [
-        updateItem({ section: 'performers', ...data }),
-        updateItem({ section: 'addMovie', ...updatedItem }),
-
-        set({
-          section,
-          isAdding: false,
-          isAdded: true,
-          addError: null,
-        }),
-      ];
-
-      dispatch(batchActions(actions));
-    });
-
-    promise.fail((xhr) => {
-      dispatch(
-        set({
-          section,
-          isAdding: false,
-          isAdded: false,
-          addError: xhr,
-        })
-      );
-    });
-  },
-
-  [ADD_STUDIO]: function (getState, payload, dispatch) {
-    dispatch(set({ section, isAdding: true }));
-
-    const foreignId = payload.foreignId;
-    const items = getState().addMovie.items;
-    const itemToAdd = _.find(items, { foreignId });
-    const newStudio = getNewStudio(_.cloneDeep(itemToAdd.studio), payload);
-    newStudio.id = 0;
-
-    const promise = createAjaxRequest({
-      url: '/studio',
-      method: 'POST',
-      dataType: 'json',
-      contentType: 'application/json',
-      data: JSON.stringify(newStudio),
-    }).request;
-
-    promise.done((data) => {
-      const updatedItem = _.cloneDeep(data);
-      updatedItem.internalId = updatedItem.id;
-      updatedItem.id = updatedItem.foreignId;
-      delete updatedItem.images;
-
-      const actions = [
-        updateItem({ section: 'studios', ...data }),
-        updateItem({ section: 'addMovie', ...updatedItem }),
-
-        set({
-          section,
-          isAdding: false,
-          isAdded: true,
-          addError: null,
-        }),
-      ];
-
-      dispatch(batchActions(actions));
-    });
-
-    promise.fail((xhr) => {
-      dispatch(
-        set({
-          section,
-          isAdding: false,
-          isAdded: false,
-          addError: xhr,
-        })
-      );
-    });
-  },
-});
 
 //
 // Reducers
+//
 
 export const reducers = createHandleActions(
   {
@@ -359,24 +130,6 @@ export const reducers = createHandleActions(
       };
 
       return updateSectionState(state, section, newState);
-    },
-
-    [SET_STUDIOS_WITH_STATUS]: function (state, { payload }) {
-      const newState = getSectionState(state, section);
-      newState.studiosWithStatus = payload;
-      return updateSectionState(state, section, newState);
-    },
-
-    [CLEAR_ADD_MOVIE]: function (state) {
-      const {
-        movieDefaults,
-        performerDefaults,
-        studioDefaults,
-        view,
-        ...otherDefaultState
-      } = defaultState;
-
-      return Object.assign({}, state, otherDefaultState);
     },
   },
   defaultState,

--- a/frontend/src/Store/Actions/addPerformerActions.js
+++ b/frontend/src/Store/Actions/addPerformerActions.js
@@ -151,7 +151,7 @@ export const actionHandlers = handleThunks({
 
       const actions = [
         updateItem({ section: 'performers', ...data }),
-        updateItem({ section: 'addMovie', ...updatedItem }),
+        updateItem({ section, ...updatedItem }),
 
         set({
           section,

--- a/frontend/src/Store/Actions/addPerformerActions.js
+++ b/frontend/src/Store/Actions/addPerformerActions.js
@@ -1,34 +1,20 @@
-import _ from 'lodash';
 import { createAction } from 'redux-actions';
-import { batchActions } from 'redux-batched-actions';
-import { createThunk, handleThunks } from 'Store/thunks';
-import createAjaxRequest from 'Utilities/createAjaxRequest';
-import getNewPerformer from 'Utilities/Performer/getNewPerformer';
 import getSectionState from 'Utilities/State/getSectionState';
 import updateSectionState from 'Utilities/State/updateSectionState';
-import { set, update, updateItem } from './baseActions';
 import createHandleActions from './Creators/createHandleActions';
 import createSetSettingValueReducer from './Creators/Reducers/createSetSettingValueReducer';
 
 //
 // Variables
+//
 
 export const section = 'addPerformer';
-let abortCurrentRequest = null;
 
 //
 // State
+//
 
 export const defaultState = {
-  isFetching: false,
-  isPopulated: false,
-  error: null,
-  isAdding: false,
-  isAdded: false,
-  addError: null,
-  items: [],
-  performersWithStatus: [],
-
   performerDefaults: {
     rootFolderPath: '',
     monitored: true,
@@ -43,23 +29,16 @@ export const persistState = ['addPerformer.performerDefaults'];
 
 //
 // Actions Types
+//
 
-export const LOOKUP_PERFORMER = 'addPerformer/lookupPerformer';
-export const ADD_PERFORMER = 'addPerformer/addPerformer';
 export const SET_ADD_PERFORMER_VALUE = 'addPerformer/setAddPerformerValue';
-export const CLEAR_ADD_PERFORMER = 'addPerformer/clearAddPerformer';
 export const SET_ADD_PERFORMER_DEFAULT = 'addPerformer/setAddPerformerDefault';
-export const SET_PERFORMERS_WITH_STATUS =
-  'addPerformer/setPerformersWithStatus';
 
 //
 // Action Creators
+//
 
-export const lookupPerformer = createThunk(LOOKUP_PERFORMER);
-export const addPerformer = createThunk(ADD_PERFORMER);
-export const clearAddPerformer = createAction(CLEAR_ADD_PERFORMER);
 export const setAddPerformerDefault = createAction(SET_ADD_PERFORMER_DEFAULT);
-export const setPerformersWithStatus = createAction(SET_PERFORMERS_WITH_STATUS);
 
 export const setAddPerformerValue = createAction(
   SET_ADD_PERFORMER_VALUE,
@@ -70,115 +49,10 @@ export const setAddPerformerValue = createAction(
     };
   }
 );
-//
-// Action Handlers
-
-export const actionHandlers = handleThunks({
-  [LOOKUP_PERFORMER]: function (getState, payload, dispatch) {
-    dispatch(set({ section, isFetching: true }));
-
-    if (abortCurrentRequest) {
-      abortCurrentRequest();
-    }
-
-    const { request, abortRequest } = createAjaxRequest({
-      url: '/lookup/performer',
-      data: {
-        term: payload.term,
-      },
-    });
-
-    abortCurrentRequest = abortRequest;
-
-    request.done((data) => {
-      data = data.map((movie) => ({
-        ...movie,
-        internalId: movie.id,
-        id: movie.foreignId,
-      }));
-
-      dispatch(
-        batchActions([
-          update({ section, data }),
-
-          set({
-            section,
-            isFetching: false,
-            isPopulated: true,
-            error: null,
-          }),
-        ])
-      );
-    });
-
-    request.fail((xhr) => {
-      dispatch(
-        set({
-          section,
-          isFetching: false,
-          isPopulated: false,
-          error: xhr.aborted ? null : xhr,
-        })
-      );
-    });
-  },
-
-  [ADD_PERFORMER]: function (getState, payload, dispatch) {
-    dispatch(set({ section, isAdding: true }));
-
-    const foreignId = payload.foreignId;
-    const items = getState().addPerformer.items;
-    const itemToAdd = _.find(items, { foreignId });
-    const newPerformer = getNewPerformer(
-      _.cloneDeep(itemToAdd.performer),
-      payload
-    );
-    newPerformer.id = 0;
-
-    const promise = createAjaxRequest({
-      url: '/performer',
-      method: 'POST',
-      dataType: 'json',
-      contentType: 'application/json',
-      data: JSON.stringify(newPerformer),
-    }).request;
-
-    promise.done((data) => {
-      const updatedItem = _.cloneDeep(data);
-      updatedItem.internalId = updatedItem.id;
-      updatedItem.id = updatedItem.foreignId;
-      delete updatedItem.images;
-
-      const actions = [
-        updateItem({ section: 'performers', ...data }),
-        updateItem({ section, ...updatedItem }),
-
-        set({
-          section,
-          isAdding: false,
-          isAdded: true,
-          addError: null,
-        }),
-      ];
-
-      dispatch(batchActions(actions));
-    });
-
-    promise.fail((xhr) => {
-      dispatch(
-        set({
-          section,
-          isAdding: false,
-          isAdded: false,
-          addError: xhr,
-        })
-      );
-    });
-  },
-});
 
 //
 // Reducers
+//
 
 export const reducers = createHandleActions(
   {
@@ -193,22 +67,6 @@ export const reducers = createHandleActions(
       };
 
       return updateSectionState(state, section, newState);
-    },
-    [SET_PERFORMERS_WITH_STATUS]: function (state, { payload }) {
-      const newState = getSectionState(state, section);
-      newState.performersWithStatus = payload;
-      return updateSectionState(state, section, newState);
-    },
-    [CLEAR_ADD_PERFORMER]: function (state) {
-      const {
-        movieDefaults,
-        performerDefaults,
-        studioDefaults,
-        view,
-        ...otherDefaultState
-      } = defaultState;
-
-      return Object.assign({}, state, otherDefaultState);
     },
   },
   defaultState,

--- a/frontend/src/Studio/AddNewStudio/AddNewStudio.tsx
+++ b/frontend/src/Studio/AddNewStudio/AddNewStudio.tsx
@@ -8,7 +8,6 @@ import LoadingIndicator from 'Components/Loading/LoadingIndicator';
 import PageContent from 'Components/Page/PageContent';
 import PageContentBody from 'Components/Page/PageContentBody';
 import { icons, kinds } from 'Helpers/Props';
-import getErrorMessage from 'Utilities/Object/getErrorMessage';
 import translate from 'Utilities/String/translate';
 import AddNewStudioSearchResult from './AddNewStudioSearchResult';
 import useAddNewStudio from './useAddNewStudio';
@@ -84,7 +83,9 @@ function AddNewStudio(props: AddNewStudioProps) {
             <div className={styles.helpText}>
               {translate('FailedLoadingSearchResults')}
             </div>
-            <Alert kind={kinds.WARNING}>{getErrorMessage(error)}</Alert>
+            <Alert kind={kinds.WARNING}>
+              {error?.statusBody?.message ?? error?.message ?? ''}
+            </Alert>
             <div>
               <Link to="https://wiki.servarr.com/whisparr/troubleshooting#invalid-response-received-from-tmdb">
                 {translate('WhySearchesCouldBeFailing')}

--- a/frontend/src/Studio/AddNewStudio/AddNewStudioModal.tsx
+++ b/frontend/src/Studio/AddNewStudio/AddNewStudioModal.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
 import Modal from 'Components/Modal/Modal';
-import { Image } from 'Studio/Studio';
+import Studio, { Image } from 'Studio/Studio';
 import AddNewStudioModalContent from './AddNewStudioModalContent';
 
 interface AddNewStudioModalProps {
   isOpen: boolean;
   onModalClose: () => void;
+  studio: Studio;
   foreignId: string;
   title: string;
   images: Image[];

--- a/frontend/src/Studio/AddNewStudio/AddNewStudioModalContent.tsx
+++ b/frontend/src/Studio/AddNewStudio/AddNewStudioModalContent.tsx
@@ -10,7 +10,7 @@ import ModalContent from 'Components/Modal/ModalContent';
 import ModalFooter from 'Components/Modal/ModalFooter';
 import ModalHeader from 'Components/Modal/ModalHeader';
 import { inputTypes, kinds } from 'Helpers/Props';
-import { Image } from 'Studio/Studio';
+import Studio, { Image } from 'Studio/Studio';
 import StudioLogo from 'Studio/StudioLogo';
 import { EnhancedSelectInputChanged } from 'typings/inputs';
 import translate from 'Utilities/String/translate';
@@ -18,6 +18,7 @@ import { useAddNewStudioModalContent } from './useAddNewStudio';
 import styles from './AddNewStudioModalContent.css';
 
 interface AddNewStudioModalContentProps {
+  studio: Studio;
   foreignId: string;
   title: string;
   images: Image[];
@@ -25,7 +26,7 @@ interface AddNewStudioModalContentProps {
 }
 
 function AddNewStudioModalContent(props: AddNewStudioModalContentProps) {
-  const { foreignId, title, images, onModalClose } = props;
+  const { title, images, onModalClose, studio } = props;
 
   const {
     isAdding,
@@ -35,7 +36,7 @@ function AddNewStudioModalContent(props: AddNewStudioModalContentProps) {
     settings,
     onInputChange,
     onAddStudioPress,
-  } = useAddNewStudioModalContent(foreignId);
+  } = useAddNewStudioModalContent(studio);
 
   const onQualityProfileIdChange = React.useCallback(
     ({ value }: EnhancedSelectInputChanged<string | number>) => {

--- a/frontend/src/Studio/AddNewStudio/AddNewStudioSearchResult.tsx
+++ b/frontend/src/Studio/AddNewStudio/AddNewStudioSearchResult.tsx
@@ -134,6 +134,7 @@ function AddNewStudioSearchResult({
 
       <AddNewStudioModal
         isOpen={isNewAddStudioModalOpen && !isExistingStudio}
+        studio={studio}
         foreignId={foreignId}
         title={title}
         images={images}

--- a/frontend/src/Studio/AddNewStudio/useAddNewStudio.ts
+++ b/frontend/src/Studio/AddNewStudio/useAddNewStudio.ts
@@ -1,14 +1,14 @@
-import React, { useState } from 'react';
+import { useMutation } from '@tanstack/react-query';
+import { cloneDeep } from 'lodash';
+import React, { useRef, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { Error as AppError } from 'App/State/AppSectionState';
+import { queryClient } from 'App/queryClient';
 import AppState from 'App/State/AppState';
 import { ValidationMessage } from 'Components/Form/FormInputGroup';
+import useApiQuery from 'Helpers/Hooks/useApiQuery';
 import {
-  addStudio,
   clearAddMovie,
-  lookupStudio,
   setAddStudioDefault,
-  setStudiosWithStatus,
 } from 'Store/Actions/addMovieActions';
 import {
   clearQueueDetails,
@@ -21,18 +21,16 @@ import createUISettingsSelector from 'Store/Selectors/createUISettingsSelector';
 import selectSettings from 'Store/Selectors/selectSettings';
 import Studio from 'Studio/Studio';
 import { InputChanged } from 'typings/inputs';
-import createAjaxRequest from 'Utilities/createAjaxRequest';
+import fetchJson, {
+  ApiError,
+  apiRoot,
+  urlBase,
+} from 'Utilities/Fetch/fetchJson';
+import getNewStudio from 'Utilities/Studio/getNewStudio';
 
 export interface StudioWithExistingStatus {
   studio: Studio;
   isExistingStudio: boolean;
-}
-
-interface LookupStudioItem {
-  foreignId: string;
-  studio: Studio;
-  id: string;
-  internalId: number;
 }
 
 interface StudioDefaults {
@@ -61,22 +59,6 @@ interface AddStudioSettings {
   tags: SettingValue<number[]>;
 }
 
-interface AddMovieState {
-  isPopulated: boolean;
-  error: AppError | null;
-  isAdding: boolean;
-  isFetching: boolean;
-  isAdded: boolean;
-  addError: AppError | null;
-  items: LookupStudioItem[];
-  studiosWithStatus: StudioWithExistingStatus[];
-  studioDefaults: StudioDefaults;
-}
-
-type RootState = AppState & {
-  addMovie: AddMovieState;
-};
-
 const defaultStudioDefaults: StudioDefaults = {
   rootFolderPath: '',
   monitored: true,
@@ -86,25 +68,42 @@ const defaultStudioDefaults: StudioDefaults = {
   tags: [],
 };
 
+const AUTH_HEADERS = {
+  'X-Api-Key': window.Whisparr.apiKey,
+  'X-Whisparr-Client': 'Whisparr',
+};
+
+function apiPost<T, TBody>(path: string, body: TBody): Promise<T> {
+  return fetchJson<T, TBody>({
+    path: `${urlBase}${apiRoot}${path}`,
+    method: 'POST',
+    body,
+    headers: AUTH_HEADERS,
+  });
+}
+
+interface SearchResource {
+  foreignId: string;
+  studio: Studio;
+  isExisting: boolean;
+}
+
 function useAddNewStudio() {
   const dispatch = useDispatch();
-  const addMovie = useSelector((state: RootState) => state.addMovie);
   const uiSettings = useSelector(createUISettingsSelector());
   const existingStudiosCount = useSelector(
     (state: AppState) => state.studios.items.length
   );
   const [term, setTerm] = useState('');
-
-  const studioLookupTimeout = React.useRef<ReturnType<
-    typeof setTimeout
-  > | null>(null);
+  const [debouncedTerm, setDebouncedTerm] = useState('');
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   React.useEffect(() => {
     dispatch(fetchRootFolders());
     dispatch(fetchQueueDetails());
     return () => {
-      if (studioLookupTimeout.current) {
-        clearTimeout(studioLookupTimeout.current);
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
       }
       dispatch(clearAddMovie());
       dispatch(clearQueueDetails());
@@ -112,82 +111,28 @@ function useAddNewStudio() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const lastRequestedIdsRef = React.useRef<string>('');
-  const hadNonEmptyItemsRef = React.useRef<boolean>(false);
-
-  // When lookup results change, check which studios already exist
-  React.useEffect(() => {
-    const items = addMovie?.items;
-
-    if (items && items.length > 0) {
-      const foreignIds = items
-        .map((item: LookupStudioItem) => item.studio.foreignId)
-        .filter((id: string | undefined): id is string => !!id);
-
-      if (foreignIds.length > 0) {
-        // cache key covers both the queried ids and the current studio count, so
-        // we re-fetch when either changes (e.g. user just added a studio)
-        const key = `${existingStudiosCount}|${foreignIds.slice().sort().join('|')}`;
-        if (key === lastRequestedIdsRef.current) {
-          return;
-        }
-        lastRequestedIdsRef.current = key;
-        hadNonEmptyItemsRef.current = true;
-
-        const { request } = createAjaxRequest({
-          url: '/studio/list',
-          method: 'POST',
-          contentType: 'application/json',
-          data: JSON.stringify(foreignIds),
-        });
-
-        request.done((existingStudios: Studio[]) => {
-          // Create a map of foreignId to full studio object
-          const existingStudioMap = new Map(
-            existingStudios.map((s) => [s.foreignId, s])
-          );
-
-          // Map over lookup items, using full studio data if available
-          const mapped = items.map((item: LookupStudioItem) => {
-            const fullStudio = existingStudioMap.get(item.studio.foreignId);
-            return {
-              studio: fullStudio || item.studio,
-              isExistingStudio: !!fullStudio,
-            };
-          });
-
-          dispatch(setStudiosWithStatus(mapped));
-        });
-
-        request.fail(() => {
-          // If the request fails, assume none exist
-          const mapped = items.map((item: LookupStudioItem) => ({
-            studio: item.studio,
-            isExistingStudio: false,
-          }));
-
-          dispatch(setStudiosWithStatus(mapped));
-        });
-      }
-    } else if (hadNonEmptyItemsRef.current) {
-      hadNonEmptyItemsRef.current = false;
-      lastRequestedIdsRef.current = '';
-      dispatch(setStudiosWithStatus([]));
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [addMovie?.items, existingStudiosCount, dispatch]);
+  const {
+    data: searchResources = [],
+    isFetching,
+    error,
+  } = useApiQuery<SearchResource[]>({
+    path: '/lookup/studio',
+    queryParams: { term: debouncedTerm },
+    queryOptions: { enabled: !!debouncedTerm.trim() },
+  });
 
   const onStudioLookupChange = React.useCallback(
     (value: string) => {
       setTerm(value);
-      if (studioLookupTimeout.current) {
-        clearTimeout(studioLookupTimeout.current);
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
       }
       if (value.trim() === '') {
+        setDebouncedTerm('');
         dispatch(clearAddMovie());
       } else {
-        studioLookupTimeout.current = setTimeout(() => {
-          dispatch(lookupStudio({ term: value }));
+        timeoutRef.current = setTimeout(() => {
+          setDebouncedTerm(value);
         }, 300);
       }
     },
@@ -196,18 +141,22 @@ function useAddNewStudio() {
 
   const onClearStudioLookupPress = React.useCallback(() => {
     setTerm('');
+    setDebouncedTerm('');
     dispatch(clearAddMovie());
   }, [dispatch]);
 
   return {
-    isPopulated: addMovie?.isPopulated || false,
-    error: addMovie?.error,
-    isAdding: addMovie?.isAdding || false,
-    isFetching: addMovie?.isFetching || false,
-    isAdded: addMovie?.isAdded || false,
-    addError: addMovie?.addError,
-    items: addMovie?.items || [],
-    studiosWithStatus: addMovie?.studiosWithStatus || [],
+    isPopulated: !!debouncedTerm.trim() && !isFetching,
+    error,
+    isAdding: false,
+    isFetching: isFetching && !!debouncedTerm.trim(),
+    isAdded: false,
+    addError: null,
+    items: searchResources,
+    studiosWithStatus: searchResources.map((r) => ({
+      studio: r.studio,
+      isExistingStudio: r.isExisting,
+    })),
     term,
     colorImpairedMode: uiSettings.enableColorImpairedMode,
     hasExistingStudios: existingStudiosCount > 0,
@@ -228,25 +177,38 @@ export function useAddNewStudioSearchResult() {
   };
 }
 
-export function useAddNewStudioModalContent(foreignId: string) {
+export function useAddNewStudioModalContent(studio: Studio) {
   const dispatch = useDispatch();
   const { isSmallScreen } = useSelector(createDimensionsSelector());
   const systemStatus = useSelector(createSystemStatusSelector());
   const safeForWorkMode = useSelector(
     (state: AppState) => state.settings.safeForWorkMode
   );
-  const addMovieState = useSelector((state: RootState) => state.addMovie);
 
-  const {
-    isAdding = false,
-    addError,
-    studioDefaults = defaultStudioDefaults,
-  } = addMovieState || {};
+  const addMovieState = useSelector(
+    (
+      state: AppState & {
+        addMovie: { studioDefaults: StudioDefaults; addError?: ApiError };
+      }
+    ) => state.addMovie
+  );
+
+  const { studioDefaults = defaultStudioDefaults } = addMovieState || {};
+
+  const mutation = useMutation<Studio, ApiError, Studio>({
+    mutationFn: (studioToAdd: Studio) => {
+      return apiPost<Studio, Studio>('/studio', studioToAdd);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['/studio/paged'] });
+      queryClient.invalidateQueries({ queryKey: ['/lookup/studio'] });
+    },
+  });
 
   const { settings, validationErrors, validationWarnings } = selectSettings(
     studioDefaults,
     {},
-    addError
+    mutation.error
   ) as {
     settings: AddStudioSettings;
     validationErrors: unknown[];
@@ -261,22 +223,21 @@ export function useAddNewStudioModalContent(foreignId: string) {
   );
 
   const onAddStudioPress = React.useCallback(() => {
-    dispatch(
-      addStudio({
-        foreignId,
-        rootFolderPath: settings.rootFolderPath.value,
-        monitored: settings.monitored.value === true,
-        moviesMonitored: settings.moviesMonitored.value === true,
-        qualityProfileId: settings.qualityProfileId.value,
-        searchForMovie: settings.searchForMovie.value,
-        tags: settings.tags.value,
-      })
-    );
-  }, [dispatch, foreignId, settings]);
+    const studioToAdd = getNewStudio(cloneDeep(studio) as object, {
+      rootFolderPath: settings.rootFolderPath.value,
+      monitored: settings.monitored.value === true,
+      moviesMonitored: settings.moviesMonitored.value === true,
+      qualityProfileId: settings.qualityProfileId.value,
+      searchForMovie: settings.searchForMovie.value,
+      tags: settings.tags.value,
+    }) as Studio;
+    studioToAdd.id = 0;
+    mutation.mutate(studioToAdd);
+  }, [studio, settings, mutation]);
 
   return {
-    addError,
-    isAdding,
+    addError: mutation.error,
+    isAdding: mutation.isPending,
     isSmallScreen,
     isWindows: systemStatus.isWindows,
     safeForWorkMode,

--- a/frontend/src/Studio/AddNewStudio/useAddNewStudio.ts
+++ b/frontend/src/Studio/AddNewStudio/useAddNewStudio.ts
@@ -112,14 +112,28 @@ function useAddNewStudio() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  const lastRequestedIdsRef = React.useRef<string>('');
+  const hadNonEmptyItemsRef = React.useRef<boolean>(false);
+
   // When lookup results change, check which studios already exist
   React.useEffect(() => {
-    if (addMovie?.items && addMovie.items.length > 0) {
-      const foreignIds = addMovie.items
+    const items = addMovie?.items;
+
+    if (items && items.length > 0) {
+      const foreignIds = items
         .map((item: LookupStudioItem) => item.studio.foreignId)
-        .filter((id: string | undefined) => id);
+        .filter((id: string | undefined): id is string => !!id);
 
       if (foreignIds.length > 0) {
+        // cache key covers both the queried ids and the current studio count, so
+        // we re-fetch when either changes (e.g. user just added a studio)
+        const key = `${existingStudiosCount}|${foreignIds.slice().sort().join('|')}`;
+        if (key === lastRequestedIdsRef.current) {
+          return;
+        }
+        lastRequestedIdsRef.current = key;
+        hadNonEmptyItemsRef.current = true;
+
         const { request } = createAjaxRequest({
           url: '/studio/list',
           method: 'POST',
@@ -134,7 +148,7 @@ function useAddNewStudio() {
           );
 
           // Map over lookup items, using full studio data if available
-          const mapped = addMovie.items.map((item: LookupStudioItem) => {
+          const mapped = items.map((item: LookupStudioItem) => {
             const fullStudio = existingStudioMap.get(item.studio.foreignId);
             return {
               studio: fullStudio || item.studio,
@@ -147,7 +161,7 @@ function useAddNewStudio() {
 
         request.fail(() => {
           // If the request fails, assume none exist
-          const mapped = addMovie.items.map((item: LookupStudioItem) => ({
+          const mapped = items.map((item: LookupStudioItem) => ({
             studio: item.studio,
             isExistingStudio: false,
           }));
@@ -155,10 +169,13 @@ function useAddNewStudio() {
           dispatch(setStudiosWithStatus(mapped));
         });
       }
-    } else {
+    } else if (hadNonEmptyItemsRef.current) {
+      hadNonEmptyItemsRef.current = false;
+      lastRequestedIdsRef.current = '';
       dispatch(setStudiosWithStatus([]));
     }
-  }, [addMovie?.items, addMovie, dispatch]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [addMovie?.items, existingStudiosCount, dispatch]);
 
   const onStudioLookupChange = React.useCallback(
     (value: string) => {

--- a/frontend/src/Studio/AddNewStudio/useAddNewStudio.ts
+++ b/frontend/src/Studio/AddNewStudio/useAddNewStudio.ts
@@ -7,7 +7,6 @@ import AppState from 'App/State/AppState';
 import { ValidationMessage } from 'Components/Form/FormInputGroup';
 import useApiQuery from 'Helpers/Hooks/useApiQuery';
 import {
-  clearAddMovie,
   setAddStudioDefault,
 } from 'Store/Actions/addMovieActions';
 import {
@@ -105,7 +104,6 @@ function useAddNewStudio() {
       if (timeoutRef.current) {
         clearTimeout(timeoutRef.current);
       }
-      dispatch(clearAddMovie());
       dispatch(clearQueueDetails());
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -129,7 +127,6 @@ function useAddNewStudio() {
       }
       if (value.trim() === '') {
         setDebouncedTerm('');
-        dispatch(clearAddMovie());
       } else {
         timeoutRef.current = setTimeout(() => {
           setDebouncedTerm(value);
@@ -142,8 +139,7 @@ function useAddNewStudio() {
   const onClearStudioLookupPress = React.useCallback(() => {
     setTerm('');
     setDebouncedTerm('');
-    dispatch(clearAddMovie());
-  }, [dispatch]);
+  }, []);
 
   return {
     isPopulated: !!debouncedTerm.trim() && !isFetching,

--- a/src/Whisparr.Api.V3/Search/SearchController.cs
+++ b/src/Whisparr.Api.V3/Search/SearchController.cs
@@ -27,6 +27,8 @@ namespace Whisparr.Api.V3.Search
         private readonly IConfigService _configService;
         private readonly IImportListExclusionService _exclusionService;
         private readonly IMovieService _movieService;
+        private readonly IStudioService _studioService;
+        private readonly IPerformerService _performerService;
 
         public SearchController(ISearchForNewMovie searchProxy,
                                 IBuildFileNames fileNameBuilder,
@@ -34,7 +36,9 @@ namespace Whisparr.Api.V3.Search
                                 IMapCoversToLocal coverMapper,
                                 IConfigService configService,
                                 IImportListExclusionService exclusionService,
-                                IMovieService movieService)
+                                IMovieService movieService,
+                                IStudioService studioService,
+                                IPerformerService performerService)
         {
             _searchProxy = searchProxy;
             _fileNameBuilder = fileNameBuilder;
@@ -43,6 +47,8 @@ namespace Whisparr.Api.V3.Search
             _configService = configService;
             _exclusionService = exclusionService;
             _movieService = movieService;
+            _studioService = studioService;
+            _performerService = performerService;
         }
 
         [HttpGet("scene")]
@@ -67,19 +73,49 @@ namespace Whisparr.Api.V3.Search
         public object SearchStudio([FromQuery] string term)
         {
             var searchResults = _searchProxy.SearchForNewStudio(term);
-            return MapToResource(searchResults).ToList();
+            var searchResources = MapToResource(searchResults).ToList();
+            MapToExistingStudios(searchResources);
+            return searchResources;
         }
 
         [HttpGet("performer")]
         public object SearchPerformer([FromQuery] string term)
         {
             var searchResults = _searchProxy.SearchForNewPerformer(term);
-            return MapToResource(searchResults).ToList();
+            var searchResources = MapToResource(searchResults).ToList();
+            MapToExistingPerformers(searchResources);
+            return searchResources;
         }
 
         private void MapToExistingMovies(List<SearchResource> searchResources)
         {
             var matches = _movieService.FindByForeignIds(searchResources.Select(m => m.ForeignId).ToList());
+            foreach (var s in searchResources)
+            {
+                var match = matches.Where(m => m.ForeignId == s.ForeignId);
+                if (match.Any())
+                {
+                    s.isExisting = true;
+                }
+            }
+        }
+
+        private void MapToExistingStudios(List<SearchResource> searchResources)
+        {
+            var matches = _studioService.FindByForeignIds(searchResources.Select(s => s.ForeignId).ToList());
+            foreach (var s in searchResources)
+            {
+                var match = matches.Where(m => m.ForeignId == s.ForeignId);
+                if (match.Any())
+                {
+                    s.isExisting = true;
+                }
+            }
+        }
+
+        private void MapToExistingPerformers(List<SearchResource> searchResources)
+        {
+            var matches = _performerService.FindByForeignIds(searchResources.Select(p => p.ForeignId).ToList());
             foreach (var s in searchResources)
             {
                 var match = matches.Where(m => m.ForeignId == s.ForeignId);


### PR DESCRIPTION
#### Database Migration

NO

#### Description

started this by trying to fix studio search spamming the endpoints. as soon as the input field wasn't empty, it would just loop spam the list endpoint

took a look at how other lookups were implemented. movie search was implemented way better because it uses react-query and determines DB existence directly on the backend search controller rather than dumping the whole collection client-side. performer search had the exact same over-fetching loop bug as studios

- updated backend search controller to map and return whether the studio/performer already exists
- migrated both useAddNewStudio and useAddNewPerformer hooks to react-query
- nuked all the legacy redux lookup/add actions, thunks, and reducers we don't need anymore (but kept the defaults state slices for settings persistence)


let me know if i missed something or if i broke any unexpected assumptions here

#### Todos

- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json) (none modified/added)

#### Issues Fixed or Closed by this PR

Not reported
