### PR TITLE
Fix Scene Title seperator

### DIFF
--- a/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
@@ -55,7 +55,7 @@ namespace NzbDrone.Core.Organizer
                                                                             RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         // Matches any of the four scene title tokens: {Scene Title}, {Scene CleanTitle}, {Scene CleanTitleNoSeasonEpisode}, {Scene TitleThe}
-        public static readonly Regex SceneTitleTokenRegex = new Regex(@"\{Scene (Title|CleanTitle|CleanTitleNoSeasonEpisode|TitleThe)\}",
+        public static readonly Regex SceneTitleTokenRegex = new Regex(@"\{Scene( |\.|-|_)(Title|CleanTitle|CleanTitleNoSeasonEpisode|TitleThe)\}",
                                           RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         public static readonly Regex MainFolderRegex = new Regex(@"^(?<main>(?:[a-zA-Z0-9]+(?:\\|\/)))",


### PR DESCRIPTION
#### Database Migration

NO

#### Description

Alter regex to allow the space, period, underscore, or dash for the scene title and variations

#### Screenshot(s) (if UI related)

<details>

</details>

#### Todos

- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)

#### Issues Fixed or Closed by this PR

<!-- If multiple, put each on a separate line -->

- Fixes whisparr/whisparr#1101
