### PR TITLE
Chore: derive base release version from git tag instead of hardcoded YAML

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -8,6 +8,9 @@ inputs:
   version:
     description: "Version number to build"
     required: true
+  assembly_version:
+    description: "Assembly version (major.minor.patch.build) to stamp"
+    required: true
   framework:
     description: ".net framework used for the build"
     required: true
@@ -38,7 +41,7 @@ runs:
         echo "SDK_PATH=${{ env.DOTNET_ROOT }}/sdk/${DOTNET_VERSION}" >> "$GITHUB_ENV"
         echo "WHISPARR_VERSION=${{ inputs.version }}" >> "$GITHUB_ENV"
         echo "BRANCH=${{ inputs.branch }}" >> "$GITHUB_ENV"
-        echo "WHISPARR_ASSEMBLY_VERSION=${{ env.WHISPARR_ASSEMBLY_VERSION }}" >> "$GITHUB_ENV"
+        echo "WHISPARR_ASSEMBLY_VERSION=${{ inputs.assembly_version }}" >> "$GITHUB_ENV"
 
         if [ "$RUNNER_OS" == "Windows" ]; then
           echo "NUGET_PACKAGES=D:\nuget\packages" >> "$GITHUB_ENV"

--- a/.github/workflows/build_v3.yml
+++ b/.github/workflows/build_v3.yml
@@ -24,8 +24,10 @@ env:
   FRAMEWORK: net10.0
   RAW_BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
   WHISPARR_MAJOR_VERSION: 3
-  VERSION: 3.3.4
-  WHISPARR_ASSEMBLY_VERSION: 3.3.4.${{ github.run_number }}
+  # Base version now comes from the newest base tag (vX.Y.Z) reachable from the
+  # building branch; this is only the fallback for the seed window before any
+  # base tag exists. See prepare job below.
+  VERSION_FALLBACK: 3.3.4
 
 jobs:
   prepare:
@@ -34,12 +36,30 @@ jobs:
       framework: ${{ steps.variables.outputs.framework }}
       major_version: ${{ steps.variables.outputs.major_version }}
       version: ${{ steps.variables.outputs.version }}
+      assembly_version: ${{ steps.variables.outputs.assembly_version }}
       branch: ${{ steps.variables.outputs.branch }}
     steps:
+      - name: Check out
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0 # fetches tags; needed to read the version marker
+
       - name: Setup Environment Variables
         id: variables
         shell: bash
         run: |
+          # Base version = highest base tag (strictly vX.Y.Z) reachable from THIS
+          # branch's history. --merged keeps it reachability-scoped so eros-develop
+          # and eros each resolve their own base; the strict regex rejects both the
+          # CI-minted -develop.N/-release.N tags and the legacy 4-part vX.Y.Z.B tags
+          # inherited from upstream (which glob-based matching cannot separate).
+          # `|| true` keeps the default bash `-eo pipefail` shell from aborting the
+          # step when no base tag matches yet (seed window) or when `head` closes the
+          # pipe early (SIGPIPE); an empty result then falls back below.
+          BASE=$(git tag --merged HEAD --sort=-v:refname 2>/dev/null \
+            | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n1 | sed 's/^v//' || true)
+          BASE=${BASE:-${{ env.VERSION_FALLBACK }}}
+
           if [[ "${{ github.ref_name }}" == "eros-develop" ]]; then
             SEMVER_LABEL="develop"
           else
@@ -47,7 +67,8 @@ jobs:
           fi
           echo "framework=${{ env.FRAMEWORK }}" >> "$GITHUB_OUTPUT"
           echo "major_version=${{ env.WHISPARR_MAJOR_VERSION }}" >> "$GITHUB_OUTPUT"
-          echo "version=${{ env.VERSION }}-${SEMVER_LABEL}.${{ github.run_number }}" >> "$GITHUB_OUTPUT"
+          echo "version=${BASE}-${SEMVER_LABEL}.${{ github.run_number }}" >> "$GITHUB_OUTPUT"
+          echo "assembly_version=${BASE}.${{ github.run_number }}" >> "$GITHUB_OUTPUT"
           echo "branch=${RAW_BRANCH_NAME//\//-}" >> "$GITHUB_OUTPUT"
 
   backend:
@@ -99,6 +120,7 @@ jobs:
         with:
           branch: ${{ needs.prepare.outputs.branch }}
           version: ${{ needs.prepare.outputs.version }}
+          assembly_version: ${{ needs.prepare.outputs.assembly_version }}
           framework: ${{ needs.prepare.outputs.framework }}
           runtime: ${{ matrix.runtime }}
           package_tests: ${{ matrix.package_tests }}

--- a/.github/workflows/build_v3.yml
+++ b/.github/workflows/build_v3.yml
@@ -55,10 +55,16 @@ jobs:
           # inherited from upstream (which glob-based matching cannot separate).
           # `|| true` keeps the default bash `-eo pipefail` shell from aborting the
           # step when no base tag matches yet (seed window) or when `head` closes the
-          # pipe early (SIGPIPE); an empty result then falls back below.
-          BASE=$(git tag --merged HEAD --sort=-v:refname 2>/dev/null \
-            | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n1 | sed 's/^v//' || true)
-          BASE=${BASE:-${{ env.VERSION_FALLBACK }}}
+          # pipe early (SIGPIPE).
+          BASE_TAG=$(git tag --merged HEAD --sort=-v:refname 2>/dev/null \
+            | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n1 || true)
+          if [ -n "$BASE_TAG" ]; then
+            BASE="${BASE_TAG#v}"
+            echo "Base version ${BASE} (from tag ${BASE_TAG})"
+          else
+            BASE="${{ env.VERSION_FALLBACK }}"
+            echo "Base version ${BASE} (from VERSION_FALLBACK; no vX.Y.Z tag reachable)"
+          fi
 
           if [[ "${{ github.ref_name }}" == "eros-develop" ]]; then
             SEMVER_LABEL="develop"


### PR DESCRIPTION
#### Database Migration

NO

#### Description

Moves the base release version out of `build_v3.yml`. Today `3.3.4` is hardcoded
in two spots (`VERSION` and `WHISPARR_ASSEMBLY_VERSION`), so bumping it means
editing the workflow and landing that number into both `eros-develop` and `eros`
via dedicated version-bump PRs.

Instead, the `prepare` job now resolves the base version at build time from the
highest strictly-`vX.Y.Z` tag reachable from the building branch
(`git tag --merged HEAD` + strict `^v[0-9]+\.[0-9]+\.[0-9]+$` regex + version
sort), falling back to `VERSION_FALLBACK` (`3.3.4`) until a base tag exists. The
strict regex is deliberate: it rejects both the CI-minted `-develop.N`/`-release.N`
tags and the ~370 legacy 4-part `vX.Y.Z.B` tags inherited from upstream (glob /
`git describe` can't separate 3-part from 4-part). `git run_number` stays the
build counter, so the per-build release tags keep their `X.Y.Z-develop.N` /
`X.Y.Z-release.N` shape that the client updater parses — no client-facing change.

The assembly version becomes a `prepare` output threaded into the build action as
a new `assembly_version` input. `deploy.yml` is unchanged; it keeps minting and
GPG-signing the per-build release tags exactly as before.

Result: bumping a version is a single `git push origin vX.Y.Z` — no YAML edit and
no version-bump PRs. Branch-based triggering, the dual-branch layout, and the
`eros-develop` → `eros` promotion PR all stay as they are.

Because no base tag exists yet, this build (and every build until a `vX.Y.Z` tag
is pushed) resolves the `3.3.4` fallback and produces the same `3.3.4-develop.N`
version string as today — the cutover is silent and only diverges once a marker
tag is pushed.

#### Screenshot(s) (if UI related)

N/A — CI workflow change, no UI.

#### Todos

- [ ] Tests — N/A: CI workflow logic, not application code. The tag-resolution
  shell was validated locally under `bash -eo pipefail` (no-match → fallback;
  match → highest by numeric sort with minted/legacy tags excluded), and the
  workflow passes `actionlint` (incl. shellcheck on the `run:` block).
- [ ] Translation Keys — N/A: no user-facing strings.

#### Issues Fixed or Closed by this PR

N/A
