### PR TITLE
Fix XBMC/Kodi NFO writing class name instead of studio title

### DIFF
--- a/src/NzbDrone.Core/Extras/Metadata/Consumers/Xbmc/XbmcMetadata.cs
+++ b/src/NzbDrone.Core/Extras/Metadata/Consumers/Xbmc/XbmcMetadata.cs
@@ -285,7 +285,7 @@ namespace NzbDrone.Core.Extras.Metadata.Consumers.Xbmc
 
                 details.Add(new XElement("year", movie.Year));
 
-                details.Add(new XElement("studio", movie.MovieMetadata.Value.Studio));
+                details.Add(new XElement("studio", movie.MovieMetadata.Value.Studio?.Title));
 
                 details.Add(new XElement("watched", watched));
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
The XBMC/Kodi metadata consumer was writing the fully-qualified class name of the `Studio` object (`NzbDrone.Core.MetadataSource.SkyHook.Resource.StudioResource`) into the `<studio>` element of generated `.nfo` files, instead of the actual studio title.

This happened because `movie.MovieMetadata.Value.Studio` is a `StudioResource` object, not a string. When passed directly into `new XElement("studio", ...)`, `XElement` calls `.ToString()` on it, and since `StudioResource` doesn't override `ToString()`, it falls back to `Object.ToString()`, which returns the type's fully qualified name.

This PR fixes it by reading `.Title` off the `Studio` object instead of passing the whole object, with a null-conditional to avoid an exception for movies with no studio set.

#### Screenshot(s) (if UI related)
<details>
N/A — backend-only fix, no UI changes.
</details>

#### Todos
- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)

#### Issues Fixed or Closed by this PR
- Fixes whisparr/whisparr-eros#1115