### PR TITLE
Fixed: Movie file quality missing from the paged movie/scene index

### DIFF
--- a/src/NzbDrone.Api.Test/v3/Movies/MovieResourceFixture.cs
+++ b/src/NzbDrone.Api.Test/v3/Movies/MovieResourceFixture.cs
@@ -1,0 +1,94 @@
+using System.Collections.Generic;
+using FluentAssertions;
+using NLog;
+using NUnit.Framework;
+using NzbDrone.Core.DecisionEngine.Specifications;
+using NzbDrone.Core.MediaFiles;
+using NzbDrone.Core.Movies;
+using NzbDrone.Core.Profiles;
+using NzbDrone.Core.Profiles.Qualities;
+using NzbDrone.Core.Qualities;
+using Whisparr.Api.V3.Movies;
+
+namespace NzbDrone.Api.Test.v3.Movies
+{
+    // MovieFileResource.ToResource dereferences Movie.QualityProfile to compute QualityCutoffNotMet,
+    // so hydrating MovieFile without a profile throws. The repository tests can't catch that because
+    // they never map a resource. These cover the shape the paged index returns.
+    [Parallelizable(ParallelScope.All)]
+    public class MovieResourceFixture
+    {
+        // QualityCutoffNotMet uses neither dependency.
+        private readonly IUpgradableSpecification _upgradableSpecification =
+            new UpgradableSpecification(null, LogManager.GetCurrentClassLogger());
+
+        private static QualityProfile Profile() => new QualityProfile
+        {
+            Id = 1,
+            Name = "TestProfile",
+            UpgradeAllowed = true,
+            Cutoff = Quality.Bluray1080p.Id,
+            MinFormatScore = 0,
+            FormatItems = new List<ProfileFormatItem>(),
+            Items = new List<QualityProfileQualityItem>
+            {
+                new QualityProfileQualityItem { Quality = Quality.DVD, Allowed = true },
+                new QualityProfileQualityItem { Quality = Quality.HDTV720p, Allowed = true },
+                new QualityProfileQualityItem { Quality = Quality.Bluray1080p, Allowed = true }
+            }
+        };
+
+        private static Movie MovieWithFile(Quality quality, QualityProfile profile) => new Movie
+        {
+            Id = 1,
+            Path = "/movies/some.movie",
+            QualityProfileId = profile.Id,
+            QualityProfile = profile,
+            MovieFileId = 1,
+            MovieMetadata = new MovieMetadata { Title = "Some Movie", ItemType = ItemType.Scene },
+            MovieFile = new MovieFile
+            {
+                Id = 1,
+                MovieId = 1,
+                RelativePath = "some.movie.mkv",
+                Quality = new QualityModel(quality)
+            }
+        };
+
+        [Test]
+        public void should_map_movie_file_quality()
+        {
+            var resource = MovieWithFile(Quality.HDTV720p, Profile()).ToResource(0, _upgradableSpecification);
+
+            resource.MovieFile.Should().NotBeNull();
+            resource.MovieFile.Quality.Quality.Id.Should().Be(Quality.HDTV720p.Id);
+        }
+
+        [Test]
+        public void should_map_quality_cutoff_not_met_when_below_cutoff()
+        {
+            // Profile cutoff is Bluray1080p, so a 720p file has not met it.
+            var resource = MovieWithFile(Quality.HDTV720p, Profile()).ToResource(0, _upgradableSpecification);
+
+            resource.MovieFile.QualityCutoffNotMet.Should().BeTrue();
+        }
+
+        [Test]
+        public void should_map_quality_cutoff_met_when_at_cutoff()
+        {
+            var resource = MovieWithFile(Quality.Bluray1080p, Profile()).ToResource(0, _upgradableSpecification);
+
+            resource.MovieFile.QualityCutoffNotMet.Should().BeFalse();
+        }
+
+        [Test]
+        public void should_not_map_movie_file_when_movie_has_none()
+        {
+            var movie = MovieWithFile(Quality.HDTV720p, Profile());
+            movie.MovieFile = null;
+            movie.MovieFileId = 0;
+
+            movie.ToResource(0, _upgradableSpecification).MovieFile.Should().BeNull();
+        }
+    }
+}

--- a/src/NzbDrone.Core.Test/MovieTests/MovieRepositoryTests/MovieRepositoryFixture.cs
+++ b/src/NzbDrone.Core.Test/MovieTests/MovieRepositoryTests/MovieRepositoryFixture.cs
@@ -4,6 +4,10 @@ using FizzWare.NBuilder;
 using FluentAssertions;
 using NUnit.Framework;
 using NzbDrone.Core.CustomFormats;
+using NzbDrone.Core.Datastore;
+using NzbDrone.Core.Languages;
+using NzbDrone.Core.MediaFiles;
+using NzbDrone.Core.MediaFiles.MediaInfo;
 using NzbDrone.Core.Movies;
 using NzbDrone.Core.Profiles.Qualities;
 using NzbDrone.Core.Qualities;
@@ -29,6 +33,58 @@ namespace NzbDrone.Core.Test.MovieTests.MovieRepositoryTests
                 .Returns(new List<CustomFormat>());
         }
 
+        private QualityProfile GivenProfile()
+        {
+            var profile = new QualityProfile
+            {
+                Items = Qualities.QualityFixture.GetDefaultQualities(Quality.Bluray1080p, Quality.DVD, Quality.HDTV720p),
+                FormatItems = CustomFormatsTestHelpers.GetDefaultFormatItems(),
+                MinFormatScore = 0,
+                Cutoff = Quality.Bluray1080p.Id,
+                Name = "TestProfile"
+            };
+
+            _profileRepository.Insert(profile);
+
+            return profile;
+        }
+
+        private MovieFile GivenMovieFile(Quality quality)
+        {
+            var movieFile = Builder<MovieFile>.CreateNew()
+                .With(f => f.Id = 0)
+                .With(f => f.Quality = new QualityModel(quality))
+                .With(f => f.Languages = new List<Language> { Language.English })
+                .With(f => f.MediaInfo = new MediaInfoModel { RawStreamData = "{ \"streams\": [] }", VideoFormat = "h264" })
+                .BuildNew();
+
+            return Db.Insert(movieFile);
+        }
+
+        // PagedBuilder INNER JOINs MovieMetadata, so a paged movie needs a metadata row to match.
+        private void GivenPagedMovie(int qualityProfileId, int movieFileId, int year = 2020)
+        {
+            var metadata = Db.Insert(Builder<MovieMetadata>.CreateNew()
+                .With(m => m.Id = 0)
+                .With(m => m.Year = year)
+                .BuildNew());
+
+            var movie = Builder<Movie>.CreateNew()
+                .With(m => m.Id = 0)
+                .With(m => m.MovieMetadataId = metadata.Id)
+                .With(m => m.QualityProfileId = qualityProfileId)
+                .With(m => m.MovieFileId = movieFileId)
+                .BuildNew();
+
+            Subject.Insert(movie);
+        }
+
+        private static PagingSpec<Movie> PagingSpec() => new PagingSpec<Movie>
+        {
+            Page = 1,
+            PageSize = 10
+        };
+
         [Test]
         public void should_load_quality_profile()
         {
@@ -49,6 +105,82 @@ namespace NzbDrone.Core.Test.MovieTests.MovieRepositoryTests
             Subject.Insert(movie);
 
             Subject.All().Single().QualityProfile.Should().NotBeNull();
+        }
+
+        [Test]
+        public void should_load_movie_file_on_paged()
+        {
+            var profile = GivenProfile();
+            var movieFile = GivenMovieFile(Quality.HDTV720p);
+            GivenPagedMovie(profile.Id, movieFile.Id);
+
+            var movie = Subject.GetPaged(PagingSpec()).Records.Single();
+
+            movie.MovieFile.Should().NotBeNull();
+            movie.MovieFile.Quality.Quality.Id.Should().Be(Quality.HDTV720p.Id);
+        }
+
+        [Test]
+        public void should_load_quality_profile_on_paged()
+        {
+            var profile = GivenProfile();
+            var movieFile = GivenMovieFile(Quality.HDTV720p);
+            GivenPagedMovie(profile.Id, movieFile.Id);
+
+            // MovieFileResource.ToResource dereferences this to compute QualityCutoffNotMet.
+            Subject.GetPaged(PagingSpec()).Records.Single().QualityProfile.Should().NotBeNull();
+        }
+
+        [Test]
+        public void should_not_load_media_info_on_paged()
+        {
+            var profile = GivenProfile();
+            var movieFile = GivenMovieFile(Quality.HDTV720p);
+            GivenPagedMovie(profile.Id, movieFile.Id);
+
+            // The paged index never renders MediaInfo, so its ~7KB blob is left out of the query.
+            Subject.GetPaged(PagingSpec()).Records.Single().MovieFile.MediaInfo.Should().BeNull();
+        }
+
+        [Test]
+        public void should_not_load_movie_file_when_movie_has_none()
+        {
+            var profile = GivenProfile();
+            GivenPagedMovie(profile.Id, 0);
+
+            Subject.GetPaged(PagingSpec()).Records.Single().MovieFile.Should().BeNull();
+        }
+
+        // A dangling QualityProfileId must still resolve to a profile: MovieFileResource.ToResource
+        // dereferences it unconditionally, so a null here would throw when mapping the resource.
+        [Test]
+        public void should_fall_back_to_a_profile_when_quality_profile_is_missing()
+        {
+            var profile = GivenProfile();
+            var movieFile = GivenMovieFile(Quality.HDTV720p);
+            GivenPagedMovie(qualityProfileId: 999, movieFileId: movieFile.Id);
+
+            var movie = Subject.GetPaged(PagingSpec()).Records.Single();
+
+            movie.QualityProfile.Should().NotBeNull();
+            movie.QualityProfile.Id.Should().Be(profile.Id);
+            movie.MovieFile.Should().NotBeNull();
+        }
+
+        // MoviesWithoutFiles shares PagedQuery with GetPaged but GROUPs BY Movies.Id, so it must
+        // keep selecting only Movies/MovieMetadata columns: a bare MovieFile column under that
+        // GROUP BY errors on Postgres.
+        [Test]
+        public void should_still_page_movies_without_files()
+        {
+            var profile = GivenProfile();
+            GivenPagedMovie(profile.Id, movieFileId: 0);
+
+            var spec = PagingSpec();
+            Subject.MoviesWithoutFiles(spec);
+
+            spec.Records.Should().HaveCount(1);
+            spec.TotalRecords.Should().Be(1);
         }
     }
 }

--- a/src/NzbDrone.Core/Movies/MovieRepository.cs
+++ b/src/NzbDrone.Core/Movies/MovieRepository.cs
@@ -63,6 +63,30 @@ namespace NzbDrone.Core.Movies
             _alternativeTitleRepository = alternativeTitleRepository;
         }
 
+        // MovieFiles.MediaInfo holds the full ffprobe dump (~7KB a row) that no paged consumer
+        // renders, so the file columns are listed explicitly instead of "MovieFiles".*. Built
+        // from the mapper rather than hardcoded so a new column can't silently go missing.
+        private static readonly string _pagedMovieFileColumns = BuildPagedMovieFileColumns();
+
+        private static string BuildPagedMovieFileColumns()
+        {
+            var table = TableMapping.Mapper.TableNameMapping(typeof(MovieFile));
+            var excluded = TableMapping.Mapper.ExcludeProperties(typeof(MovieFile)).Select(x => x.Name).ToList();
+
+            var columns = typeof(MovieFile).GetProperties()
+                .Where(x => x.IsMappableProperty() &&
+                            !excluded.Contains(x.Name) &&
+                            x.Name != nameof(MovieFile.MediaInfo))
+                .Select(x => x.Name)
+
+                // Dapper splits on the first "Id" column, so the file's must lead its segment.
+                .OrderBy(x => x == nameof(ModelBase.Id) ? 0 : 1)
+                .ThenBy(x => x, StringComparer.Ordinal)
+                .Select(x => $"\"{table}\".\"{x}\"");
+
+            return string.Join(", ", columns);
+        }
+
         protected override IEnumerable<Movie> PagedQuery(SqlBuilder builder) =>
             _database.QueryJoined<Movie, MovieMetadata>(builder, (movie, movieMetadata) =>
             {
@@ -73,11 +97,49 @@ namespace NzbDrone.Core.Movies
         // Paged queries omit the AlternativeTitles JOIN to prevent duplicate rows.
         // The one-to-many JOIN in Builder() multiplies rows; PagedQuery maps each
         // SQL row directly without the deduplication that Query() performs via Map().
-        // QualityProfile is intentionally excluded: QualityProfileId on Movies is sufficient
-        // for sort/filter; the client resolves the display name from its own store.
+        // QualityProfile is intentionally not joined: QualityProfileId on Movies is sufficient
+        // for sort/filter, and GetPaged hydrates the profile itself from the profile repository.
         protected override SqlBuilder PagedBuilder() => new SqlBuilder(_database.DatabaseType)
             .Join<Movie, MovieMetadata>((m, p) => m.MovieMetadataId == p.Id)
             .LeftJoin<Movie, MovieFile>((m, f) => m.MovieFileId == f.Id);
+
+        public override PagingSpec<Movie> GetPaged(PagingSpec<Movie> pagingSpec)
+        {
+            pagingSpec.Records = GetPagedRecords(PagedBuilder(), pagingSpec, PagedQueryWithFile);
+            pagingSpec.TotalRecords = GetPagedRecordCount(PagedBuilder().SelectCount(), pagingSpec);
+
+            return pagingSpec;
+        }
+
+        // The index renders the file's quality, so the paged index needs MovieFile hydrated.
+        // MoviesWithoutFiles and MoviesWhereCutoffUnmet deliberately keep using PagedQuery: they
+        // GROUP BY Movies.Id, and selecting a non-aggregated file column under that errors on
+        // Postgres. QualityProfile comes from the repository rather than a JOIN because
+        // MovieFileResource.ToResource dereferences it to compute QualityCutoffNotMet.
+        private IEnumerable<Movie> PagedQueryWithFile(SqlBuilder builder)
+        {
+            var profiles = _profileRepository.All().ToDictionary(x => x.Id);
+
+            // A movie can point at a profile that no longer exists, and QualityCutoffNotMet
+            // dereferences the profile, so fall back the way All() does rather than leave it null.
+            var fallbackProfile = profiles.Values.FirstOrDefault(x => x.Fallback) ?? profiles.Values.FirstOrDefault();
+
+            var sql = builder
+                .Select($"\"{_table}\".*, \"MovieMetadata\".*, {_pagedMovieFileColumns}")
+                .AddSelectTemplate(typeof(Movie));
+
+            return _database.Query<Movie, MovieMetadata, MovieFile, Movie>(
+                sql.RawSql,
+                (movie, movieMetadata, movieFile) =>
+                {
+                    movie.MovieMetadata = movieMetadata;
+                    movie.MovieFile = movieFile;
+                    movie.QualityProfile = profiles.TryGetValue(movie.QualityProfileId, out var profile) ? profile : fallbackProfile;
+
+                    return movie;
+                },
+                sql.Parameters);
+        }
 
         protected override SqlBuilder Builder() => new SqlBuilder(_database.DatabaseType)
             .Join<Movie, QualityProfile>((m, p) => m.QualityProfileId == p.Id)

--- a/src/Whisparr.Api.V3/Movies/MovieController.cs
+++ b/src/Whisparr.Api.V3/Movies/MovieController.cs
@@ -610,7 +610,9 @@ namespace Whisparr.Api.V3.Movies
             var pageSpec = new NzbDrone.Core.Datastore.PagingSpec<Movie>
             {
                 Page = request.Page ?? 1,
-                PageSize = request.PageSize ?? 10,
+
+                // The index page size options allow up to 1000 inclusive.
+                PageSize = request.PageSize > 0 && request.PageSize <= 1000 ? request.PageSize.Value : 10,
                 SortKey = Sorting.GetSortKeyNormalized(_allowedMovieSortKeys.Contains(request.SortKey ?? "") ? request.SortKey : null),
                 SortDirection = request.SortDirection ?? NzbDrone.Core.Datastore.SortDirection.Ascending,
                 DefaultSortKeys = new List<string> { "movieMetadata.ReleaseDate", "movieMetadata.StudioTitle", "movieMetadata.SortTitle" }


### PR DESCRIPTION
Fixes Whisparr/Whisparr-Eros#837

The index status bar showed a generic "Downloaded" instead of the file's quality. Radarr shows the quality, and this used to as well.

## What was actually wrong

The issue suspected an expensive `movie.moviefileid.quality.id` relationship walk needing an in-memory movie-file cache. It turned out to be neither expensive nor a frontend gap:

- **The frontend was already complete.** Table, poster and overview — for both scenes and movies — already render `movieFile.quality.quality.name` with `?? translate('Downloaded')` as the fallback. That fallback *is* the reported bug. No frontend changes here.
- **The JOIN already existed.** `PagedBuilder` already LEFT JOINs `MovieFiles`. But `QueryJoined` builds its SELECT from its *type parameters*, so `PagedQuery`'s `<Movie, MovieMetadata>` emitted only `Movies.*` and `MovieMetadata.*` — the file was joined and then discarded. `Movie.MovieFile` is a plain property rather than `LazyLoaded`, so nothing back-filled it and `ToResource`'s null-conditional dropped it.

## The change

`GetPaged` now maps `MovieFile` through its own query. Two constraints shaped it, and both are worth knowing before simplifying this:

1. **`PagedQuery` is deliberately left alone.** It is shared with `MoviesWithoutFiles` and `MoviesWhereCutoffUnmet`, which `GROUP BY Movies.Id`. Selecting a non-aggregated file column under that GROUP BY errors on **PostgreSQL** (`column "MovieFiles.Id" must appear in the GROUP BY clause`) — SQLite tolerates it, so this would not surface in local testing. Neither Wanted page needs the file: their rows already fetch it via `useSingleMovieFile`.
2. **`QualityProfile` must be hydrated.** `MovieFileResource.ToResource` dereferences `movie.QualityProfile` unconditionally to compute `QualityCutoffNotMet`, and `UpgradableSpecification.QualityCutoffNotMet` dereferences `profile.UpgradeAllowed` on its first line. Hydrating `MovieFile` without a profile throws `NullReferenceException` (verified) — latent today only because `MovieFile` is always null. The profile comes from the repository with a fallback, the way `All()` already handles movies pointing at a profile that no longer exists.

`MediaInfo` is excluded from the query. Measured against a real library it stores the full ffprobe dump at ~7KB a row, ~90% of it `rawStreamData`, which `MediaInfoResource` discards anyway and no index view renders. Including it would deserialize ~7MB per request on a page of 1000. Consequence: `/movie/paged` returns `movieFile.mediaInfo = null` while `/movie` still populates it.

The column list is derived from the mapper rather than hardcoded, so a new `MovieFiles` column can't silently go missing, and `Id` is forced to lead the segment because Dapper splits on the first `Id` column.

## Second commit

`POST /movie/paged` took `request.PageSize` verbatim, so a client could request any number of records. The tag-filter branch of this same endpoint, `StudioController` and `PerformerController` all already guard theirs. Kept as a separate commit — it's a pre-existing gap, not part of the quality fix.

Uses `<= 1000` rather than the `< 1000` those three use: the index page size options allow 1000 inclusive, so the exclusive form would quietly serve 10 records to anyone picking the documented maximum. **Behavior change** for any client passing a page size above 1000 (now falls back to 10, matching the existing guards).

## Testing

- 7 repository tests covering quality hydration, profile hydration, the missing-profile fallback, `MediaInfo` exclusion, and null-file. 4 of them fail without the fix.
- A `MoviesWithoutFiles` test pinning constraint 1 — that path had no coverage at all.
- 4 `MovieResource` mapping tests covering constraint 2, which the repository tests can't reach.
- Verified end-to-end against a real library: `/movie/paged` returns the file's quality with `qualityCutoffNotMet` computed and `mediaInfo: null`; Wanted/Missing and Cutoff Unmet still return records; 1000 records served in ~48ms. Quality confirmed rendering on the index in the UI.

Not verified: the Postgres GROUP BY hazard is reasoned from the shared-`PagedQuery` structure and avoided by construction rather than reproduced — SQLite won't surface it.