### PR TITLE
chore: migrate "add new studio" lookup and add flow to tanstack query

### DIFF
--- a/frontend/src/Store/Actions/addMovieActions.js
+++ b/frontend/src/Store/Actions/addMovieActions.js
@@ -6,7 +6,6 @@ import createAjaxRequest from 'Utilities/createAjaxRequest';
 import getNewPerformer from 'Utilities/Performer/getNewPerformer';
 import getSectionState from 'Utilities/State/getSectionState';
 import updateSectionState from 'Utilities/State/updateSectionState';
-import getNewStudio from 'Utilities/Studio/getNewStudio';
 import { set, update, updateItem } from './baseActions';
 import createHandleActions from './Creators/createHandleActions';
 import createSetSettingValueReducer from './Creators/Reducers/createSetSettingValueReducer';
@@ -28,8 +27,6 @@ export const defaultState = {
   isAdded: false,
   addError: null,
   items: [],
-  studiosWithStatus: [],
-
   movieDefaults: {
     rootFolderPath: '',
     monitor: 'movieOnly',
@@ -65,31 +62,24 @@ export const persistState = [
 //
 // Actions Types
 
-export const LOOKUP_STUDIO = 'addMovie/lookupStudio';
 export const LOOKUP_PERFORMER = 'addMovie/lookupPerformer';
 export const ADD_PERFORMER = 'addMovie/addPerformer';
-export const ADD_STUDIO = 'addMovie/addStudio';
 export const SET_ADD_MOVIE_VALUE = 'addMovie/setAddMovieValue';
 export const SET_ADD_PERFORMER_VALUE = 'addMovie/setAddPerformerValue';
-export const SET_ADD_STUDIO_VALUE = 'addMovie/setAddStudioValue';
 export const CLEAR_ADD_MOVIE = 'addMovie/clearAddMovie';
 export const SET_ADD_MOVIE_DEFAULT = 'addMovie/setAddMovieDefault';
 export const SET_ADD_PERFORMER_DEFAULT = 'addMovie/setAddPerformerDefault';
 export const SET_ADD_STUDIO_DEFAULT = 'addMovie/setAddStudioDefault';
-export const SET_STUDIOS_WITH_STATUS = 'addMovie/setStudiosWithStatus';
 
 //
 // Action Creators
 
-export const lookupStudio = createThunk(LOOKUP_STUDIO);
 export const lookupPerformer = createThunk(LOOKUP_PERFORMER);
 export const addPerformer = createThunk(ADD_PERFORMER);
-export const addStudio = createThunk(ADD_STUDIO);
 export const clearAddMovie = createAction(CLEAR_ADD_MOVIE);
 export const setAddMovieDefault = createAction(SET_ADD_MOVIE_DEFAULT);
 export const setAddPerformerDefault = createAction(SET_ADD_PERFORMER_DEFAULT);
 export const setAddStudioDefault = createAction(SET_ADD_STUDIO_DEFAULT);
-export const setStudiosWithStatus = createAction(SET_STUDIOS_WITH_STATUS);
 
 export const setAddMovieValue = createAction(SET_ADD_MOVIE_VALUE, (payload) => {
   return {
@@ -106,67 +96,12 @@ export const setAddPerformerValue = createAction(
     };
   }
 );
-export const setAddStudioValue = createAction(
-  SET_ADD_STUDIO_VALUE,
-  (payload) => {
-    return {
-      section,
-      ...payload,
-    };
-  }
-);
+
 //
 // Action Handlers
 
 export const actionHandlers = handleThunks({
-  [LOOKUP_STUDIO]: function (getState, payload, dispatch) {
-    dispatch(set({ section, isFetching: true }));
 
-    if (abortCurrentRequest) {
-      abortCurrentRequest();
-    }
-
-    const { request, abortRequest } = createAjaxRequest({
-      url: '/lookup/studio',
-      data: {
-        term: payload.term,
-      },
-    });
-
-    abortCurrentRequest = abortRequest;
-
-    request.done((data) => {
-      data = data.map((movie) => ({
-        ...movie,
-        internalId: movie.id,
-        id: movie.foreignId,
-      }));
-
-      dispatch(
-        batchActions([
-          update({ section, data }),
-
-          set({
-            section,
-            isFetching: false,
-            isPopulated: true,
-            error: null,
-          }),
-        ])
-      );
-    });
-
-    request.fail((xhr) => {
-      dispatch(
-        set({
-          section,
-          isFetching: false,
-          isPopulated: false,
-          error: xhr.aborted ? null : xhr,
-        })
-      );
-    });
-  },
 
   [LOOKUP_PERFORMER]: function (getState, payload, dispatch) {
     dispatch(set({ section, isFetching: true }));
@@ -270,55 +205,7 @@ export const actionHandlers = handleThunks({
     });
   },
 
-  [ADD_STUDIO]: function (getState, payload, dispatch) {
-    dispatch(set({ section, isAdding: true }));
 
-    const foreignId = payload.foreignId;
-    const items = getState().addMovie.items;
-    const itemToAdd = _.find(items, { foreignId });
-    const newStudio = getNewStudio(_.cloneDeep(itemToAdd.studio), payload);
-    newStudio.id = 0;
-
-    const promise = createAjaxRequest({
-      url: '/studio',
-      method: 'POST',
-      dataType: 'json',
-      contentType: 'application/json',
-      data: JSON.stringify(newStudio),
-    }).request;
-
-    promise.done((data) => {
-      const updatedItem = _.cloneDeep(data);
-      updatedItem.internalId = updatedItem.id;
-      updatedItem.id = updatedItem.foreignId;
-      delete updatedItem.images;
-
-      const actions = [
-        updateItem({ section: 'studios', ...data }),
-        updateItem({ section: 'addMovie', ...updatedItem }),
-
-        set({
-          section,
-          isAdding: false,
-          isAdded: true,
-          addError: null,
-        }),
-      ];
-
-      dispatch(batchActions(actions));
-    });
-
-    promise.fail((xhr) => {
-      dispatch(
-        set({
-          section,
-          isAdding: false,
-          isAdded: false,
-          addError: xhr,
-        })
-      );
-    });
-  },
 });
 
 //
@@ -328,7 +215,6 @@ export const reducers = createHandleActions(
   {
     [SET_ADD_MOVIE_VALUE]: createSetSettingValueReducer(section),
     [SET_ADD_PERFORMER_VALUE]: createSetSettingValueReducer(section),
-    [SET_ADD_STUDIO_VALUE]: createSetSettingValueReducer(section),
 
     [SET_ADD_MOVIE_DEFAULT]: function (state, { payload }) {
       const newState = getSectionState(state, section);
@@ -358,12 +244,6 @@ export const reducers = createHandleActions(
         ...payload,
       };
 
-      return updateSectionState(state, section, newState);
-    },
-
-    [SET_STUDIOS_WITH_STATUS]: function (state, { payload }) {
-      const newState = getSectionState(state, section);
-      newState.studiosWithStatus = payload;
       return updateSectionState(state, section, newState);
     },
 

--- a/frontend/src/Studio/AddNewStudio/AddNewStudio.tsx
+++ b/frontend/src/Studio/AddNewStudio/AddNewStudio.tsx
@@ -8,7 +8,6 @@ import LoadingIndicator from 'Components/Loading/LoadingIndicator';
 import PageContent from 'Components/Page/PageContent';
 import PageContentBody from 'Components/Page/PageContentBody';
 import { icons, kinds } from 'Helpers/Props';
-import getErrorMessage from 'Utilities/Object/getErrorMessage';
 import translate from 'Utilities/String/translate';
 import AddNewStudioSearchResult from './AddNewStudioSearchResult';
 import useAddNewStudio from './useAddNewStudio';
@@ -84,7 +83,9 @@ function AddNewStudio(props: AddNewStudioProps) {
             <div className={styles.helpText}>
               {translate('FailedLoadingSearchResults')}
             </div>
-            <Alert kind={kinds.WARNING}>{getErrorMessage(error)}</Alert>
+            <Alert kind={kinds.WARNING}>
+              {error?.statusBody?.message ?? error?.message ?? ''}
+            </Alert>
             <div>
               <Link to="https://wiki.servarr.com/whisparr/troubleshooting#invalid-response-received-from-tmdb">
                 {translate('WhySearchesCouldBeFailing')}

--- a/frontend/src/Studio/AddNewStudio/AddNewStudioModal.tsx
+++ b/frontend/src/Studio/AddNewStudio/AddNewStudioModal.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
 import Modal from 'Components/Modal/Modal';
-import { Image } from 'Studio/Studio';
+import Studio, { Image } from 'Studio/Studio';
 import AddNewStudioModalContent from './AddNewStudioModalContent';
 
 interface AddNewStudioModalProps {
   isOpen: boolean;
   onModalClose: () => void;
+  studio: Studio;
   foreignId: string;
   title: string;
   images: Image[];

--- a/frontend/src/Studio/AddNewStudio/AddNewStudioModalContent.tsx
+++ b/frontend/src/Studio/AddNewStudio/AddNewStudioModalContent.tsx
@@ -10,7 +10,7 @@ import ModalContent from 'Components/Modal/ModalContent';
 import ModalFooter from 'Components/Modal/ModalFooter';
 import ModalHeader from 'Components/Modal/ModalHeader';
 import { inputTypes, kinds } from 'Helpers/Props';
-import { Image } from 'Studio/Studio';
+import Studio, { Image } from 'Studio/Studio';
 import StudioLogo from 'Studio/StudioLogo';
 import { EnhancedSelectInputChanged } from 'typings/inputs';
 import translate from 'Utilities/String/translate';
@@ -18,6 +18,7 @@ import { useAddNewStudioModalContent } from './useAddNewStudio';
 import styles from './AddNewStudioModalContent.css';
 
 interface AddNewStudioModalContentProps {
+  studio: Studio;
   foreignId: string;
   title: string;
   images: Image[];
@@ -25,7 +26,7 @@ interface AddNewStudioModalContentProps {
 }
 
 function AddNewStudioModalContent(props: AddNewStudioModalContentProps) {
-  const { foreignId, title, images, onModalClose } = props;
+  const { title, images, onModalClose, studio } = props;
 
   const {
     isAdding,
@@ -35,7 +36,7 @@ function AddNewStudioModalContent(props: AddNewStudioModalContentProps) {
     settings,
     onInputChange,
     onAddStudioPress,
-  } = useAddNewStudioModalContent(foreignId);
+  } = useAddNewStudioModalContent(studio);
 
   const onQualityProfileIdChange = React.useCallback(
     ({ value }: EnhancedSelectInputChanged<string | number>) => {

--- a/frontend/src/Studio/AddNewStudio/AddNewStudioSearchResult.tsx
+++ b/frontend/src/Studio/AddNewStudio/AddNewStudioSearchResult.tsx
@@ -134,6 +134,7 @@ function AddNewStudioSearchResult({
 
       <AddNewStudioModal
         isOpen={isNewAddStudioModalOpen && !isExistingStudio}
+        studio={studio}
         foreignId={foreignId}
         title={title}
         images={images}

--- a/frontend/src/Studio/AddNewStudio/useAddNewStudio.ts
+++ b/frontend/src/Studio/AddNewStudio/useAddNewStudio.ts
@@ -1,14 +1,12 @@
-import { useMutation } from '@tanstack/react-query';
 import { cloneDeep } from 'lodash';
 import React, { useRef, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { queryClient } from 'App/queryClient';
 import AppState from 'App/State/AppState';
 import { ValidationMessage } from 'Components/Form/FormInputGroup';
+import useApiMutation from 'Helpers/Hooks/useApiMutation';
 import useApiQuery from 'Helpers/Hooks/useApiQuery';
-import {
-  setAddStudioDefault,
-} from 'Store/Actions/addMovieActions';
+import { setAddStudioDefault } from 'Store/Actions/addMovieActions';
 import {
   clearQueueDetails,
   fetchQueueDetails,
@@ -20,11 +18,7 @@ import createUISettingsSelector from 'Store/Selectors/createUISettingsSelector';
 import selectSettings from 'Store/Selectors/selectSettings';
 import Studio from 'Studio/Studio';
 import { InputChanged } from 'typings/inputs';
-import fetchJson, {
-  ApiError,
-  apiRoot,
-  urlBase,
-} from 'Utilities/Fetch/fetchJson';
+import { ApiError } from 'Utilities/Fetch/fetchJson';
 import getNewStudio from 'Utilities/Studio/getNewStudio';
 
 export interface StudioWithExistingStatus {
@@ -67,20 +61,6 @@ const defaultStudioDefaults: StudioDefaults = {
   tags: [],
 };
 
-const AUTH_HEADERS = {
-  'X-Api-Key': window.Whisparr.apiKey,
-  'X-Whisparr-Client': 'Whisparr',
-};
-
-function apiPost<T, TBody>(path: string, body: TBody): Promise<T> {
-  return fetchJson<T, TBody>({
-    path: `${urlBase}${apiRoot}${path}`,
-    method: 'POST',
-    body,
-    headers: AUTH_HEADERS,
-  });
-}
-
 interface SearchResource {
   foreignId: string;
   studio: Studio;
@@ -119,22 +99,19 @@ function useAddNewStudio() {
     queryOptions: { enabled: !!debouncedTerm.trim() },
   });
 
-  const onStudioLookupChange = React.useCallback(
-    (value: string) => {
-      setTerm(value);
-      if (timeoutRef.current) {
-        clearTimeout(timeoutRef.current);
-      }
-      if (value.trim() === '') {
-        setDebouncedTerm('');
-      } else {
-        timeoutRef.current = setTimeout(() => {
-          setDebouncedTerm(value);
-        }, 300);
-      }
-    },
-    [dispatch]
-  );
+  const onStudioLookupChange = React.useCallback((value: string) => {
+    setTerm(value);
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+    }
+    if (value.trim() === '') {
+      setDebouncedTerm('');
+    } else {
+      timeoutRef.current = setTimeout(() => {
+        setDebouncedTerm(value);
+      }, 300);
+    }
+  }, []);
 
   const onClearStudioLookupPress = React.useCallback(() => {
     setTerm('');
@@ -191,13 +168,14 @@ export function useAddNewStudioModalContent(studio: Studio) {
 
   const { studioDefaults = defaultStudioDefaults } = addMovieState || {};
 
-  const mutation = useMutation<Studio, ApiError, Studio>({
-    mutationFn: (studioToAdd: Studio) => {
-      return apiPost<Studio, Studio>('/studio', studioToAdd);
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['/studio/paged'] });
-      queryClient.invalidateQueries({ queryKey: ['/lookup/studio'] });
+  const mutation = useApiMutation<Studio, Studio>({
+    method: 'POST',
+    path: '/studio',
+    mutationOptions: {
+      onSuccess: () => {
+        queryClient.invalidateQueries({ queryKey: ['/studio/paged'] });
+        queryClient.invalidateQueries({ queryKey: ['/lookup/studio'] });
+      },
     },
   });
 

--- a/frontend/src/Studio/AddNewStudio/useAddNewStudio.ts
+++ b/frontend/src/Studio/AddNewStudio/useAddNewStudio.ts
@@ -1,14 +1,13 @@
-import React, { useState } from 'react';
+import { useMutation } from '@tanstack/react-query';
+import { cloneDeep } from 'lodash';
+import React, { useRef, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { Error as AppError } from 'App/State/AppSectionState';
+import { queryClient } from 'App/queryClient';
 import AppState from 'App/State/AppState';
 import { ValidationMessage } from 'Components/Form/FormInputGroup';
+import useApiQuery from 'Helpers/Hooks/useApiQuery';
 import {
-  addStudio,
-  clearAddMovie,
-  lookupStudio,
   setAddStudioDefault,
-  setStudiosWithStatus,
 } from 'Store/Actions/addMovieActions';
 import {
   clearQueueDetails,
@@ -21,18 +20,16 @@ import createUISettingsSelector from 'Store/Selectors/createUISettingsSelector';
 import selectSettings from 'Store/Selectors/selectSettings';
 import Studio from 'Studio/Studio';
 import { InputChanged } from 'typings/inputs';
-import createAjaxRequest from 'Utilities/createAjaxRequest';
+import fetchJson, {
+  ApiError,
+  apiRoot,
+  urlBase,
+} from 'Utilities/Fetch/fetchJson';
+import getNewStudio from 'Utilities/Studio/getNewStudio';
 
 export interface StudioWithExistingStatus {
   studio: Studio;
   isExistingStudio: boolean;
-}
-
-interface LookupStudioItem {
-  foreignId: string;
-  studio: Studio;
-  id: string;
-  internalId: number;
 }
 
 interface StudioDefaults {
@@ -61,22 +58,6 @@ interface AddStudioSettings {
   tags: SettingValue<number[]>;
 }
 
-interface AddMovieState {
-  isPopulated: boolean;
-  error: AppError | null;
-  isAdding: boolean;
-  isFetching: boolean;
-  isAdded: boolean;
-  addError: AppError | null;
-  items: LookupStudioItem[];
-  studiosWithStatus: StudioWithExistingStatus[];
-  studioDefaults: StudioDefaults;
-}
-
-type RootState = AppState & {
-  addMovie: AddMovieState;
-};
-
 const defaultStudioDefaults: StudioDefaults = {
   rootFolderPath: '',
   monitored: true,
@@ -86,91 +67,69 @@ const defaultStudioDefaults: StudioDefaults = {
   tags: [],
 };
 
+const AUTH_HEADERS = {
+  'X-Api-Key': window.Whisparr.apiKey,
+  'X-Whisparr-Client': 'Whisparr',
+};
+
+function apiPost<T, TBody>(path: string, body: TBody): Promise<T> {
+  return fetchJson<T, TBody>({
+    path: `${urlBase}${apiRoot}${path}`,
+    method: 'POST',
+    body,
+    headers: AUTH_HEADERS,
+  });
+}
+
+interface SearchResource {
+  foreignId: string;
+  studio: Studio;
+  isExisting: boolean;
+}
+
 function useAddNewStudio() {
   const dispatch = useDispatch();
-  const addMovie = useSelector((state: RootState) => state.addMovie);
   const uiSettings = useSelector(createUISettingsSelector());
   const existingStudiosCount = useSelector(
     (state: AppState) => state.studios.items.length
   );
   const [term, setTerm] = useState('');
-
-  const studioLookupTimeout = React.useRef<ReturnType<
-    typeof setTimeout
-  > | null>(null);
+  const [debouncedTerm, setDebouncedTerm] = useState('');
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   React.useEffect(() => {
     dispatch(fetchRootFolders());
     dispatch(fetchQueueDetails());
     return () => {
-      if (studioLookupTimeout.current) {
-        clearTimeout(studioLookupTimeout.current);
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
       }
-      dispatch(clearAddMovie());
       dispatch(clearQueueDetails());
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // When lookup results change, check which studios already exist
-  React.useEffect(() => {
-    if (addMovie?.items && addMovie.items.length > 0) {
-      const foreignIds = addMovie.items
-        .map((item: LookupStudioItem) => item.studio.foreignId)
-        .filter((id: string | undefined) => id);
-
-      if (foreignIds.length > 0) {
-        const { request } = createAjaxRequest({
-          url: '/studio/list',
-          method: 'POST',
-          contentType: 'application/json',
-          data: JSON.stringify(foreignIds),
-        });
-
-        request.done((existingStudios: Studio[]) => {
-          // Create a map of foreignId to full studio object
-          const existingStudioMap = new Map(
-            existingStudios.map((s) => [s.foreignId, s])
-          );
-
-          // Map over lookup items, using full studio data if available
-          const mapped = addMovie.items.map((item: LookupStudioItem) => {
-            const fullStudio = existingStudioMap.get(item.studio.foreignId);
-            return {
-              studio: fullStudio || item.studio,
-              isExistingStudio: !!fullStudio,
-            };
-          });
-
-          dispatch(setStudiosWithStatus(mapped));
-        });
-
-        request.fail(() => {
-          // If the request fails, assume none exist
-          const mapped = addMovie.items.map((item: LookupStudioItem) => ({
-            studio: item.studio,
-            isExistingStudio: false,
-          }));
-
-          dispatch(setStudiosWithStatus(mapped));
-        });
-      }
-    } else {
-      dispatch(setStudiosWithStatus([]));
-    }
-  }, [addMovie?.items, addMovie?.isAdding, dispatch]);
+  const {
+    data: searchResources = [],
+    isFetching,
+    error,
+  } = useApiQuery<SearchResource[]>({
+    path: '/lookup/studio',
+    queryParams: { term: debouncedTerm },
+    queryOptions: { enabled: !!debouncedTerm.trim() },
+  });
 
   const onStudioLookupChange = React.useCallback(
     (value: string) => {
       setTerm(value);
-      if (studioLookupTimeout.current) {
-        clearTimeout(studioLookupTimeout.current);
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
       }
       if (value.trim() === '') {
-        dispatch(clearAddMovie());
+        setDebouncedTerm('');
       } else {
-        studioLookupTimeout.current = setTimeout(() => {
-          dispatch(lookupStudio({ term: value }));
+        timeoutRef.current = setTimeout(() => {
+          setDebouncedTerm(value);
         }, 300);
       }
     },
@@ -179,18 +138,21 @@ function useAddNewStudio() {
 
   const onClearStudioLookupPress = React.useCallback(() => {
     setTerm('');
-    dispatch(clearAddMovie());
-  }, [dispatch]);
+    setDebouncedTerm('');
+  }, []);
 
   return {
-    isPopulated: addMovie?.isPopulated || false,
-    error: addMovie?.error,
-    isAdding: addMovie?.isAdding || false,
-    isFetching: addMovie?.isFetching || false,
-    isAdded: addMovie?.isAdded || false,
-    addError: addMovie?.addError,
-    items: addMovie?.items || [],
-    studiosWithStatus: addMovie?.studiosWithStatus || [],
+    isPopulated: !!debouncedTerm.trim() && !isFetching,
+    error,
+    isAdding: false,
+    isFetching: isFetching && !!debouncedTerm.trim(),
+    isAdded: false,
+    addError: null,
+    items: searchResources,
+    studiosWithStatus: searchResources.map((r) => ({
+      studio: r.studio,
+      isExistingStudio: r.isExisting,
+    })),
     term,
     colorImpairedMode: uiSettings.enableColorImpairedMode,
     hasExistingStudios: existingStudiosCount > 0,
@@ -211,25 +173,38 @@ export function useAddNewStudioSearchResult() {
   };
 }
 
-export function useAddNewStudioModalContent(foreignId: string) {
+export function useAddNewStudioModalContent(studio: Studio) {
   const dispatch = useDispatch();
   const { isSmallScreen } = useSelector(createDimensionsSelector());
   const systemStatus = useSelector(createSystemStatusSelector());
   const safeForWorkMode = useSelector(
     (state: AppState) => state.settings.safeForWorkMode
   );
-  const addMovieState = useSelector((state: RootState) => state.addMovie);
 
-  const {
-    isAdding = false,
-    addError,
-    studioDefaults = defaultStudioDefaults,
-  } = addMovieState || {};
+  const addMovieState = useSelector(
+    (
+      state: AppState & {
+        addMovie: { studioDefaults: StudioDefaults; addError?: ApiError };
+      }
+    ) => state.addMovie
+  );
+
+  const { studioDefaults = defaultStudioDefaults } = addMovieState || {};
+
+  const mutation = useMutation<Studio, ApiError, Studio>({
+    mutationFn: (studioToAdd: Studio) => {
+      return apiPost<Studio, Studio>('/studio', studioToAdd);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['/studio/paged'] });
+      queryClient.invalidateQueries({ queryKey: ['/lookup/studio'] });
+    },
+  });
 
   const { settings, validationErrors, validationWarnings } = selectSettings(
     studioDefaults,
     {},
-    addError
+    mutation.error
   ) as {
     settings: AddStudioSettings;
     validationErrors: unknown[];
@@ -244,22 +219,21 @@ export function useAddNewStudioModalContent(foreignId: string) {
   );
 
   const onAddStudioPress = React.useCallback(() => {
-    dispatch(
-      addStudio({
-        foreignId,
-        rootFolderPath: settings.rootFolderPath.value,
-        monitored: settings.monitored.value === true,
-        moviesMonitored: settings.moviesMonitored.value === true,
-        qualityProfileId: settings.qualityProfileId.value,
-        searchForMovie: settings.searchForMovie.value,
-        tags: settings.tags.value,
-      })
-    );
-  }, [dispatch, foreignId, settings]);
+    const studioToAdd = getNewStudio(cloneDeep(studio) as object, {
+      rootFolderPath: settings.rootFolderPath.value,
+      monitored: settings.monitored.value === true,
+      moviesMonitored: settings.moviesMonitored.value === true,
+      qualityProfileId: settings.qualityProfileId.value,
+      searchForMovie: settings.searchForMovie.value,
+      tags: settings.tags.value,
+    }) as Studio;
+    studioToAdd.id = 0;
+    mutation.mutate(studioToAdd);
+  }, [studio, settings, mutation]);
 
   return {
-    addError,
-    isAdding,
+    addError: mutation.error,
+    isAdding: mutation.isPending,
     isSmallScreen,
     isWindows: systemStatus.isWindows,
     safeForWorkMode,

--- a/src/Whisparr.Api.V3/Search/SearchController.cs
+++ b/src/Whisparr.Api.V3/Search/SearchController.cs
@@ -27,6 +27,7 @@ namespace Whisparr.Api.V3.Search
         private readonly IConfigService _configService;
         private readonly IImportListExclusionService _exclusionService;
         private readonly IMovieService _movieService;
+        private readonly IStudioService _studioService;
 
         public SearchController(ISearchForNewMovie searchProxy,
                                 IBuildFileNames fileNameBuilder,
@@ -34,7 +35,8 @@ namespace Whisparr.Api.V3.Search
                                 IMapCoversToLocal coverMapper,
                                 IConfigService configService,
                                 IImportListExclusionService exclusionService,
-                                IMovieService movieService)
+                                IMovieService movieService,
+                                IStudioService studioService)
         {
             _searchProxy = searchProxy;
             _fileNameBuilder = fileNameBuilder;
@@ -43,6 +45,7 @@ namespace Whisparr.Api.V3.Search
             _configService = configService;
             _exclusionService = exclusionService;
             _movieService = movieService;
+            _studioService = studioService;
         }
 
         [HttpGet("scene")]
@@ -67,7 +70,9 @@ namespace Whisparr.Api.V3.Search
         public object SearchStudio([FromQuery] string term)
         {
             var searchResults = _searchProxy.SearchForNewStudio(term);
-            return MapToResource(searchResults).ToList();
+            var searchResources = MapToResource(searchResults).ToList();
+            MapToExistingStudios(searchResources);
+            return searchResources;
         }
 
         [HttpGet("performer")]
@@ -80,6 +85,19 @@ namespace Whisparr.Api.V3.Search
         private void MapToExistingMovies(List<SearchResource> searchResources)
         {
             var matches = _movieService.FindByForeignIds(searchResources.Select(m => m.ForeignId).ToList());
+            foreach (var s in searchResources)
+            {
+                var match = matches.Where(m => m.ForeignId == s.ForeignId);
+                if (match.Any())
+                {
+                    s.isExisting = true;
+                }
+            }
+        }
+
+        private void MapToExistingStudios(List<SearchResource> searchResources)
+        {
+            var matches = _studioService.FindByForeignIds(searchResources.Select(s => s.ForeignId).ToList());
             foreach (var s in searchResources)
             {
                 var match = matches.Where(m => m.ForeignId == s.ForeignId);


### PR DESCRIPTION
#### Database Migration

NO

#### Description

smaller part of https://github.com/Whisparr/Whisparr-Eros/pull/300

moves the studio lookup/add flow off redux and onto tanstack query, matching the pattern already used for movies. the isExisting flag now comes directly from the backend lookup endpoint instead of requiring a separate round-trip

