### PR TITLE
refactor: use bulk delete endpoints for movies, scenes and performers

### DIFF
--- a/frontend/src/Movie/Index/Select/Delete/useDeleteMovieModalFooterHandler.ts
+++ b/frontend/src/Movie/Index/Select/Delete/useDeleteMovieModalFooterHandler.ts
@@ -17,7 +17,8 @@ export function useDeleteMovieModalFooterHandler({
       onModalClose();
       mutate({
         movieIds,
-        options: { deleteFiles, addImportExclusion },
+        deleteFiles,
+        addImportExclusion,
       });
     },
     [movieIds, onModalClose, mutate]

--- a/frontend/src/Movie/Index/Select/Delete/useDeleteMoviesMutation.ts
+++ b/frontend/src/Movie/Index/Select/Delete/useDeleteMoviesMutation.ts
@@ -1,53 +1,27 @@
-import { useMutation } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
 import { queryClient } from 'App/queryClient';
-
-interface DeleteMovieOptions {
-  deleteFiles: boolean;
-  addImportExclusion: boolean;
-}
+import useApiMutation from 'Helpers/Hooks/useApiMutation';
 
 interface DeleteMoviesPayload {
   movieIds: number[];
-  options: DeleteMovieOptions;
+  deleteFiles: boolean;
+  addImportExclusion: boolean;
 }
 
 export function useDeleteMoviesMutation() {
   const navigate = useNavigate();
 
-  // TODO: Move to useApiMutation
-  const mutation = useMutation<void, Error, DeleteMoviesPayload>({
-    mutationFn: async ({ movieIds, options }: DeleteMoviesPayload) => {
-      // Delete movies sequentially
-      for (const id of movieIds) {
-        const queryParams = new URLSearchParams({
-          deleteFiles: String(options.deleteFiles),
-          addImportExclusion: String(options.addImportExclusion),
+  const mutation = useApiMutation<unknown, DeleteMoviesPayload>({
+    method: 'DELETE',
+    path: '/movie/editor',
+    mutationOptions: {
+      onSuccess: () => {
+        queryClient.invalidateQueries({
+          queryKey: ['/movie/paged'],
         });
 
-        const response = await fetch(
-          `/api/v3/movie/${id}?${queryParams.toString()}`,
-          {
-            method: 'DELETE',
-            headers: {
-              'X-Api-Key': window.Whisparr.apiKey,
-            },
-          }
-        );
-
-        if (!response.ok) {
-          throw new Error(`Failed to delete item ${id}`);
-        }
-      }
-    },
-    onSuccess: () => {
-      // Invalidate all movie paged queries
-      queryClient.invalidateQueries({
-        queryKey: ['/movie/paged'],
-      });
-
-      // Navigate back to movies list
-      navigate('/movies');
+        navigate('/movies');
+      },
     },
   });
 

--- a/frontend/src/Performer/Index/Select/Delete/useDeletePerformerModalFooterHandler.ts
+++ b/frontend/src/Performer/Index/Select/Delete/useDeletePerformerModalFooterHandler.ts
@@ -18,7 +18,8 @@ export function useDeletePerformerModalFooterHandler({
       onModalClose(); // Close modal immediately when delete is confirmed
       deleteMutation.mutate({
         performerIds,
-        options: { deleteFiles, addImportExclusion },
+        deleteFiles,
+        addImportExclusion,
       });
     },
     [performerIds, onModalClose, deleteMutation]

--- a/frontend/src/Performer/Index/Select/Delete/useDeletePerformersMutation.ts
+++ b/frontend/src/Performer/Index/Select/Delete/useDeletePerformersMutation.ts
@@ -1,52 +1,27 @@
-import { useMutation } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
 import { queryClient } from 'App/queryClient';
-
-interface DeletePerformerOptions {
-  deleteFiles: boolean;
-  addImportExclusion: boolean;
-}
+import useApiMutation from 'Helpers/Hooks/useApiMutation';
 
 interface DeletePerformersPayload {
   performerIds: number[];
-  options: DeletePerformerOptions;
+  deleteFiles: boolean;
+  addImportExclusion: boolean;
 }
 
 export function useDeletePerformersMutation() {
   const navigate = useNavigate();
 
-  const mutation = useMutation<void, Error, DeletePerformersPayload>({
-    mutationFn: async ({ performerIds, options }: DeletePerformersPayload) => {
-      // Delete performers sequentially
-      for (const id of performerIds) {
-        const queryParams = new URLSearchParams({
-          deleteFiles: String(options.deleteFiles),
-          addImportExclusion: String(options.addImportExclusion),
+  const mutation = useApiMutation<unknown, DeletePerformersPayload>({
+    method: 'DELETE',
+    path: '/performer/editor',
+    mutationOptions: {
+      onSuccess: () => {
+        queryClient.invalidateQueries({
+          queryKey: ['/performer/paged'],
         });
 
-        const response = await fetch(
-          `/api/v3/performer/${id}?${queryParams.toString()}`,
-          {
-            method: 'DELETE',
-            headers: {
-              'X-Api-Key': window.Whisparr.apiKey,
-            },
-          }
-        );
-
-        if (!response.ok) {
-          throw new Error(`Failed to delete performer ${id}`);
-        }
-      }
-    },
-    onSuccess: () => {
-      // Invalidate all performer paged queries
-      queryClient.invalidateQueries({
-        queryKey: ['/performer/paged'],
-      });
-
-      // Navigate back to performers list
-      navigate('/performers');
+        navigate('/performers');
+      },
     },
   });
 

--- a/frontend/src/Scene/Index/Select/Delete/useDeleteSceneModalFooterHandler.ts
+++ b/frontend/src/Scene/Index/Select/Delete/useDeleteSceneModalFooterHandler.ts
@@ -17,8 +17,9 @@ export function useDeleteSceneModalFooterHandler({
     (deleteFiles: boolean, addImportExclusion: boolean) => {
       onModalClose(); // Close modal immediately when delete is confirmed
       deleteMutation.mutate({
-        sceneIds,
-        options: { deleteFiles, addImportExclusion },
+        movieIds: sceneIds,
+        deleteFiles,
+        addImportExclusion,
       });
     },
     [sceneIds, onModalClose, deleteMutation]

--- a/frontend/src/Scene/Index/Select/Delete/useDeleteScenesMutation.ts
+++ b/frontend/src/Scene/Index/Select/Delete/useDeleteScenesMutation.ts
@@ -1,53 +1,27 @@
-import { useMutation } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
 import { queryClient } from 'App/queryClient';
-
-interface DeleteMovieOptions {
-  deleteFiles: boolean;
-  addImportExclusion: boolean;
-}
+import useApiMutation from 'Helpers/Hooks/useApiMutation';
 
 interface DeleteScenesPayload {
-  sceneIds: number[];
-  options: DeleteMovieOptions;
+  movieIds: number[];
+  deleteFiles: boolean;
+  addImportExclusion: boolean;
 }
 
 export function useDeleteScenesMutation() {
   const navigate = useNavigate();
 
-  // TODO: Move to useApiMutation
-  const mutation = useMutation<void, Error, DeleteScenesPayload>({
-    mutationFn: async ({ sceneIds, options }: DeleteScenesPayload) => {
-      // Delete scenes sequentially
-      for (const id of sceneIds) {
-        const queryParams = new URLSearchParams({
-          deleteFiles: String(options.deleteFiles),
-          addImportExclusion: String(options.addImportExclusion),
+  const mutation = useApiMutation<unknown, DeleteScenesPayload>({
+    method: 'DELETE',
+    path: '/movie/editor',
+    mutationOptions: {
+      onSuccess: () => {
+        queryClient.invalidateQueries({
+          queryKey: ['/movie/paged'],
         });
 
-        const response = await fetch(
-          `/api/v3/movie/${id}?${queryParams.toString()}`,
-          {
-            method: 'DELETE',
-            headers: {
-              'X-Api-Key': globalThis.Whisparr.apiKey,
-            },
-          }
-        );
-
-        if (!response.ok) {
-          throw new Error(`Failed to delete item ${id}`);
-        }
-      }
-    },
-    onSuccess: () => {
-      // Invalidate all movie paged queries
-      queryClient.invalidateQueries({
-        queryKey: ['/movie/paged'],
-      });
-
-      // Navigate back to scenes list
-      navigate('/scenes');
+        navigate('/scenes');
+      },
     },
   });
 


### PR DESCRIPTION
#### Database Migration

NO

#### Description

switch from firing one request per selected id in a sequential loop to just calling a bulk delete endpoint. this is now done for scenes, movies and performers.
also reuse `useApiMutation` instead of the repeated code here