### PR TITLE
Fixed: Scene title replacement eating codec tokens from simpleReleaseTitle

### DIFF
--- a/src/NzbDrone.Core.Test/ParserTests/ParseMovieTitleFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/ParseMovieTitleFixture.cs
@@ -171,6 +171,33 @@ namespace NzbDrone.Core.Test.ParserTests
             result.IsScene.Should().BeTrue();
         }
 
+        // The title capture is measured against a string that has already had the quality and codec
+        // tokens stripped, so replacing the title on those offsets used to overrun into the quality
+        // block and shred the codec token that Release Title custom formats match on.
+        [TestCase("Studio.26.07.09.Performer.Its.Great.In.The.Sample.XXX.1080p.x265-GROUP", "x265")]
+        [TestCase("Studio.26.07.09.Performer.Title.XXX.1080p.x265-GROUP", "x265")]
+        [TestCase("Studio.26.07.09.Performer.A.Much.Longer.Scene.Title.XXX.1080p.x265-GROUP", "x265")]
+        [TestCase("Studio2.24.07.26.Performer.Plain.Title.Words.Here.XXX.1080p.HEVC.x265.PRT", "x265")]
+        [TestCase("Studio.22.10.18.Title.XXX.720p.HEVC.x265.PRT[XvX]", "x265")]
+        [TestCase("Studio.26.07.09.Performer.Title.XXX.1080p.h264-GROUP", "h264")]
+        public void should_keep_codec_token_in_simple_release_title(string title, string codec)
+        {
+            var result = Parser.Parser.ParseMovieTitle(title);
+
+            result.Should().NotBeNull();
+            result.SimpleReleaseTitle.Should().Contain(codec);
+        }
+
+        [TestCase("Studio.26.07.09.Performer.Its.Great.In.The.Sample.XXX.1080p.x265-GROUP", "Studio.26.07.09.A.Movie.XXX.1080p.x265-GROUP")]
+        [TestCase("Studio.26.07.09.Performer.Title.XXX.1080p.x265-GROUP", "Studio.26.07.09.A.Movie.XXX.1080p.x265-GROUP")]
+        public void should_replace_only_the_title_tokens_in_simple_release_title(string title, string expected)
+        {
+            var result = Parser.Parser.ParseMovieTitle(title);
+
+            result.Should().NotBeNull();
+            result.SimpleReleaseTitle.Should().Be(expected);
+        }
+
         [TestCase("something random 77f1b861-91c1-4e6f-b0b1-3b1c46733fb2 anything")]
         [TestCase("prefix 77f1b861-91c1-4e6f-b0b1-3b1c46733fb2 suffix")]
         public void should_populate_all_required_fields_on_stash_id_fallback(string title)

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -344,21 +344,33 @@ namespace NzbDrone.Core.Parser
 
                             if (result != null)
                             {
-                                // TODO: Add tests for this!
                                 var simpleReleaseTitle = SimpleReleaseTitleRegex.Replace(releaseTitle, string.Empty);
 
                                 var simpleTitleReplaceString = match[0].Groups["title"].Success ? match[0].Groups["title"].Value : result.PrimaryMovieTitle;
 
                                 if (simpleTitleReplaceString.IsNotNullOrWhiteSpace())
                                 {
-                                    if (match[0].Groups["title"].Success && match[0].Groups["title"].Index < simpleReleaseTitle.Length)
+                                    var titleReplacement = simpleTitleReplaceString.Contains('.') ? "A.Movie" : "A Movie";
+                                    var releaseTokens = result.ReleaseTokens?.Trim('.', ' ', '-', '_');
+
+                                    // For a scene release the "title" capture runs to the end of the string, so it spans
+                                    // the quality block as well as the title, and its offsets count characters in
+                                    // simpleTitle, which has had the quality and codec tokens deleted. Replacing on those
+                                    // offsets overruns into simpleReleaseTitle's quality block and shreds the codec token.
+                                    // ReleaseTokens is cut from releaseTitle at the title boundary, so swapping it out by
+                                    // value keeps the quality block intact for custom formats to match against.
+                                    if (releaseTokens.IsNotNullOrWhiteSpace() && simpleReleaseTitle.Contains(releaseTokens))
+                                    {
+                                        simpleReleaseTitle = simpleReleaseTitle.Replace(releaseTokens, titleReplacement);
+                                    }
+                                    else if (match[0].Groups["title"].Success && match[0].Groups["title"].Index < simpleReleaseTitle.Length)
                                     {
                                         simpleReleaseTitle = simpleReleaseTitle.Remove(match[0].Groups["title"].Index, match[0].Groups["title"].Length)
-                                                                               .Insert(match[0].Groups["title"].Index, simpleTitleReplaceString.Contains('.') ? "A.Movie" : "A Movie");
+                                                                               .Insert(match[0].Groups["title"].Index, titleReplacement);
                                     }
                                     else
                                     {
-                                        simpleReleaseTitle = simpleReleaseTitle.Replace(simpleTitleReplaceString, simpleTitleReplaceString.Contains('.') ? "A.Movie" : "A Movie");
+                                        simpleReleaseTitle = simpleReleaseTitle.Replace(simpleTitleReplaceString, titleReplacement);
                                     }
                                 }
 


### PR DESCRIPTION
#### Database Migration

NO

#### Description

Release Title custom formats matching on codec tokens (x265/HEVC, x264, ...) silently failed to score on scene releases, seemingly at random.

`ParseMovieTitle` matches the report regexes against `simpleTitle`, which has already had the quality and codec tokens deleted by `SimpleTitleRegex`. It then applies the title replacement to `simpleReleaseTitle`, which keeps them. The two strings don't address the same characters, so the replacement span overran the title and cut into the quality block, leaving exactly as many trailing characters as `SimpleTitleRegex` had deleted:

| Stripped | Chars | Surviving tail |
| --- | --- | --- |
| `x265` | 4 | `ROUP` |
| `1080p` | 5 | `GROUP` |
| `1080p` + `x265` | 9 | `265-GROUP` |

So `x265` became `265`, the codec token no longer existed in the string the custom format is evaluated against, and the CF couldn't match. Whether the codec survived was pure arithmetic coincidence — the issue's "working" example only worked because the 9 surviving characters happened to be `.x265.PRT`. The apostrophe correlation reported in the issue is a red herring; titles with no punctuation at all reproduce it just as reliably.

This block came from Radarr, where the title capture is bounded by the year and so never crosses the stripped region. Whisparr's scene regexes capture the title through to the end of the string, so the capture spans the quality block as well — meaning simply realigning the offsets would drop the codec entirely rather than partially.

Fixed by replacing `ReleaseTokens` by value instead of splicing on the stale offsets. `ReleaseTokens` is cut from `releaseTitle` at the title boundary, so the quality block survives for custom formats to match against:

```
Studio.26.07.09.Performer.Its.Great.In.The.Sample.XXX.1080p.x265-GROUP
  before: Studio.26.07.09.Performer.Its.A.Movie265-GROUP
  after:  Studio.26.07.09.A.Movie.XXX.1080p.x265-GROUP
```

Movie parsing is unaffected — the movie branch never sets `ReleaseTokens` and falls through to the existing path.

Verified against the issue's repro through `/api/v3/parse` with the reporter's exact custom format regex, which now matches. Also removes the `// TODO: Add tests for this!` that sat above this block.

Known remaining gap, pre-existing and not a regression: `SpecialEpisodeTitleRegex` bounds on resolutions and `WEB`/`HDTV` but not codec tokens, so a release carrying a codec but no resolution (`Studio.26.07.09.Performer.Title.XXX.x265-GROUP`) still loses it. Those releases already parse as quality `Unknown`. Worth a follow-up rather than widening this change, since that regex also drives title matching.

#### Screenshot(s) (if UI related)

N/A — not UI related.

#### Todos

- [x] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json) — n/a, no user-facing strings

#### Issues Fixed or Closed by this PR

- Fixes Whisparr/Whisparr-Eros#838
