### PR TITLE
fix: Check Health taking 24h+ on large libraries

### DIFF
--- a/src/NzbDrone.Common/Disk/DiskProviderBase.cs
+++ b/src/NzbDrone.Common/Disk/DiskProviderBase.cs
@@ -155,7 +155,7 @@ namespace NzbDrone.Common.Disk
             }
             catch (Exception e)
             {
-                Logger.Trace("Directory '{0}' isn't writable. {1}", path, e.Message);
+                Logger.Trace(e, "Directory '{0}' isn't writable.", path);
                 return false;
             }
         }
@@ -405,11 +405,11 @@ namespace NzbDrone.Common.Disk
             File.SetLastWriteTime(path, dateTime);
         }
 
-        public bool IsFileLocked(string file)
+        public bool IsFileLocked(string path)
         {
             try
             {
-                using (File.Open(file, FileMode.Open, FileAccess.Read, FileShare.None))
+                using (File.Open(path, FileMode.Open, FileAccess.Read, FileShare.None))
                 {
                     return false;
                 }
@@ -451,20 +451,6 @@ namespace NzbDrone.Common.Disk
                 {
                     var newAttributes = attributes & ~FileAttributes.ReadOnly;
                     File.SetAttributes(path, newAttributes);
-                }
-            }
-        }
-
-        private static void RemoveReadOnlyFolder(string path)
-        {
-            if (Directory.Exists(path))
-            {
-                var dirInfo = new DirectoryInfo(path);
-
-                if (dirInfo.Attributes.HasFlag(FileAttributes.ReadOnly))
-                {
-                    var newAttributes = dirInfo.Attributes & ~FileAttributes.ReadOnly;
-                    dirInfo.Attributes = newAttributes;
                 }
             }
         }
@@ -587,7 +573,7 @@ namespace NzbDrone.Common.Disk
             return ancestors.Any(a => a.Equals(parent, true));
         }
 
-        protected List<DriveInfo> GetDriveInfoMounts()
+        protected static List<DriveInfo> GetDriveInfoMounts()
         {
             return DriveInfo.GetDrives()
                             .Where(d => d.IsReady)

--- a/src/NzbDrone.Common/Disk/DiskProviderBase.cs
+++ b/src/NzbDrone.Common/Disk/DiskProviderBase.cs
@@ -552,17 +552,39 @@ namespace NzbDrone.Common.Disk
         {
             try
             {
-                var mounts = GetAllMounts();
+                // IsParentPath walks the path back up to the root, and that walk is identical for every mount, so
+                // do it once here rather than once per mount. MountCheck performs a lookup per movie path, so on a
+                // large library this comparison runs hundreds of thousands of times.
+                var ancestors = GetAncestors(path);
 
-                return mounts.Where(drive => drive.RootDirectory.PathEquals(path) ||
-                                             drive.RootDirectory.IsParentPath(path))
-                          .MaxBy(drive => drive.RootDirectory.Length);
+                return GetAllMounts()
+                    .Where(drive => drive.RootDirectory.PathEquals(path) || IsAncestor(ancestors, drive.RootDirectory))
+                    .MaxBy(drive => drive.RootDirectory.Length);
             }
             catch (Exception ex)
             {
                 Logger.Debug(ex, $"Failed to get mount for path {path}");
                 return null;
             }
+        }
+
+        private static List<OsPath> GetAncestors(string path)
+        {
+            var ancestors = new List<OsPath>();
+
+            for (var directory = new OsPath(path).Directory; directory != OsPath.Null; directory = directory.Directory)
+            {
+                ancestors.Add(directory);
+            }
+
+            return ancestors;
+        }
+
+        private static bool IsAncestor(List<OsPath> ancestors, string parentPath)
+        {
+            var parent = new OsPath(parentPath);
+
+            return ancestors.Any(a => a.Equals(parent, true));
         }
 
         protected List<DriveInfo> GetDriveInfoMounts()

--- a/src/NzbDrone.Common/Disk/DiskProviderBase.cs
+++ b/src/NzbDrone.Common/Disk/DiskProviderBase.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using NLog;
+using NzbDrone.Common.Cache;
 using NzbDrone.Common.EnsureThat;
 using NzbDrone.Common.EnvironmentInfo;
 using NzbDrone.Common.Extensions;
@@ -14,6 +15,22 @@ namespace NzbDrone.Common.Disk
     public abstract class DiskProviderBase : IDiskProvider
     {
         private static readonly Logger Logger = NzbDroneLogger.GetLogger(typeof(DiskProviderBase));
+
+        // Enumerating the mount table is expensive: on Linux it reads /proc/mounts and stats every mount point,
+        // which on a host with a lot of network mounts is hundreds of syscalls (and round trips) per call.
+        // GetMount is called once per movie path by MountCheck, so a library with a few hundred thousand movies
+        // performed that enumeration a few hundred thousand times.
+        //
+        // Only the mount topology is cached. Free space is not: IMount implementations read it live from the
+        // underlying DriveInfo/UnixDriveInfo on every property access, so cached mounts never report stale space.
+        private static readonly TimeSpan MountCacheLifetime = TimeSpan.FromSeconds(15);
+
+        private readonly ICached<List<IMount>> _mountCache;
+
+        protected DiskProviderBase(ICacheManager cacheManager)
+        {
+            _mountCache = cacheManager.GetCache<List<IMount>>(GetType(), "AllMounts");
+        }
 
         public static StringComparison PathStringComparison
         {
@@ -509,7 +526,16 @@ namespace NzbDrone.Common.Disk
             return GetAllMounts().Where(d => !IsSpecialMount(d)).ToList();
         }
 
-        protected virtual List<IMount> GetAllMounts()
+        // The returned list is shared between callers for the lifetime of the cache entry, treat it as read-only.
+        private List<IMount> GetAllMounts()
+        {
+            // The lifetime has to be passed explicitly, GetCache has no default and a null lifetime never expires.
+            return _mountCache.Get("all", FetchAllMounts, MountCacheLifetime);
+        }
+
+        // Don't call this from a constructor, overrides depend on fields that derived constructors haven't
+        // assigned yet. Going through GetAllMounts() keeps it lazy.
+        protected virtual List<IMount> FetchAllMounts()
         {
             return GetDriveInfoMounts().Where(d => d.DriveType == DriveType.Fixed || d.DriveType == DriveType.Network || d.DriveType == DriveType.Removable)
                                        .Select(d => new DriveInfoMount(d))

--- a/src/NzbDrone.Core.Test/HealthCheck/Checks/MountCheckFixture.cs
+++ b/src/NzbDrone.Core.Test/HealthCheck/Checks/MountCheckFixture.cs
@@ -1,0 +1,186 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+using NzbDrone.Common.Disk;
+using NzbDrone.Core.HealthCheck.Checks;
+using NzbDrone.Core.Localization;
+using NzbDrone.Core.Movies;
+using NzbDrone.Core.Test.Framework;
+using NzbDrone.Test.Common;
+
+namespace NzbDrone.Core.Test.HealthCheck.Checks
+{
+    [TestFixture]
+    public class MountCheckFixture : CoreTest<MountCheck>
+    {
+        [SetUp]
+        public void Setup()
+        {
+            Mocker.GetMock<ILocalizationService>()
+                  .Setup(s => s.GetLocalizedString(It.IsAny<string>()))
+                  .Returns("Mount is read only: ");
+
+            Mocker.GetMock<IDiskProvider>()
+                  .Setup(s => s.GetMount(It.IsAny<string>()))
+                  .Returns((IMount)null);
+        }
+
+        private void GivenMoviePaths(params string[] paths)
+        {
+            Mocker.GetMock<IMovieService>()
+                  .Setup(s => s.AllMoviePaths())
+                  .Returns(paths.Select((path, index) => new { index, path })
+                                .ToDictionary(x => x.index, x => x.path));
+        }
+
+        private void GivenMount(string name, string rootDirectory, MountOptions mountOptions, params string[] paths)
+        {
+            var mount = new Mock<IMount>();
+
+            mount.SetupGet(m => m.RootDirectory).Returns(rootDirectory);
+            mount.SetupGet(m => m.Name).Returns(name);
+            mount.SetupGet(m => m.MountOptions).Returns(mountOptions);
+
+            foreach (var path in paths)
+            {
+                Mocker.GetMock<IDiskProvider>()
+                      .Setup(s => s.GetMount(path))
+                      .Returns(mount.Object);
+            }
+        }
+
+        private static MountOptions ReadOnly()
+        {
+            return new MountOptions(new Dictionary<string, string> { { "ro", string.Empty } });
+        }
+
+        private static MountOptions Writable()
+        {
+            return new MountOptions(new Dictionary<string, string>());
+        }
+
+        [Test]
+        public void should_not_return_error_when_no_movies()
+        {
+            GivenMoviePaths();
+
+            Subject.Check().ShouldBeOk();
+        }
+
+        [Test]
+        public void should_not_return_error_when_mount_cannot_be_resolved()
+        {
+            GivenMoviePaths(@"C:\Movies\movie".AsOsAgnostic());
+
+            Subject.Check().ShouldBeOk();
+        }
+
+        [Test]
+        public void should_not_return_error_when_mount_options_are_unavailable()
+        {
+            // DriveInfoMount is constructed without mount options, so MountOptions is always null on Windows.
+            var path = @"C:\Movies\movie".AsOsAgnostic();
+
+            GivenMoviePaths(path);
+            GivenMount("Movies", @"C:\Movies".AsOsAgnostic(), null, path);
+
+            Subject.Check().ShouldBeOk();
+        }
+
+        [Test]
+        public void should_not_return_error_when_mount_is_writable()
+        {
+            var path = @"C:\Movies\movie".AsOsAgnostic();
+
+            GivenMoviePaths(path);
+            GivenMount("Movies", @"C:\Movies".AsOsAgnostic(), Writable(), path);
+
+            Subject.Check().ShouldBeOk();
+        }
+
+        [Test]
+        public void should_return_error_when_mount_is_read_only()
+        {
+            var path = @"C:\Movies\movie".AsOsAgnostic();
+
+            GivenMoviePaths(path);
+            GivenMount("Movies", @"C:\Movies".AsOsAgnostic(), ReadOnly(), path);
+
+            var result = Subject.Check();
+
+            result.ShouldBeError(wikiFragment: "#movie-mount-ro");
+            result.Message.Should().Contain("Movies");
+            result.Message.Should().Contain(path);
+        }
+
+        [Test]
+        public void should_only_report_each_mount_once()
+        {
+            var paths = new[] { @"C:\Movies\first", @"C:\Movies\second", @"C:\Movies\third" }
+                .Select(p => p.AsOsAgnostic())
+                .ToArray();
+
+            GivenMoviePaths(paths);
+            GivenMount("ReadOnlyMount", @"C:\Movies".AsOsAgnostic(), ReadOnly(), paths);
+
+            var result = Subject.Check();
+
+            result.ShouldBeError();
+            Regex.Matches(result.Message, "ReadOnlyMount").Count.Should().Be(1);
+        }
+
+        [Test]
+        public void should_report_the_first_path_for_a_mount()
+        {
+            var paths = new[] { @"C:\Movies\first", @"C:\Movies\second", @"C:\Movies\third" }
+                .Select(p => p.AsOsAgnostic())
+                .ToArray();
+
+            GivenMoviePaths(paths);
+            GivenMount("ReadOnlyMount", @"C:\Movies".AsOsAgnostic(), ReadOnly(), paths);
+
+            var result = Subject.Check();
+
+            result.Message.Should().Contain(paths[0]);
+            result.Message.Should().NotContain(paths[1]);
+            result.Message.Should().NotContain(paths[2]);
+        }
+
+        [Test]
+        public void should_report_each_read_only_mount()
+        {
+            var first = @"C:\First\movie".AsOsAgnostic();
+            var second = @"C:\Second\movie".AsOsAgnostic();
+
+            GivenMoviePaths(first, second);
+            GivenMount("FirstMount", @"C:\First".AsOsAgnostic(), ReadOnly(), first);
+            GivenMount("SecondMount", @"C:\Second".AsOsAgnostic(), ReadOnly(), second);
+
+            var result = Subject.Check();
+
+            result.ShouldBeError();
+            result.Message.Should().Contain(first);
+            result.Message.Should().Contain(second);
+        }
+
+        [Test]
+        public void should_only_report_read_only_mounts()
+        {
+            var readOnly = @"C:\First\movie".AsOsAgnostic();
+            var writable = @"C:\Second\movie".AsOsAgnostic();
+
+            GivenMoviePaths(readOnly, writable);
+            GivenMount("FirstMount", @"C:\First".AsOsAgnostic(), ReadOnly(), readOnly);
+            GivenMount("SecondMount", @"C:\Second".AsOsAgnostic(), Writable(), writable);
+
+            var result = Subject.Check();
+
+            result.ShouldBeError();
+            result.Message.Should().Contain(readOnly);
+            result.Message.Should().NotContain(writable);
+        }
+    }
+}

--- a/src/NzbDrone.Core.Test/HealthCheck/Checks/RootFolderCheckFixture.cs
+++ b/src/NzbDrone.Core.Test/HealthCheck/Checks/RootFolderCheckFixture.cs
@@ -24,9 +24,9 @@ namespace NzbDrone.Core.Test.HealthCheck.Checks
                   .Returns("Some Warning Message");
         }
 
-        private void GivenMissingRootFolder(string rootFolderPath)
+        private void GivenMissingRootFolder(string rootFolderPath, int movieCount = 1)
         {
-            var movies = Builder<Movie>.CreateListOfSize(1)
+            var movies = Builder<Movie>.CreateListOfSize(movieCount)
                                         .Build()
                                         .ToList();
 
@@ -35,7 +35,11 @@ namespace NzbDrone.Core.Test.HealthCheck.Checks
                   .Returns(movies.ToDictionary(x => x.Id, x => x.Path));
 
             Mocker.GetMock<IRootFolderService>()
-                .Setup(s => s.GetBestRootFolderPath(It.IsAny<string>(), null))
+                .Setup(s => s.All())
+                .Returns(new List<RootFolder>());
+
+            Mocker.GetMock<IRootFolderService>()
+                .Setup(s => s.GetBestRootFolderPath(It.IsAny<string>(), It.IsAny<List<RootFolder>>()))
                 .Returns(rootFolderPath);
 
             Mocker.GetMock<IDiskProvider>()
@@ -77,6 +81,21 @@ namespace NzbDrone.Core.Test.HealthCheck.Checks
             GivenMissingRootFolder(@"C:\Movies");
 
             Subject.Check().ShouldBeError();
+        }
+
+        [Test]
+        public void should_only_fetch_root_folders_once_regardless_of_movie_count()
+        {
+            GivenMissingRootFolder(@"C:\Movies".AsOsAgnostic(), 10);
+
+            Subject.Check();
+
+            // Omitting the root folders makes GetBestRootFolderPath re-query them on every cache miss, once per movie.
+            Mocker.GetMock<IRootFolderService>()
+                  .Verify(s => s.GetBestRootFolderPath(It.IsAny<string>(), null), Times.Never());
+
+            Mocker.GetMock<IRootFolderService>()
+                  .Verify(s => s.All(), Times.Once());
         }
     }
 }

--- a/src/NzbDrone.Core/DiskSpace/DiskSpaceService.cs
+++ b/src/NzbDrone.Core/DiskSpace/DiskSpaceService.cs
@@ -52,9 +52,12 @@ namespace NzbDrone.Core.DiskSpace
             // Get all movie paths and find the correct root folder for each. For each unique root folder path,
             // ensure the path exists and get its path root and return all unique path roots.
 
+            // Pass the root folders in, otherwise every cache miss re-queries them from the database, once per movie.
+            var allRootFolders = _rootFolderService.All();
+
             return _movieService.AllMoviePaths()
                 .Where(s => s.Value.IsPathValid(PathValidationType.CurrentOs))
-                .Select(s => _rootFolderService.GetBestRootFolderPath(s.Value))
+                .Select(s => _rootFolderService.GetBestRootFolderPath(s.Value, allRootFolders))
                 .Distinct()
                 .Where(r => _diskProvider.FolderExists(r))
                 .Select(r => _diskProvider.GetPathRoot(r))

--- a/src/NzbDrone.Core/HealthCheck/Checks/RootFolderCheck.cs
+++ b/src/NzbDrone.Core/HealthCheck/Checks/RootFolderCheck.cs
@@ -30,8 +30,11 @@ namespace NzbDrone.Core.HealthCheck.Checks
 
         public override HealthCheck Check()
         {
+            // Pass the root folders in, otherwise every cache miss re-queries them from the database, once per movie.
+            var allRootFolders = _rootFolderService.All();
+
             var rootFolders = _movieService.AllMoviePaths()
-                .Select(s => _rootFolderService.GetBestRootFolderPath(s.Value))
+                .Select(s => _rootFolderService.GetBestRootFolderPath(s.Value, allRootFolders))
                 .Distinct();
 
             var missingRootFolders = rootFolders.Where(s => !s.IsPathValid(PathValidationType.CurrentOs) || !_diskProvider.FolderExists(s))

--- a/src/NzbDrone.Mono.Test/DiskProviderTests/DiskProviderFixture.cs
+++ b/src/NzbDrone.Mono.Test/DiskProviderTests/DiskProviderFixture.cs
@@ -54,7 +54,7 @@ namespace NzbDrone.Mono.Test.DiskProviderTests
             SetWritePermissionsInternal(path, writable, false);
         }
 
-        protected void SetWritePermissionsInternal(string path, bool writable, bool setgid)
+        protected static void SetWritePermissionsInternal(string path, bool writable, bool setgid)
         {
             // Remove Write permissions, we're still owner so we can clean it up, but we'll have to do that explicitly.
             Syscall.stat(path, out var stat);

--- a/src/NzbDrone.Mono.Test/DiskProviderTests/DiskProviderFixture.cs
+++ b/src/NzbDrone.Mono.Test/DiskProviderTests/DiskProviderFixture.cs
@@ -175,6 +175,49 @@ namespace NzbDrone.Mono.Test.DiskProviderTests
             mount.RootDirectory.Should().Be(rootDir);
         }
 
+        private void GivenMounts(params string[] rootDirs)
+        {
+            Mocker.GetMock<ISymbolicLinkResolver>()
+                .Setup(v => v.GetCompleteRealPath(It.IsAny<string>()))
+                .Returns<string>(s => s);
+
+            Mocker.GetMock<IProcMountProvider>()
+                .Setup(v => v.GetMounts())
+                .Returns(rootDirs.Select(r =>
+                    (IMount)new ProcMount(DriveType.Fixed, r, r, "myfs", new MountOptions(new Dictionary<string, string>())))
+                    .ToList());
+        }
+
+        [Test]
+        public void should_return_the_longest_matching_mount()
+        {
+            GivenMounts("/mnt/nested-test", "/mnt/nested-test/media");
+
+            var mount = Subject.GetMount("/mnt/nested-test/media/movie/file.mkv");
+
+            mount.RootDirectory.Should().Be("/mnt/nested-test/media");
+        }
+
+        [Test]
+        public void should_return_mount_when_path_is_the_mount_root()
+        {
+            GivenMounts("/mnt/exact-test");
+
+            var mount = Subject.GetMount("/mnt/exact-test");
+
+            mount.RootDirectory.Should().Be("/mnt/exact-test");
+        }
+
+        [Test]
+        public void should_return_mount_for_path_containing_relative_segments()
+        {
+            GivenMounts("/mnt/relative-test");
+
+            var mount = Subject.GetMount("/mnt/other/../relative-test");
+
+            mount.RootDirectory.Should().Be("/mnt/relative-test");
+        }
+
         [Test]
         public void should_only_enumerate_mounts_once_for_repeated_lookups()
         {

--- a/src/NzbDrone.Mono.Test/DiskProviderTests/DiskProviderFixture.cs
+++ b/src/NzbDrone.Mono.Test/DiskProviderTests/DiskProviderFixture.cs
@@ -176,6 +176,19 @@ namespace NzbDrone.Mono.Test.DiskProviderTests
         }
 
         [Test]
+        public void should_only_enumerate_mounts_once_for_repeated_lookups()
+        {
+            GivenSpecialMount("/mnt/cache-test");
+
+            Subject.GetMount("/mnt/cache-test/dir/one.mkv");
+            Subject.GetMount("/mnt/cache-test/dir/two.mkv");
+            Subject.GetMounts();
+
+            Mocker.GetMock<IProcMountProvider>()
+                  .Verify(v => v.GetMounts(), Times.Once());
+        }
+
+        [Test]
         public void should_copy_folder_permissions()
         {
             var src = GetTempFilePath();

--- a/src/NzbDrone.Mono/Disk/DiskProvider.cs
+++ b/src/NzbDrone.Mono/Disk/DiskProvider.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using Mono.Unix;
 using Mono.Unix.Native;
 using NLog;
+using NzbDrone.Common.Cache;
 using NzbDrone.Common.Disk;
 using NzbDrone.Common.EnsureThat;
 using NzbDrone.Common.EnvironmentInfo;
@@ -23,7 +24,8 @@ namespace NzbDrone.Mono.Disk
         private readonly ISymbolicLinkResolver _symLinkResolver;
         private readonly ICreateRefLink _createRefLink;
 
-        public DiskProvider(IProcMountProvider procMountProvider, ISymbolicLinkResolver symLinkResolver, ICreateRefLink createRefLink, Logger logger)
+        public DiskProvider(IProcMountProvider procMountProvider, ISymbolicLinkResolver symLinkResolver, ICreateRefLink createRefLink, ICacheManager cacheManager, Logger logger)
+            : base(cacheManager)
         {
             _procMountProvider = procMountProvider;
             _symLinkResolver = symLinkResolver;
@@ -166,7 +168,7 @@ namespace NzbDrone.Mono.Disk
             }
         }
 
-        protected override List<IMount> GetAllMounts()
+        protected override List<IMount> FetchAllMounts()
         {
             var mounts = new List<IMount>();
 

--- a/src/NzbDrone.Windows/Disk/DiskProvider.cs
+++ b/src/NzbDrone.Windows/Disk/DiskProvider.cs
@@ -5,6 +5,7 @@ using System.Runtime.InteropServices;
 using System.Security.AccessControl;
 using System.Security.Principal;
 using NLog;
+using NzbDrone.Common.Cache;
 using NzbDrone.Common.Disk;
 using NzbDrone.Common.EnsureThat;
 using NzbDrone.Common.Instrumentation;
@@ -14,6 +15,11 @@ namespace NzbDrone.Windows.Disk
     public class DiskProvider : DiskProviderBase
     {
         private static readonly Logger Logger = NzbDroneLogger.GetLogger(typeof(DiskProvider));
+
+        public DiskProvider(ICacheManager cacheManager)
+            : base(cacheManager)
+        {
+        }
 
         [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Auto)]
         [return: MarshalAs(UnmanagedType.Bool)]


### PR DESCRIPTION
Fixes Whisparr/Whisparr-Eros#835

`CheckHealthCommand` runs for 24+ hours on a 264k scene library (~130 NFS/ZFS mounts), pinning CPU throughout, then re-triggers 6 hours later. Health checks run serially on the command executor thread, so this blocks every other scheduled task.

Note: Radarr `develop` is byte-identical in `MountCheck.cs` and `DiskProviderBase.cs`, so this is not Whisparr specific and there was no upstream fix to mirror. Worth upstreaming.

## The bug

`MountCheck` calls `GetMount()` once per movie path, and `GetMount()` re-enumerated the entire OS mount table on **every** call, with no caching. On Linux that means reading `/proc/mounts` and stat'ing every mount point, so at 264k paths it did 264k full mount table enumerations, each hundreds of syscalls (and network round trips, on NFS).

## The changes

Each is a separate commit and reviewable on its own.

**1. Cache the mount list (the actual fix).** `GetAllMounts()` becomes a private caching wrapper with a 15s absolute TTL over a new `protected virtual FetchAllMounts()`, which Mono overrides. Private so a subclass cannot accidentally bypass the cache, and so a stray `override GetAllMounts` fails loudly at compile time rather than silently doing nothing.

`GetMount()` deliberately stays per-path. `MountCheck` resolves mounts from movie paths specifically so the provider handles symlinks and junctions, so the number of lookups is unchanged, only their cost.

Only topology is cached. Free space is unaffected: `DriveInfoMount` and `ProcMount` read it live from the underlying `DriveInfo`/`UnixDriveInfo` on each property access.

15s is short enough that a newly mounted share still turns up in the folder browser without needing any invalidation hooks, while still collapsing a health check run from hundreds of thousands of enumerations to roughly one per 15s. This also speeds up imports, since `DiskTransferService` pays two lookups per file transfer.

**2. Fix a `RootFolderCheck` N+1 (independent bug found on the way).** `RootFolderCheck` and `DiskSpaceService` called `GetBestRootFolderPath` without passing the root folders. The result is cached per path, but on a miss it falls back to querying every root folder from the database. `RootFolderCheck` runs on startup, when the cache is always cold, so that was one query per movie. Fixed via the existing overload, which exists for exactly this.

**3. Cheapen the per-mount scan.** `GetMount` tested every mount with `IsParentPath`, which walks the path back up to the root each time. That walk only depends on the path, so it was repeated identically for all ~130 mounts. Hoisted to once per lookup.

I originally planned to also hoist `PathEquals`'s normalization, but benchmarking showed that assumption was wrong: normalization was only ~14% of the cost, while the ancestor walk was the bulk. So `PathEquals` is left completely untouched, which avoids precomputing `CleanFilePath` per mount (it can throw, which would have changed when exceptions fire on the import hot path).

Measured over 130 mounts: ~160us -> ~62us per lookup, or ~42s -> ~16s across 264k paths.

## Testing

`MountCheck` had no coverage at all, so the first commit adds a fixture pinning current behaviour before anything changed: the null-mount and null-`MountOptions` guards (`MountOptions` is always null on Windows, since `DriveInfoMount` is constructed without them), the `DistinctBy` on root directory, and the reported path ordering.

Both regression tests were confirmed to fail without their fix:

- mount cache: *"Expected invocation on the mock once, but was 3 times"*
- root folder N+1: *"should never have been performed, but was 10 times"* (10 movies)

New `GetMount` semantics tests (longest matching mount wins, exact mount root, paths with relative segments) were confirmed to **pass against the old code** first, so they pin existing behaviour rather than the new implementation.

I also ran a differential check of old vs new resolution across 34 real paths against this machine's 11 real mounts, including a nested pair (`/System/Volumes/Data` and `/System/Volumes/Data/home`), `..` segments and trailing slashes. Identical results.

Green: `Common.Test`, `Mono.Test`, `Host.Test` (`ContainerFixture` resolves the whole DI graph, which covers the constructor plumbing), and the 144 `Core.Test` health check tests. Two `HttpClientFixture` Cloudflare tests fail, but they fail identically on `eros-develop` without these changes; they hit a live network endpoint and are unrelated.

## Caveat

I could not reproduce a 264k library on ~130 NFS mounts locally, so the headline timing is extrapolated from benchmarks. Merging this auto-closes Whisparr/Whisparr-Eros#835, so it may be worth having the reporter confirm the improvement on their library first.

## Follow-up (not in this PR)

`RemovedMovieCheck` materializes 264k `Movie` + `MovieMetadata` + alt-title rows just to read one enum per row. Not an N+1, but a large allocation spike. Proper fix is a status filtered repo query.
