### PR TITLE
Fix: Scrollable root folder and quality profile dropdowns

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,7 +126,7 @@ Each item names a representative path — follow the existing neighbors.
   + Yarn via `corepack enable`.
 - Backend: `dotnet msbuild -restore src/Whisparr.sln -p:Configuration=Debug -p:Platform=Posix -t:PublishAllRids`
   (or `Platform=Windows`), or the orchestrator `build.sh`. Output in `_output/`;
-  app runs at `http://localhost:7878`.
+  app runs at `http://localhost:6969`.
 - .NET SDK is pinned in `global.json` (10.0.x). API docs: `docs.sh`.
 
 ## Conventions live elsewhere

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,7 +67,7 @@ The backend solution is most easily built and ran in Visual Studio [Code] or Rid
 
 1. First `Build` the solution in Visual Studio, this will ensure all projects are correctly built and dependencies restored
 1. Next `Debug/Run` the project in Visual Studio to start Whisparr
-1. Open <http://localhost:7878>
+1. Open <http://localhost:6969>
 
 #### Command line
 

--- a/frontend/src/Components/Form/Select/EnhancedSelectInput.tsx
+++ b/frontend/src/Components/Form/Select/EnhancedSelectInput.tsx
@@ -193,8 +193,16 @@ function EnhancedSelectInput<V, T extends EnhancedSelectInputValue<V>>(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const handleComputeMaxHeight = useCallback(({ state }: { state: any }) => {
     const windowHeight = window.innerHeight;
+    const referenceRect = state.elements.reference.getBoundingClientRect();
+    const spaceBelow =
+      windowHeight - referenceRect.bottom - MINIMUM_DISTANCE_FROM_EDGE;
+    const spaceAbove = referenceRect.top - MINIMUM_DISTANCE_FROM_EDGE;
+    const available = state.placement.startsWith('top')
+      ? spaceAbove
+      : spaceBelow;
+    const maxHeight = Math.max(0, Math.min(windowHeight / 2, available));
 
-    state.styles.popper.maxHeight = `${windowHeight - MINIMUM_DISTANCE_FROM_EDGE}px`;
+    state.styles.popper.maxHeight = `${maxHeight}px`;
   }, []);
 
   const handleWindowClick = useCallback(
@@ -499,6 +507,7 @@ function EnhancedSelectInput<V, T extends EnhancedSelectInputValue<V>>(
                 requires: ['computeStyles'],
                 fn: handleComputeMaxHeight,
               },
+              { name: 'flip' },
               { name: 'preventOverflow' },
             ]}
           >


### PR DESCRIPTION
#### Database Migration

NO

#### Description

The `EnhancedSelectInput` popup (root folder, quality profile, and every select
built on it) computed its `max-height` from the full viewport height regardless
of where the trigger sat. A dropdown opened low on the screen therefore extended
past the bottom of the viewport, and because the content rarely exceeded a whole
viewport the inner `Scroller`'s `overflow-y: auto` never engaged — so long lists
were unreachable below the fold.

The fix bounds the popup to the space actually available beside the trigger
(clamped to half the viewport, mirroring Sonarr's upstream `size` middleware) and
adds popper's `flip` modifier so a near-bottom select opens upward instead of
running off-screen. No CSS change is needed — the existing `Scroller` scrolls
correctly once the height is properly bounded.

A second, trivial commit corrects the documented dev port (Radarr's `7878` →
Eros's `6969`) in `AGENTS.md`/`CLAUDE.md` and `CONTRIBUTING.md`, found while
running the app to verify this fix.

#### Screenshot(s) (if UI related)

<details>

<!-- paste screenshots below here.-->

Quality Profile dropdown on a performer edit form, now bounded to the viewport
with a working scrollbar reaching every profile.

<!-- paste screenshots above here.  MAKE SURE THE ARE SFW -->
</details>

#### Todos

- [ ] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)

<sub>No new user-facing strings; no unit-test harness exercises this popup, so it
was verified manually in the running app (dropdown stays on-screen, scrolls to
all options, flips upward near the bottom edge).</sub>

#### Issues Fixed or Closed by this PR

- Fixes whisparr/whisparr#1072
