### PR TITLE
Chore: Cloudflare cookie test expiring and reddening CI

### DIFF
--- a/src/NzbDrone.Common.Test/Http/HttpClientFixture.cs
+++ b/src/NzbDrone.Common.Test/Http/HttpClientFixture.cs
@@ -796,8 +796,13 @@ namespace NzbDrone.Common.Test.Http
             Thread.CurrentThread.CurrentUICulture = CultureInfo.GetCultureInfo(culture);
             try
             {
-                // the date is bad in the below - should be 13-Jul-2026
-                var malformedCookie = @"__cfduid=d29e686a9d65800021c66faca0a29b4261436890790; expires=Mon, 13-Jul-26 16:19:50 GMT; path=/; HttpOnly";
+                // The two digit year is the malformed part: a server should send 2027, not 27. Generate the date
+                // rather than hardcoding it, otherwise the cookie eventually expires and the test starts failing
+                // on a fixed date for everyone. Format as invariant because that is what a server sends; the
+                // thread culture stays set to the test case's culture so we still cover parsing it as a client
+                // running under a non-English locale.
+                var expires = DateTime.UtcNow.AddYears(1).ToString("ddd, dd-MMM-yy HH:mm:ss 'GMT'", CultureInfo.InvariantCulture);
+                var malformedCookie = $"__cfduid=d29e686a9d65800021c66faca0a29b4261436890790; expires={expires}; path=/; HttpOnly";
                 var requestSet = new HttpRequestBuilder($"https://{_httpBinHost}/response-headers")
                     .AddQueryParam("Set-Cookie", malformedCookie)
                     .Build();


### PR DESCRIPTION
`integration_test` is currently failing on **every** PR in the repo, on all three platforms. It is not infrastructure, and it is not any individual PR's change.

## Cause

`HttpClientFixture.should_parse_malformed_cloudflare_cookie` hardcoded a cookie expiry:

```
__cfduid=...; expires=Mon, 13-Jul-26 16:19:50 GMT; path=/; HttpOnly
```

`13-Jul-26` parses as **2026-07-13 16:19:50 GMT**. That moment has passed, so the cookie is now genuinely expired. `CookieContainer` correctly drops it, nothing is stored, no `Cookie` header goes out on the follow up request, and the assertion on line 814 fails.

The test was a time bomb from the day it was written (2015, inherited from Sonarr). It detonated on 2026-07-13.

The CI timeline matches exactly:

| PR | `integration_test` ran | result |
|---|---|---|
| #322 | 2026-07-13 **07:19** UTC | pass (9h before the expiry) |
| #323 | 2026-07-15 08:00 UTC | fail |
| #324 | 2026-07-15 19:08 UTC | fail |

## What is *not* wrong

Worth stating, because the failure looks like both:

- **Not httpbin.** The server echoed the `Set-Cookie` back correctly. With the date fixed, the test passes against the live host as-is.
- **Not cookie parsing, and not culture.** I probed `CookieContainer.SetCookies` directly: the same cookie string with the year moved forward parses fine, and en-US, es-ES and tr-TR behave identically on .NET 10. Only "expiry in the past" is dropped.

## Fix

Generate the expiry rather than hardcoding it:

```csharp
var expires = DateTime.UtcNow.AddYears(1).ToString("ddd, dd-MMM-yy HH:mm:ss 'GMT'", CultureInfo.InvariantCulture);
```

This keeps the two digit year, which is the actual malformed thing under test, and formats invariant because that is what a server sends. The thread culture stays set to the test case's culture, so the test still covers what it was written to cover: parsing an English cookie date on a non-English client.

`AddYears(1)` also stays clear of the two digit year window (`TwoDigitYearMax` is 2049), so it will not resurface for another ~22 years.

## Testing

Both cases pass, and the full `HttpClientFixture` is green (49/49) against the live host.

## Notes for follow-up (deliberately not in this PR)

- **`should_reject_malformed_domain_cookie` hardcodes `23-Dec-2026`.** It cannot fail the same way, since it asserts the cookie is *rejected*, and it carries `Max-Age` which likely takes precedence. But after that date it may start passing for the wrong reason (expired rather than domain mismatch). Worth a look, not urgent.
- **The fixture depends on `httpbin.servarr.com`** across 51 tests / 63 references. That external dependency is real and worth removing in favour of an in-process listener, but it is a project rather than a cleanup and is not what is breaking CI today.