### PR TITLE
refactor: support PATCH and dynamic paths in useApiMutation

### DIFF
--- a/frontend/src/Helpers/Hooks/useApiMutation.ts
+++ b/frontend/src/Helpers/Hooks/useApiMutation.ts
@@ -1,5 +1,4 @@
 import { useMutation, UseMutationOptions } from '@tanstack/react-query';
-import { useMemo } from 'react';
 import { ValidationFailures } from 'Store/Selectors/selectSettings';
 import {
   ValidationError,
@@ -15,32 +14,31 @@ import getQueryString, { QueryParams } from 'Utilities/Fetch/getQueryString';
 
 interface MutationOptions<T, TData> extends Omit<
   FetchJsonOptions<TData>,
-  'method'
+  'method' | 'path'
 > {
-  method: 'POST' | 'PUT' | 'DELETE';
+  method: 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+  path: string | ((data: TData) => string);
   mutationOptions?: Omit<UseMutationOptions<T, ApiError, TData>, 'mutationFn'>;
   queryParams?: QueryParams;
 }
 
 function useApiMutation<T, TData>(options: MutationOptions<T, TData>) {
-  const requestOptions = useMemo(() => {
-    return {
-      ...options,
-      path: getQueryPath(options.path) + getQueryString(options.queryParams),
-      headers: {
-        ...options.headers,
-        'X-Api-Key': window.Whisparr.apiKey,
-        'X-Whisparr-Client': 'Whisparr',
-      },
-    };
-  }, [options]);
-
   return useMutation<T, ApiError, TData>({
     ...options.mutationOptions,
-    mutationFn: async (data?: TData) => {
-      const { path, ...otherOptions } = requestOptions;
+    mutationFn: async (data: TData) => {
+      const { path, queryParams, mutationOptions, ...otherOptions } = options;
+      const resolvedPath = typeof path === 'function' ? path(data) : path;
 
-      return fetchJson<T, TData>({ path, ...otherOptions, body: data });
+      return fetchJson<T, TData>({
+        ...otherOptions,
+        path: getQueryPath(resolvedPath) + getQueryString(queryParams),
+        headers: {
+          ...options.headers,
+          'X-Api-Key': window.Whisparr.apiKey,
+          'X-Whisparr-Client': 'Whisparr',
+        },
+        body: data,
+      });
     },
   });
 }


### PR DESCRIPTION
#### Database Migration

NO

#### Description

add PATCH to the allowed methods and allow path to be a function of the mutation data, so dynamic routes like `/history/failed/{id}` can go through the standard client. 
backwards compatible, string paths are unchanged

#### Fixes Unrelated Issues
- mutationOptions leaked into fetchJson — the old spread { ...options } included mutationOptions in requestOptions, which then ended up in ...otherOptions and was passed directly to fetchJson. The new explicit destructure correctly excludes it.
- queryParams leaked the same way — same issue, same fix.

#### Todos

- [x] Tests
