### PR TITLE
chore: split npm Dependabot updates by intent

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,14 +10,58 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "daily"
-    open-pull-requests-limit: 1
+      interval: "weekly"
+    open-pull-requests-limit: 10
     commit-message:
       prefix: "chore"
+    # A dependency joins the FIRST group it matches, so the coupled families
+    # are listed before the catch-all dev/prod groups. Anything matching no
+    # group gets its own PR -- which is how majors end up one-per-PR.
     groups:
-      all-npm-updates:
+      # Coupled families: these have to move together, majors included.
+      babel:
         patterns:
-          - "*"
+          - "@babel/*"
+          - "babel-loader"
+          - "babel-plugin-*"
+      eslint:
+        patterns:
+          - "eslint"
+          - "eslint-*"
+          - "@eslint/*"
+          - "@typescript-eslint/*"
+      redux:
+        patterns:
+          - "redux"
+          - "redux-*"
+          - "react-redux"
+          - "reselect"
+      react-router:
+        patterns:
+          - "react-router"
+          - "react-router-dom"
+      # Everything else: batched by intent, majors excluded so they land alone.
+      dev-minor:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
+      prod-minor:
+        dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"
+    ignore:
+      # Each of these needs source changes, not just a version bump. Drop the
+      # entry when we're ready to do that migration.
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "jquery"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "react-window"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "swiper"
+        update-types: ["version-update:semver-major"]
   - package-ecosystem: "nuget"
     directory: "/src"
     schedule:


### PR DESCRIPTION
#### Database Migration

NO

#### Description

The npm ecosystem used a single `all-npm-updates` group matching `*`, which
produced one PR bumping 61 packages at once (#332) — ~15 of them majors,
mixed in with routine patch noise. That is not reviewable, and it fails as a
unit: #332 is red because `react-router@8` requires Node >= 22.22.0 while we
pin 20.19.0, which blocks the other 60 updates for an unrelated reason.

Dependabot has no notion of "intent", but it has the two axes that matter:
`dependency-type` (development vs. production) and `update-types`. This
splits the npm config along both:

- Coupled families first — `babel`, `eslint`, `redux`, `react-router` — since
  a dependency joins the first group it matches. These stay grouped including
  majors, because they have to move together.
- Then `dev-minor` and `prod-minor`, batching everything else by intent with
  majors excluded.
- Anything matching no group gets its own PR, so remaining majors arrive one
  at a time.
- `open-pull-requests-limit` 1 → 10 to make room for the split, cadence daily
  → weekly to cut churn.

Also ignores majors for `typescript`, `jquery`, `react-window` and `swiper`.
Each needs source changes rather than a version bump (react-window 2.x and
swiper 14 are API rewrites; jquery 4 touches every AJAX path), so they'd only
sit open and red. Un-ignore them one at a time as we do the migration work.

Follow-ups, not in this PR: vetting the Node 20.19 pin (react-router 8 needs
22+), and the same intent split for the NuGet ecosystem if this works out.

#### Screenshot(s) (if UI related)

n/a — CI configuration only.

#### Todos

- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)

Neither applies: no application code changes and no user-facing strings.

#### Issues Fixed or Closed by this PR

- None
