### PR TITLE
fix: stop add-studio/performer lookup from looping requests

### DIFF
--- a/frontend/src/Performer/AddPerformer/useAddNewPerformer.ts
+++ b/frontend/src/Performer/AddPerformer/useAddNewPerformer.ts
@@ -159,7 +159,7 @@ function useAddNewPerformer() {
     } else {
       dispatch(setPerformersWithStatus([]));
     }
-  }, [addPerformer?.items, addPerformer, dispatch]);
+  }, [addPerformer?.items, addPerformer?.isAdding, dispatch]);
 
   const onPerformerLookupChange = React.useCallback(
     (value: string) => {

--- a/frontend/src/Studio/AddNewStudio/useAddNewStudio.ts
+++ b/frontend/src/Studio/AddNewStudio/useAddNewStudio.ts
@@ -158,7 +158,7 @@ function useAddNewStudio() {
     } else {
       dispatch(setStudiosWithStatus([]));
     }
-  }, [addMovie?.items, addMovie, dispatch]);
+  }, [addMovie?.items, addMovie?.isAdding, dispatch]);
 
   const onStudioLookupChange = React.useCallback(
     (value: string) => {


### PR DESCRIPTION
#### Database Migration

NO

#### Description

fixes the infinite loop where typing in the "add new studio/performer" search field would spam /studio/list requests (the useEffect was re-triggering itself because it depended on the whole addMovie state object which it was also updating)
smallest possible fix
