### PR TITLE
feat: no-date episodic scene parsing for tracker releases

### DIFF
--- a/docs/dev/no-date-episodic-code-map.md
+++ b/docs/dev/no-date-episodic-code-map.md
@@ -1,0 +1,43 @@
+# No-Date Episodic Code Map
+
+## Parser entry
+
+| File | Method | Line (approx) | Change |
+|------|--------|---------------|--------|
+| `src/NzbDrone.Core/Parser/Parser.cs` | `ParseMovieTitle` | 264 | Capture regex result; no-date fallback before StashId |
+| `src/NzbDrone.Core/Parser/Parser.cs` | `TryParseNoDateEpisodicRelease` | new | Bracketed SxxExx / Season Episode parsing |
+| `src/NzbDrone.Core/Parser/Parser.cs` | `HasExplicitNoDateEpisodicMarker` | new | Override gate for weak E### matches |
+
+## Model
+
+| File | Method | Change |
+|------|--------|--------|
+| `src/NzbDrone.Core/Parser/Model/ParsedMovieInfo.cs` | fields | Season, EpisodeStart, EpisodeEnd, ParserSource, IsNoDateEpisodic, IsEpisodeRange, HasReleaseDate |
+
+## Resolver
+
+| File | Method | Change |
+|------|--------|--------|
+| `src/NzbDrone.Core/Parser/ParsingService.cs` | `GetSceneMovie` | Target-aware no-date match before FindScene |
+| `src/NzbDrone.Core/Movies/MovieService.cs` | `IsNoDateEpisodicSceneMatch` | Studio/title/episode validation |
+
+## Sample title current behavior (pre-fix)
+
+| Release | Parse | Failure |
+|---------|-------|---------|
+| `[AgentRedGirl] All My Roommates Love Season 2: Episode 2` | null | No Season/Episode regex |
+| `[Wildeer Studio] Lara In Trouble S01 E01 [1080p]` | broken | L128 E01 regex; wrong StudioTitle |
+| `[Wildeer Studio] Lara In Trouble S01 E01 - E06 [1080p]` | broken | Range ignored |
+
+## Config
+
+| File | Settings |
+|------|----------|
+| `IConfigService.cs` / `ConfigService.cs` | WhisparrNoDateEpisodicParsingMode, RangePackMode, MinimumConfidence, PreferGrabbedTargetOnImport |
+
+## Tests
+
+| File | Purpose |
+|------|---------|
+| `NoDateEpisodicParserFixture.cs` | Parser positive/negative/regression |
+| `NoDateEpisodicMatchFixture.cs` | Target-aware resolver |

--- a/docs/dev/no-date-episodic-parser-plan.md
+++ b/docs/dev/no-date-episodic-parser-plan.md
@@ -1,0 +1,11 @@
+# No-Date Episodic Scene Parser — Implementation Plan
+
+See the approved plan in Cursor. This branch implements layered parsing:
+
+1. Existing date/studio parser path first
+2. No-date episodic parser fallback/override second
+3. Target-aware resolver third
+4. Pack-range safety gates fourth
+5. Import mapping improvements fifth
+
+Branch: `feature/no-date-episodic-scene-parser`

--- a/docs/dev/no-date-episodic-parser-progress.md
+++ b/docs/dev/no-date-episodic-parser-progress.md
@@ -9,6 +9,7 @@
 - Added config kill switches (defaults: InteractiveOnly)
 - Added import conflict guard for grabbed no-date episodic targets
 - Core unit suite: 3950 passed, 0 failed
+- Diagnostics: structured debug logs in parser and resolver; Parse API inherits new ParsedMovieInfo fields via existing endpoint
 
 ## v1 limitations
 

--- a/docs/dev/no-date-episodic-parser-progress.md
+++ b/docs/dev/no-date-episodic-parser-progress.md
@@ -1,0 +1,16 @@
+# No-Date Episodic Parser — Progress Log
+
+## 2025-06-25
+
+- Created branch `feature/no-date-episodic-scene-parser` from `eros-develop`
+- Added `ParsedMovieInfo` transient no-date episodic fields
+- Implemented `TryParseNoDateEpisodicRelease` with explicit-marker override for weak E### regex matches
+- Added target-aware resolver in `ParsingService.GetSceneMovie` and `MovieService.IsNoDateEpisodicSceneMatch`
+- Added config kill switches (defaults: InteractiveOnly)
+- Added import conflict guard for grabbed no-date episodic targets
+- Core unit suite: 3950 passed, 0 failed
+
+## v1 limitations
+
+- Multi-file range packs: per-file import only; single combined pack files may require manual import
+- Cross-episode pack re-grab dedup relies on existing grab history; dedicated pack history deferred to v2

--- a/src/NzbDrone.Core.Test/MovieTests/MovieServiceTests/NoDateEpisodicMatchFixture.cs
+++ b/src/NzbDrone.Core.Test/MovieTests/MovieServiceTests/NoDateEpisodicMatchFixture.cs
@@ -1,0 +1,141 @@
+using System.Collections.Generic;
+using FizzWare.NBuilder;
+using FluentAssertions;
+using NUnit.Framework;
+using NzbDrone.Core.Configuration;
+using NzbDrone.Core.Movies;
+using NzbDrone.Core.Movies.Studios;
+using NzbDrone.Core.Parser.Model;
+using NzbDrone.Core.Test.Framework;
+
+namespace NzbDrone.Core.Test.MovieTests.MovieServiceTests
+{
+    [TestFixture]
+    public class NoDateEpisodicMatchFixture : CoreTest<MovieService>
+    {
+        private Movie _targetScene;
+        private ParsedMovieInfo _singleEpisodeParse;
+        private ParsedMovieInfo _rangePackParse;
+
+        [SetUp]
+        public void Setup()
+        {
+            _targetScene = Builder<Movie>.CreateNew()
+                .With(m => m.Id = 42)
+                .With(m => m.Title = "Lara in Trouble S01 E01")
+                .With(m => m.MovieMetadata.Value.StudioTitle = "Wildeer Studio")
+                .With(m => m.MovieMetadata.Value.StudioForeignId = "wildeer-studio-id")
+                .With(m => m.MovieMetadata.Value.ItemType = ItemType.Scene)
+                .Build();
+
+            _singleEpisodeParse = new ParsedMovieInfo
+            {
+                StudioTitle = "Wildeer Studio",
+                ReleaseTokens = "Lara In Trouble",
+                Season = "1",
+                Episode = "S01E01",
+                EpisodeStart = "1",
+                IsNoDateEpisodic = true
+            };
+
+            _rangePackParse = new ParsedMovieInfo
+            {
+                StudioTitle = "Wildeer Studio",
+                ReleaseTokens = "Lara In Trouble",
+                Season = "1",
+                Episode = "S01E01",
+                EpisodeStart = "1",
+                EpisodeEnd = "6",
+                IsNoDateEpisodic = true,
+                IsEpisodeRange = true
+            };
+
+            Mocker.GetMock<IStudioService>()
+                .Setup(s => s.FindAllByTitle("Wildeer Studio"))
+                .Returns(new List<Studio>
+                {
+                    new Studio { ForeignId = "wildeer-studio-id", Title = "Wildeer Studio" }
+                });
+
+            Mocker.GetMock<IConfigService>()
+                .SetupGet(c => c.NoDateEpisodicMinimumConfidence)
+                .Returns(85);
+        }
+
+        [Test]
+        public void should_match_single_episode_release_to_target_scene()
+        {
+            Subject.IsNoDateEpisodicSceneMatch(_singleEpisodeParse, _targetScene, true).Should().BeTrue();
+        }
+
+        [Test]
+        public void should_match_range_pack_when_target_episode_is_inside_range()
+        {
+            Subject.IsNoDateEpisodicSceneMatch(_rangePackParse, _targetScene, true).Should().BeTrue();
+        }
+
+        [Test]
+        public void should_reject_range_pack_when_target_episode_is_outside_range()
+        {
+            var targetEpisodeSeven = Builder<Movie>.CreateNew()
+                .With(m => m.Title = "Lara in Trouble S01 E07")
+                .With(m => m.MovieMetadata.Value.StudioTitle = "Wildeer Studio")
+                .With(m => m.MovieMetadata.Value.StudioForeignId = "wildeer-studio-id")
+                .With(m => m.MovieMetadata.Value.ItemType = ItemType.Scene)
+                .Build();
+
+            Subject.IsNoDateEpisodicSceneMatch(_rangePackParse, targetEpisodeSeven, true).Should().BeFalse();
+        }
+
+        [Test]
+        public void should_reject_when_studio_does_not_match()
+        {
+            var wrongStudioParse = new ParsedMovieInfo
+            {
+                StudioTitle = "Other Studio",
+                ReleaseTokens = "Lara In Trouble",
+                Season = "1",
+                Episode = "S01E01",
+                EpisodeStart = "1",
+                IsNoDateEpisodic = true
+            };
+
+            Mocker.GetMock<IStudioService>()
+                .Setup(s => s.FindAllByTitle("Other Studio"))
+                .Returns(new List<Studio>());
+
+            Subject.IsNoDateEpisodicSceneMatch(wrongStudioParse, _targetScene, true).Should().BeFalse();
+        }
+
+        [Test]
+        public void should_reject_when_title_does_not_match()
+        {
+            var wrongTitleParse = new ParsedMovieInfo
+            {
+                StudioTitle = "Wildeer Studio",
+                ReleaseTokens = "Different Title",
+                Season = "1",
+                Episode = "S01E01",
+                EpisodeStart = "1",
+                IsNoDateEpisodic = true
+            };
+
+            Subject.IsNoDateEpisodicSceneMatch(wrongTitleParse, _targetScene, true).Should().BeFalse();
+        }
+
+        [TestCase("Lara in Trouble S01 E01", 1, 1, true)]
+        [TestCase("All My Roommates Love Season 2 - Episode 2", 2, 2, true)]
+        [TestCase("Some Random Title", 0, 0, false)]
+        public void should_extract_season_episode_from_title(string title, int season, int episode, bool expected)
+        {
+            var result = MovieService.TryExtractSeasonEpisode(title, out var parsedSeason, out var parsedEpisode);
+
+            result.Should().Be(expected);
+            if (expected)
+            {
+                parsedSeason.Should().Be(season);
+                parsedEpisode.Should().Be(episode);
+            }
+        }
+    }
+}

--- a/src/NzbDrone.Core.Test/ParserTests/NoDateEpisodicParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/NoDateEpisodicParserFixture.cs
@@ -1,0 +1,86 @@
+using FluentAssertions;
+using NUnit.Framework;
+using NzbDrone.Core.Qualities;
+using NzbDrone.Core.Test.Framework;
+
+namespace NzbDrone.Core.Test.ParserTests
+{
+    [TestFixture]
+    public class NoDateEpisodicParserFixture : CoreTest
+    {
+        [TestCase("[Wildeer Studio] Lara In Trouble S01 E01 [1080p]", "Wildeer Studio", "Lara In Trouble", "1", "S01E01", "1", null, false)]
+        [TestCase("[Wildeer Studio] Lara In Trouble S01E01 [1080p]", "Wildeer Studio", "Lara In Trouble", "1", "S01E01", "1", null, false)]
+        [TestCase("[Wildeer Studio] Lara In Trouble S01 E01 - E06 [1080p]", "Wildeer Studio", "Lara In Trouble", "1", "S01E01", "1", "6", true)]
+        [TestCase("[AgentRedGirl] All My Roommates Love Season 2: Episode 2", "AgentRedGirl", "All My Roommates Love", "2", "S02E02", "2", null, false)]
+        [TestCase("[AgentRedGirl] All My Roommates Love Season 2 - Episode 2", "AgentRedGirl", "All My Roommates Love", "2", "S02E02", "2", null, false)]
+        public void should_parse_no_date_episodic_release(
+            string title,
+            string studioTitle,
+            string releaseTokens,
+            string season,
+            string episode,
+            string episodeStart,
+            string episodeEnd,
+            bool isRange)
+        {
+            var result = Parser.Parser.ParseMovieTitle(title);
+
+            result.Should().NotBeNull();
+            result.IsScene.Should().BeTrue();
+            result.IsNoDateEpisodic.Should().BeTrue();
+            result.ParserSource.Should().Be("NoDateEpisodic");
+            result.StudioTitle.Should().Be(studioTitle);
+            result.ReleaseTokens.Should().Be(releaseTokens);
+            result.MovieTitles[0].Should().Be(releaseTokens);
+            result.Season.Should().Be(season);
+            result.Episode.Should().Be(episode);
+            result.EpisodeStart.Should().Be(episodeStart);
+            result.EpisodeEnd.Should().Be(episodeEnd);
+            result.IsEpisodeRange.Should().Be(isRange);
+            result.ReleaseDate.Should().BeNullOrWhiteSpace();
+        }
+
+        [Test]
+        public void should_parse_1080p_quality_for_no_date_episodic_release()
+        {
+            var result = Parser.Parser.ParseMovieTitle("[Wildeer Studio] Lara In Trouble S01 E01 [1080p]");
+
+            result.Quality.Quality.Should().Be(Quality.WEBDL1080p);
+        }
+
+        [Test]
+        public void should_override_weak_regex_match_for_wildeer_title()
+        {
+            var result = Parser.Parser.ParseMovieTitle("[Wildeer Studio] Lara In Trouble S01 E01 [1080p]");
+
+            result.StudioTitle.Should().Be("Wildeer Studio");
+            result.StudioTitle.Should().NotContain("[");
+            result.ReleaseTokens.Should().Be("Lara In Trouble");
+        }
+
+        [TestCase("[Studio] Random Scene Title [1080p]")]
+        [TestCase("[Studio] The S01 Experiment [1080p]")]
+        [TestCase("[Studio] Some Title Part 01 [1080p]")]
+        [TestCase("[Studio] Episode Title Without Number [1080p]")]
+        public void should_not_parse_generic_bracketed_release_as_no_date_episodic(string title)
+        {
+            var result = Parser.Parser.ParseMovieTitle(title);
+
+            if (result != null)
+            {
+                result.IsNoDateEpisodic.Should().BeFalse();
+            }
+        }
+
+        [TestCase("Studio.24.06.14.Some.Scene.Title.1080p.WEB-DL")]
+        [TestCase("Studio.2024.06.14.Some.Scene.Title.2160p.WEB-DL")]
+        [TestCase("[Vixen] Matthew Meie, Erica Mori & Era Queen - Bratty College Girls Have Naughty Threesome (2025-12-03) [2160p]")]
+        public void should_not_mark_dated_scenes_as_no_date_episodic(string title)
+        {
+            var result = Parser.Parser.ParseMovieTitle(title);
+
+            result.Should().NotBeNull();
+            result.IsNoDateEpisodic.Should().BeFalse();
+        }
+    }
+}

--- a/src/NzbDrone.Core.Test/ParserTests/ParsingServiceTests/NoDateEpisodicMapFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/ParsingServiceTests/NoDateEpisodicMapFixture.cs
@@ -1,0 +1,71 @@
+using System.Collections.Generic;
+using FizzWare.NBuilder;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+using NzbDrone.Core.Configuration;
+using NzbDrone.Core.IndexerSearch.Definitions;
+using NzbDrone.Core.Movies;
+using NzbDrone.Core.Movies.Studios;
+using NzbDrone.Core.Parser;
+using NzbDrone.Core.Parser.Model;
+using NzbDrone.Test.Common;
+
+namespace NzbDrone.Core.Test.ParserTests.ParsingServiceTests
+{
+    [TestFixture]
+    public class NoDateEpisodicMapFixture : TestBase<ParsingService>
+    {
+        private Movie _targetScene;
+        private MovieSearchCriteria _searchCriteria;
+
+        [SetUp]
+        public void Setup()
+        {
+            _targetScene = Builder<Movie>.CreateNew()
+                .With(m => m.Id = 99)
+                .With(m => m.Title = "Lara in Trouble S01 E01")
+                .With(m => m.MovieMetadata.Value.StudioTitle = "Wildeer Studio")
+                .With(m => m.MovieMetadata.Value.StudioForeignId = "wildeer-studio-id")
+                .With(m => m.MovieMetadata.Value.ItemType = ItemType.Scene)
+                .Build();
+
+            _searchCriteria = new MovieSearchCriteria
+            {
+                Movie = _targetScene,
+                InteractiveSearch = true
+            };
+
+            Mocker.GetMock<IConfigService>()
+                .SetupGet(c => c.NoDateEpisodicParsingMode)
+                .Returns(NoDateEpisodicParsingMode.InteractiveOnly);
+
+            Mocker.GetMock<IConfigService>()
+                .SetupGet(c => c.NoDateEpisodicRangePackMode)
+                .Returns(NoDateEpisodicRangePackMode.InteractiveOnly);
+
+            Mocker.GetMock<IStudioService>()
+                .Setup(s => s.FindAllByTitle("Wildeer Studio"))
+                .Returns(new List<Studio>
+                {
+                    new Studio { ForeignId = "wildeer-studio-id", Title = "Wildeer Studio" }
+                });
+
+            Mocker.GetMock<IMovieService>()
+                .Setup(s => s.IsNoDateEpisodicSceneMatch(It.IsAny<ParsedMovieInfo>(), _targetScene, true))
+                .Returns(true);
+        }
+
+        [Test]
+        public void should_map_no_date_episodic_release_to_search_target()
+        {
+            var parsed = Parser.Parser.ParseMovieTitle("[Wildeer Studio] Lara In Trouble S01 E01 - E06 [1080p]");
+
+            var remoteMovie = Subject.Map(parsed, string.Empty, 0, _searchCriteria);
+
+            remoteMovie.Movie.Should().Be(_targetScene);
+            remoteMovie.MovieRequested.Should().BeTrue();
+            remoteMovie.ParsedMovieInfo.IsNoDateEpisodic.Should().BeTrue();
+        }
+    }
+}

--- a/src/NzbDrone.Core/Configuration/ConfigService.cs
+++ b/src/NzbDrone.Core/Configuration/ConfigService.cs
@@ -554,6 +554,30 @@ namespace NzbDrone.Core.Configuration
             set { SetValue("WhisparrFuzzyTitleMatchingThreshold", value); }
         }
 
+        public NoDateEpisodicParsingMode NoDateEpisodicParsingMode
+        {
+            get { return GetValueEnum("WhisparrNoDateEpisodicParsingMode", NoDateEpisodicParsingMode.InteractiveOnly); }
+            set { SetValue("WhisparrNoDateEpisodicParsingMode", value); }
+        }
+
+        public NoDateEpisodicRangePackMode NoDateEpisodicRangePackMode
+        {
+            get { return GetValueEnum("WhisparrNoDateEpisodicRangePackMode", NoDateEpisodicRangePackMode.InteractiveOnly); }
+            set { SetValue("WhisparrNoDateEpisodicRangePackMode", value); }
+        }
+
+        public int NoDateEpisodicMinimumConfidence
+        {
+            get { return GetValueInt("WhisparrNoDateEpisodicMinimumConfidence", 85); }
+            set { SetValue("WhisparrNoDateEpisodicMinimumConfidence", value); }
+        }
+
+        public bool PreferGrabbedTargetOnImport
+        {
+            get { return GetValueBoolean("WhisparrPreferGrabbedTargetOnImport", true); }
+            set { SetValue("WhisparrPreferGrabbedTargetOnImport", value); }
+        }
+
         public bool WhisparrValidateRuntime
         {
             get { return GetValueBoolean("WhisparrValidateRuntime", false); }

--- a/src/NzbDrone.Core/Configuration/IConfigService.cs
+++ b/src/NzbDrone.Core/Configuration/IConfigService.cs
@@ -120,6 +120,10 @@ namespace NzbDrone.Core.Configuration
         bool WhisparrCacheStudioAPI { get; }
         bool WhisparrCorruptFileDetection { get; }
         int WhisparrFuzzyTitleMatchingThreshold { get; }
+        NoDateEpisodicParsingMode NoDateEpisodicParsingMode { get; }
+        NoDateEpisodicRangePackMode NoDateEpisodicRangePackMode { get; }
+        int NoDateEpisodicMinimumConfidence { get; }
+        bool PreferGrabbedTargetOnImport { get; }
         MovieMetadataType WhisparrMovieMetadataSource { get; }
         bool WhisparrValidateRuntime { get; }
         int WhisparrValidateRuntimeLimit { get; }

--- a/src/NzbDrone.Core/Configuration/NoDateEpisodicParsingMode.cs
+++ b/src/NzbDrone.Core/Configuration/NoDateEpisodicParsingMode.cs
@@ -1,0 +1,10 @@
+namespace NzbDrone.Core.Configuration
+{
+    public enum NoDateEpisodicParsingMode
+    {
+        Off = 0,
+        InteractiveOnly = 1,
+        InteractiveAndAutomatic = 2,
+        AllIncludingRss = 3
+    }
+}

--- a/src/NzbDrone.Core/Configuration/NoDateEpisodicRangePackMode.cs
+++ b/src/NzbDrone.Core/Configuration/NoDateEpisodicRangePackMode.cs
@@ -1,0 +1,9 @@
+namespace NzbDrone.Core.Configuration
+{
+    public enum NoDateEpisodicRangePackMode
+    {
+        Off = 0,
+        InteractiveOnly = 1,
+        InteractiveAndAutomatic = 2
+    }
+}

--- a/src/NzbDrone.Core/MediaFiles/MovieImport/ImportDecisionMaker.cs
+++ b/src/NzbDrone.Core/MediaFiles/MovieImport/ImportDecisionMaker.cs
@@ -268,6 +268,14 @@ namespace NzbDrone.Core.MediaFiles.MovieImport
 
                         // Switch the movie so that the QualityProfile is populated
                         localMovie.Movie = matchedMovie;
+
+                        if (_configService.PreferGrabbedTargetOnImport
+                            && localMovie.DownloadClientMovieInfo?.IsNoDateEpisodic == true
+                            && fileMovieInfo?.IsNoDateEpisodic == true
+                            && !_movieService.IsNoDateEpisodicSceneMatch(fileMovieInfo, matchedMovie, true))
+                        {
+                            return new ImportDecision(localMovie, new ImportRejection(ImportRejectionReason.UnknownMovie, "Downloaded file episode conflicts with grabbed no-date episodic scene target"));
+                        }
                     }
                     else
                     {

--- a/src/NzbDrone.Core/Movies/MovieService.cs
+++ b/src/NzbDrone.Core/Movies/MovieService.cs
@@ -71,6 +71,7 @@ namespace NzbDrone.Core.Movies
         bool ExistsByMetadataId(int metadataId);
         void SetFileIds(List<Movie> movies);
         Dictionary<Movie, MovieParseMatchType> MatchMovies(string parsedMovieTitle, string releaseDate, string foreignId, string episode, List<Movie> movies, bool verifyDate, bool verifyEpisode);
+        bool IsNoDateEpisodicSceneMatch(ParsedMovieInfo parsedMovieInfo, Movie targetMovie, bool interactiveSearch);
         List<Movie> SearchMovies(string query);
         HashSet<int> AllMovieWithCollectionsTmdbIds();
     }
@@ -1160,6 +1161,171 @@ namespace NzbDrone.Core.Movies
             }
 
             return matches;
+        }
+
+        public bool IsNoDateEpisodicSceneMatch(ParsedMovieInfo parsedMovieInfo, Movie targetMovie, bool interactiveSearch)
+        {
+            if (parsedMovieInfo == null || targetMovie == null || !parsedMovieInfo.IsNoDateEpisodic)
+            {
+                return false;
+            }
+
+            if (targetMovie.MovieMetadata?.Value?.ItemType != ItemType.Scene)
+            {
+                _logger.Debug("NoDateEpisodicResolver rejected: target is not a scene");
+                return false;
+            }
+
+            if (!StudioMatchesNoDateEpisodic(parsedMovieInfo.StudioTitle, targetMovie))
+            {
+                _logger.Debug("NoDateEpisodicResolver rejected: studio mismatch '{0}' != '{1}'",
+                    parsedMovieInfo.StudioTitle,
+                    targetMovie.MovieMetadata.Value.StudioTitle);
+                return false;
+            }
+
+            if (!TitleMatchesNoDateEpisodic(parsedMovieInfo, targetMovie))
+            {
+                _logger.Debug("NoDateEpisodicResolver rejected: title score below threshold for target '{0}'", targetMovie.Title);
+                return false;
+            }
+
+            if (!TryExtractSeasonEpisode(targetMovie.Title, out var targetSeason, out var targetEpisode))
+            {
+                _logger.Debug("NoDateEpisodicResolver rejected: unable to extract season/episode from target '{0}'", targetMovie.Title);
+                return false;
+            }
+
+            if (!EpisodeWithinRange(parsedMovieInfo, targetSeason, targetEpisode))
+            {
+                _logger.Debug("NoDateEpisodicResolver rejected: target episode S{0:D2}E{1:D2} outside parsed range S{2}E{3}-S{4}E{5}",
+                    targetSeason,
+                    targetEpisode,
+                    parsedMovieInfo.Season,
+                    parsedMovieInfo.EpisodeStart,
+                    parsedMovieInfo.Season,
+                    parsedMovieInfo.EpisodeEnd ?? parsedMovieInfo.EpisodeStart);
+                return false;
+            }
+
+            _logger.Debug(
+                "NoDateEpisodicResolver target match: Target='{0}', Parsed='{1} / {2} / S{3}E{4}-S{5}E{6}', Reason='title+studio+episode-in-range'",
+                targetMovie.Title,
+                parsedMovieInfo.StudioTitle,
+                parsedMovieInfo.ReleaseTokens,
+                parsedMovieInfo.Season,
+                parsedMovieInfo.EpisodeStart,
+                parsedMovieInfo.Season,
+                parsedMovieInfo.IsEpisodeRange ? parsedMovieInfo.EpisodeEnd : parsedMovieInfo.EpisodeStart);
+
+            return true;
+        }
+
+        private bool StudioMatchesNoDateEpisodic(string parsedStudioTitle, Movie targetMovie)
+        {
+            var targetStudioTitle = targetMovie.MovieMetadata?.Value?.StudioTitle;
+            if (parsedStudioTitle.IsNullOrWhiteSpace() || targetStudioTitle.IsNullOrWhiteSpace())
+            {
+                return false;
+            }
+
+            var studios = _studioService.FindAllByTitle(parsedStudioTitle);
+            var targetStudioForeignId = targetMovie.MovieMetadata.Value.StudioForeignId;
+
+            if (studios != null && studios.Any(studio => studio.ForeignId == targetStudioForeignId))
+            {
+                return true;
+            }
+
+            return Parser.Parser.NormalizeEpisodeTitle(parsedStudioTitle)
+                .Equals(Parser.Parser.NormalizeEpisodeTitle(targetStudioTitle));
+        }
+
+        private bool TitleMatchesNoDateEpisodic(ParsedMovieInfo parsedMovieInfo, Movie targetMovie)
+        {
+            var parsedTitle = NormalizeNoDateEpisodicTitle(parsedMovieInfo.ReleaseTokens);
+            var targetTitle = NormalizeNoDateEpisodicTitle(StripSeasonEpisodeFromTitle(targetMovie.Title));
+
+            if (parsedTitle.Equals(targetTitle))
+            {
+                return true;
+            }
+
+            var minimumConfidence = _configService.NoDateEpisodicMinimumConfidence;
+            var score = FuzzySharp.Fuzz.Ratio(parsedTitle, targetTitle);
+            return score >= minimumConfidence;
+        }
+
+        private static string NormalizeNoDateEpisodicTitle(string value)
+        {
+            return Parser.Parser.NormalizeEpisodeTitle(value);
+        }
+
+        private static string StripSeasonEpisodeFromTitle(string title)
+        {
+            if (title.IsNullOrWhiteSpace())
+            {
+                return string.Empty;
+            }
+
+            title = Regex.Replace(title, @"\s*S\d{1,2}\s*E\d{1,3}\s*$", string.Empty, RegexOptions.IgnoreCase);
+            title = Regex.Replace(title, @"\s*Season\s+\d{1,2}\s*[:\-]?\s*Episode\s+\d{1,3}\s*$", string.Empty, RegexOptions.IgnoreCase);
+
+            return title.Trim();
+        }
+
+        public static bool TryExtractSeasonEpisode(string value, out int season, out int episode)
+        {
+            season = 0;
+            episode = 0;
+
+            if (value.IsNullOrWhiteSpace())
+            {
+                return false;
+            }
+
+            var sxxExxMatch = Regex.Match(value, @"S(?<season>\d{1,2})\s*E(?<episode>\d{1,3})", RegexOptions.IgnoreCase);
+            if (sxxExxMatch.Success
+                && int.TryParse(sxxExxMatch.Groups["season"].Value, out season)
+                && int.TryParse(sxxExxMatch.Groups["episode"].Value, out episode))
+            {
+                return true;
+            }
+
+            var seasonEpisodeMatch = Regex.Match(value, @"Season\s+(?<season>\d{1,2})\s*[:\-]?\s*Episode\s+(?<episode>\d{1,3})", RegexOptions.IgnoreCase);
+            if (seasonEpisodeMatch.Success
+                && int.TryParse(seasonEpisodeMatch.Groups["season"].Value, out season)
+                && int.TryParse(seasonEpisodeMatch.Groups["episode"].Value, out episode))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        private static bool EpisodeWithinRange(ParsedMovieInfo parsed, int season, int episode)
+        {
+            if (!int.TryParse(parsed.Season, out var parsedSeason) || parsedSeason != season)
+            {
+                return false;
+            }
+
+            if (!int.TryParse(parsed.EpisodeStart, out var episodeStart))
+            {
+                return false;
+            }
+
+            if (!parsed.IsEpisodeRange)
+            {
+                return episodeStart == episode;
+            }
+
+            if (!int.TryParse(parsed.EpisodeEnd, out var episodeEnd))
+            {
+                return episodeStart == episode;
+            }
+
+            return episode >= episodeStart && episode <= episodeEnd;
         }
 
         /// <summary> Return a single movie from a list or throw an exception if multiple movies are found. </summary>

--- a/src/NzbDrone.Core/Parser/Model/ParsedMovieInfo.cs
+++ b/src/NzbDrone.Core/Parser/Model/ParsedMovieInfo.cs
@@ -33,8 +33,16 @@ namespace NzbDrone.Core.Parser.Model
         public int TmdbId { get; set; }
         public string HardcodedSubs { get; set; }
         public string ReleaseTokens { get; set; }
+        public string Season { get; set; }
+        public string EpisodeStart { get; set; }
+        public string EpisodeEnd { get; set; }
+        public string ParserSource { get; set; }
+        public bool IsNoDateEpisodic { get; set; }
+        public bool IsEpisodeRange { get; set; }
 
         public string MovieTitle => PrimaryMovieTitle;
+
+        public bool HasReleaseDate => ReleaseDate.IsNotNullOrWhiteSpace();
 
         public string PrimaryMovieTitle
         {
@@ -59,6 +67,11 @@ namespace NzbDrone.Core.Parser.Model
 
         public override string ToString()
         {
+            if (IsNoDateEpisodic)
+            {
+                return string.Format("{0} - no-date - {1} {2} [{3}]", StudioTitle, ReleaseTokens, Episode, Quality);
+            }
+
             var result = string.Format("{0} - {1} {2}", PrimaryMovieTitle, Year, Quality);
 
             if (IsScene)

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -217,6 +217,22 @@ namespace NzbDrone.Core.Parser
         private static readonly Regex CleanQualityBracketsRegex = new Regex(@"\[[a-z0-9 ._-]+\]$",
                                                                    RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
+        private static readonly Regex BracketStudioSxxExxRangeRegex = new Regex(
+            @"^\[(?<studiotitle>[^\]]+)\]\s*(?<title>.+?)\s+S(?<season>\d{1,2})\s*E(?<from>\d{1,3})\s*[-–]\s*E?(?<to>\d{1,3})(?<tail>.*)$",
+            RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+        private static readonly Regex BracketStudioSxxExxRegex = new Regex(
+            @"^\[(?<studiotitle>[^\]]+)\]\s*(?<title>.+?)\s+S(?<season>\d{1,2})\s*E(?<episode>\d{1,3})(?<tail>.*)$",
+            RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+        private static readonly Regex BracketStudioSeasonEpisodeRegex = new Regex(
+            @"^\[(?<studiotitle>[^\]]+)\]\s*(?<title>.+?)\s+Season\s*(?<season>\d{1,2})\s*[:\-]?\s*Episode\s*(?<episode>\d{1,3})(?<tail>.*)$",
+            RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+        private static readonly Regex ExplicitNoDateEpisodicMarkerRegex = new Regex(
+            @"^\[(?<studiotitle>[^\]]+)\].*?(?:S\d{1,2}\s*E\d{1,3}|Season\s+\d{1,2}\s*[:\-]?\s*Episode\s+\d{1,3})",
+            RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
         private static readonly Regex YearInTitleRegex = new Regex(@"^(?<title>.+?)(?:\W|_.)?[\(\[]?(?<year>\d{4})[\]\)]?",
                                                                 RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
@@ -324,6 +340,8 @@ namespace NzbDrone.Core.Parser
                     allRegexes.AddRange(ReportTitleFolderRegex);
                 }
 
+                ParsedMovieInfo regexResult = null;
+
                 foreach (var regex in allRegexes)
                 {
                     var match = regex.Matches(simpleTitle);
@@ -396,7 +414,8 @@ namespace NzbDrone.Core.Parser
                                 result.ImdbId = ParseImdbId(simpleReleaseTitle);
                                 result.TmdbId = ParseTmdbId(simpleReleaseTitle);
 
-                                return result;
+                                regexResult = result;
+                                break;
                             }
                         }
                         catch (InvalidDateException ex)
@@ -405,6 +424,20 @@ namespace NzbDrone.Core.Parser
                             break;
                         }
                     }
+                }
+
+                if (ShouldTryNoDateEpisodicParse(originalTitle, regexResult))
+                {
+                    var noDateEpisodicResult = TryParseNoDateEpisodicRelease(originalTitle, releaseTitle, simpleTitle);
+                    if (noDateEpisodicResult != null)
+                    {
+                        return noDateEpisodicResult;
+                    }
+                }
+
+                if (regexResult != null)
+                {
+                    return regexResult;
                 }
 
                 // If we got here, it means we were unable to parse the title with any of the regexes. Let's do some final checks before giving up.
@@ -1035,6 +1068,129 @@ namespace NzbDrone.Core.Parser
             }
 
             return string.Empty;
+        }
+
+        private static bool ShouldTryNoDateEpisodicParse(string originalTitle, ParsedMovieInfo regexResult)
+        {
+            if (regexResult?.HasReleaseDate == true)
+            {
+                return false;
+            }
+
+            return HasExplicitNoDateEpisodicMarker(originalTitle);
+        }
+
+        private static bool HasExplicitNoDateEpisodicMarker(string title)
+        {
+            if (title.IsNullOrWhiteSpace())
+            {
+                return false;
+            }
+
+            return ExplicitNoDateEpisodicMarkerRegex.IsMatch(title);
+        }
+
+        private static ParsedMovieInfo TryParseNoDateEpisodicRelease(string originalTitle, string releaseTitle, string simpleTitle)
+        {
+            var titleToMatch = CleanQualityBracketsRegex.Replace(releaseTitle, string.Empty).Trim();
+
+            var match = BracketStudioSxxExxRangeRegex.Match(titleToMatch);
+            if (match.Success)
+            {
+                return BuildNoDateEpisodicParsedMovieInfo(
+                    originalTitle,
+                    releaseTitle,
+                    simpleTitle,
+                    match.Groups["studiotitle"].Value,
+                    match.Groups["title"].Value.Trim(),
+                    match.Groups["season"].Value,
+                    match.Groups["from"].Value,
+                    match.Groups["to"].Value,
+                    isRange: true);
+            }
+
+            match = BracketStudioSxxExxRegex.Match(titleToMatch);
+            if (match.Success)
+            {
+                return BuildNoDateEpisodicParsedMovieInfo(
+                    originalTitle,
+                    releaseTitle,
+                    simpleTitle,
+                    match.Groups["studiotitle"].Value,
+                    match.Groups["title"].Value.Trim(),
+                    match.Groups["season"].Value,
+                    match.Groups["episode"].Value,
+                    episodeEnd: null,
+                    isRange: false);
+            }
+
+            match = BracketStudioSeasonEpisodeRegex.Match(titleToMatch);
+            if (match.Success)
+            {
+                return BuildNoDateEpisodicParsedMovieInfo(
+                    originalTitle,
+                    releaseTitle,
+                    simpleTitle,
+                    match.Groups["studiotitle"].Value,
+                    match.Groups["title"].Value.Trim(),
+                    match.Groups["season"].Value,
+                    match.Groups["episode"].Value,
+                    episodeEnd: null,
+                    isRange: false);
+            }
+
+            return null;
+        }
+
+        private static ParsedMovieInfo BuildNoDateEpisodicParsedMovieInfo(
+            string originalTitle,
+            string releaseTitle,
+            string simpleTitle,
+            string studioTitle,
+            string baseTitle,
+            string season,
+            string episodeStart,
+            string episodeEnd = null,
+            bool isRange = false)
+        {
+            if (!int.TryParse(season, out var seasonNumber) || !int.TryParse(episodeStart, out var episodeNumber))
+            {
+                return null;
+            }
+
+            var studio = studioTitle.Replace('.', ' ').Replace('_', ' ').Trim();
+            var releaseTokens = baseTitle.Trim();
+
+            var result = new ParsedMovieInfo
+            {
+                StudioTitle = studio,
+                ReleaseTokens = releaseTokens,
+                MovieTitles = new List<string> { releaseTokens },
+                Season = seasonNumber.ToString(),
+                EpisodeStart = episodeNumber.ToString(),
+                EpisodeEnd = isRange && int.TryParse(episodeEnd, out var episodeEndNumber) ? episodeEndNumber.ToString() : null,
+                Episode = $"S{seasonNumber:00}E{episodeNumber:00}",
+                IsNoDateEpisodic = true,
+                IsEpisodeRange = isRange,
+                ParserSource = "NoDateEpisodic",
+                OriginalTitle = originalTitle,
+                ReleaseTitle = releaseTitle,
+                SimpleReleaseTitle = simpleTitle,
+                Quality = QualityParser.ParseQuality(originalTitle),
+                Languages = LanguageParser.ParseLanguages(simpleTitle)
+            };
+
+            Logger.Debug(
+                "NoDateEpisodicParser matched: Original='{0}', Studio='{1}', Title='{2}', Season={3}, EpisodeStart={4}, EpisodeEnd={5}, Quality='{6}'",
+                originalTitle,
+                studio,
+                releaseTokens,
+                seasonNumber,
+                episodeNumber,
+                episodeEnd ?? "null",
+                result.Quality);
+
+            return result;
         }
     }
 }

--- a/src/NzbDrone.Core/Parser/ParsingService.cs
+++ b/src/NzbDrone.Core/Parser/ParsingService.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using NLog;
 using NzbDrone.Common.Extensions;
+using NzbDrone.Core.Configuration;
 using NzbDrone.Core.IndexerSearch.Definitions;
 using NzbDrone.Core.Movies;
 using NzbDrone.Core.Parser.Model;
@@ -24,12 +25,15 @@ namespace NzbDrone.Core.Parser
         private static HashSet<ArabicRomanNumeral> _arabicRomanNumeralMappings;
 
         private readonly IMovieService _movieService;
+        private readonly IConfigService _configService;
         private readonly Logger _logger;
 
         public ParsingService(IMovieService movieService,
+                              IConfigService configService,
                               Logger logger)
         {
             _movieService = movieService;
+            _configService = configService;
             _logger = logger;
 
             if (_arabicRomanNumeralMappings == null)
@@ -252,6 +256,16 @@ namespace NzbDrone.Core.Parser
 
         private FindMovieResult GetSceneMovie(ParsedMovieInfo parsedMovieInfo, SearchCriteriaBase searchCriteria)
         {
+            if (parsedMovieInfo.IsNoDateEpisodic
+                && searchCriteria?.Movie != null
+                && IsNoDateEpisodicSearchAllowed(searchCriteria, parsedMovieInfo.IsEpisodeRange))
+            {
+                if (_movieService.IsNoDateEpisodicSceneMatch(parsedMovieInfo, searchCriteria.Movie, searchCriteria.InteractiveSearch))
+                {
+                    return new FindMovieResult(searchCriteria.Movie, MovieMatchType.Title);
+                }
+            }
+
             Movie movieInfo = null;
             Movie movie = null;
             try
@@ -291,6 +305,48 @@ namespace NzbDrone.Core.Parser
             }
 
             return new FindMovieResult(movieInfo, MovieMatchType.Title);
+        }
+
+        private bool IsNoDateEpisodicSearchAllowed(SearchCriteriaBase searchCriteria, bool isRangePack)
+        {
+            if (isRangePack)
+            {
+                var rangeMode = _configService.NoDateEpisodicRangePackMode;
+                if (rangeMode == NoDateEpisodicRangePackMode.Off)
+                {
+                    return false;
+                }
+
+                if (searchCriteria == null)
+                {
+                    return false;
+                }
+
+                if (searchCriteria.InteractiveSearch)
+                {
+                    return rangeMode >= NoDateEpisodicRangePackMode.InteractiveOnly;
+                }
+
+                return rangeMode >= NoDateEpisodicRangePackMode.InteractiveAndAutomatic;
+            }
+
+            var parsingMode = _configService.NoDateEpisodicParsingMode;
+            if (parsingMode == NoDateEpisodicParsingMode.Off)
+            {
+                return false;
+            }
+
+            if (searchCriteria == null)
+            {
+                return parsingMode == NoDateEpisodicParsingMode.AllIncludingRss;
+            }
+
+            if (searchCriteria.InteractiveSearch)
+            {
+                return parsingMode >= NoDateEpisodicParsingMode.InteractiveOnly;
+            }
+
+            return parsingMode >= NoDateEpisodicParsingMode.InteractiveAndAutomatic;
         }
     }
 }


### PR DESCRIPTION
## Summary
- Add a layered no-date episodic parser for bracketed tracker formats (SxxExx, Season/Episode, range packs) without regressing date-first scene parsing
- Introduce target-aware resolver for interactive/automatic search so releases like `[Wildeer Studio] Lara In Trouble S01 E01 - E06` match the searched scene when the target episode is in range
- Add config kill switches (default InteractiveOnly), import conflict guard for grabbed targets, and structured parser/resolver debug logging

## Test plan
- [x] `dotnet test src/NzbDrone.Core.Test/Whisparr.Core.Test.csproj --filter "FullyQualifiedName~NoDateEpisodic"`
- [x] `dotnet test src/NzbDrone.Core.Test/Whisparr.Core.Test.csproj --filter "FullyQualifiedName~ParseMovieTitleFixture"`
- [x] Core unit suite: 3950 passed, 0 failed
- [ ] Manual interactive search for AgentRedGirl Season/Episode and Wildeer S01E01 / E01-E06 pack titles
- [ ] Confirm dated scenes (e.g. `Studio.24.06.14.*`, `[Vixen] ... (2025-12-03)`) unchanged
- [ ] Confirm RSS does not grab no-date range packs with default config
