### PR TITLE
chore: ignore ImageSharp major updates in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,7 @@ updates:
       interval: "daily"
     open-pull-requests-limit: 1
     commit-message:
-      prefix: "Chore"
+      prefix: "chore"
     groups:
       all-npm-updates:
         patterns:
@@ -24,8 +24,11 @@ updates:
       interval: "daily"
     open-pull-requests-limit: 1
     commit-message:
-      prefix: "Chore"
+      prefix: "chore"
     groups:
       all-nuget-updates:
         patterns:
           - "*"
+    ignore:
+      - dependency-name: "SixLabors.ImageSharp"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
#### Database Migration

NO

#### Description

`SixLabors.ImageSharp` 4.0.0 enforces a commercial licence at build time via an MSBuild target shipped in the package. Without a purchased key the build fails outright:

```
sixlabors.imagesharp/4.0.0/build/SixLabors.ImageSharp.targets(27,5):
  error : No Six Labors license found. Set $(SixLaborsLicenseKey), set $(SixLaborsLicenseFile),
          or add a 'sixlabors.lic' file to the project/workspace.
  error : Please obtain a license from https://sixlabors.com/pricing/
```

This is not an API break that can be coded around — it fails during build, so it took out all ten `backend` RID jobs in the grouped NuGet bump (#333), which in turn skipped `unit_test`, `unit_test_postgres` and `integration_test`.

This PR adds an `ignore` rule for semver-major updates to `SixLabors.ImageSharp`, keeping the grouped NuGet PRs on the 3.x line. 3.1.12 (already in tree) is the latest 3.x release; 4.0.0 is the only version above it, so there is no intermediate to move to. Without this rule the daily group PR keeps reintroducing 4.0.0 and the build stays red.

Also normalises the Dependabot `commit-message.prefix` for both ecosystems from `Chore` to lowercase `chore`, matching the conventional prefixes CONTRIBUTING already tolerates.

Follow-up, not in scope here: ImageSharp is used in exactly one place — a ~5-line JPEG thumbnail resize in `src/NzbDrone.Core/MediaCover/ImageResizer.cs`. Staying on 3.1.x means eventually losing security fixes, so replacing it is worth its own issue.

#### Screenshot(s) (if UI related)

N/A — CI configuration only.

#### Todos

- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)

Neither applies: this changes `.github/dependabot.yml` only, with no application code and no user-facing strings.

#### Issues Fixed or Closed by this PR

No tracked issue. Unblocks #333, which should be closed and left to regenerate once this merges.
