### PR TITLE
Fix: Accept Studio TitleSlug tokens in Scene Folder Format validation

### DIFF
--- a/src/NzbDrone.Core.Test/OrganizerTests/GetMovieFolderFixture.cs
+++ b/src/NzbDrone.Core.Test/OrganizerTests/GetMovieFolderFixture.cs
@@ -89,6 +89,7 @@ namespace NzbDrone.Core.Test.OrganizerTests
 
         [TestCase("scenes-{Studio Network}-{Studio Title}-{Release Date} - {Scene CleanTitle} {[StashId]}", "scenes-Network's Name-Studio's Name-2025-11-25 - The Last Train Home [019abb52-0557-7c5f-83df-94b828851fd1]")]
         [TestCase("scenes-{Studio CleanNetwork}-{Studio CleanTitle}-{Release Date} - {Scene CleanTitle} {[StashId]}", "scenes-Networks Name-Studios Name-2025-11-25 - The Last Train Home [019abb52-0557-7c5f-83df-94b828851fd1]")]
+        [TestCase("scenes-{Studio CleanNetwork}-{Studio CleanTitleSlug}-{Release Date} - {Scene CleanTitle} {[StashId]}", "scenes-Networks Name-StudiosName-2025-11-25 - The Last Train Home [019abb52-0557-7c5f-83df-94b828851fd1]")]
         public void should_use_sceneFolderFormat_to_build_folder_name(string format, string expected)
         {
             _namingConfig.SceneFolderFormat = format;

--- a/src/NzbDrone.Core.Test/OrganizerTests/SceneFolderRegexFixture.cs
+++ b/src/NzbDrone.Core.Test/OrganizerTests/SceneFolderRegexFixture.cs
@@ -1,0 +1,31 @@
+using FluentAssertions;
+using NUnit.Framework;
+using NzbDrone.Core.Organizer;
+using NzbDrone.Core.Test.Framework;
+
+namespace NzbDrone.Core.Test.OrganizerTests
+{
+    [TestFixture]
+    public class SceneFolderRegexFixture : CoreTest
+    {
+        // Every studio-title token that FileNameBuilder registers must be accepted by the
+        // Scene Folder Format validator, otherwise a valid token is rejected on save.
+        [TestCase("{Studio Title}")]
+        [TestCase("{Studio TitleSlug}")]
+        [TestCase("{Studio CleanTitle}")]
+        [TestCase("{Studio CleanTitleSlug}")]
+        [TestCase("{Studio TitleThe}")]
+        [TestCase("{Studio TitleFirstCharacter}")]
+        public void should_accept_studio_title_token(string format)
+        {
+            FileNameBuilder.SceneFolderRegex.IsMatch(format).Should().BeTrue();
+        }
+
+        [TestCase("no studio token here")]
+        [TestCase("{Scene CleanTitle}")]
+        public void should_reject_format_without_studio_token(string format)
+        {
+            FileNameBuilder.SceneFolderRegex.IsMatch(format).Should().BeFalse();
+        }
+    }
+}

--- a/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
@@ -51,7 +51,7 @@ namespace NzbDrone.Core.Organizer
         public static readonly Regex MovieTitleRegex = new Regex(@"(?<token>\{((?:(Movie|Original))(?<separator>[- ._])(Clean)?(Original)?(Title|Filename)(The)?)(?::(?<customFormat>[a-z0-9|-]+))?\})",
                                                                             RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
-        public static readonly Regex SceneFolderRegex = new Regex(@"(?<token>\{((?:(Studio|Original))(?<separator>[- ._])(Clean)?(Original)?(Title|Filename)(The)?)(?::(?<customFormat>[a-z0-9|]+))?\})",
+        public static readonly Regex SceneFolderRegex = new Regex(@"(?<token>\{((?:(Studio|Original))(?<separator>[- ._])(Clean)?(Original)?(Title|Filename)(The|Slug|FirstCharacter)?)(?::(?<customFormat>[a-z0-9|]+))?\})",
                                                                             RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         // Matches any of the four scene title tokens: {Scene Title}, {Scene CleanTitle}, {Scene CleanTitleNoSeasonEpisode}, {Scene TitleThe}


### PR DESCRIPTION
#### Database Migration

NO

#### Description

Saving a Scene Folder Format containing `{Studio CleanTitleSlug}` was rejected
with *"Must contain scene studio token, ex. {Studio CleanTitle}"*, even though
it is a valid, registered naming token.

The `SceneFolderFormat` validator matches `SceneFolderRegex`, whose studio-title
token ended at `(Title|Filename)(The)?`. That branch had no `Slug` /
`FirstCharacter` suffix, so `{Studio TitleSlug}`, `{Studio CleanTitleSlug}`, and
`{Studio TitleFirstCharacter}` failed validation — despite `FileNameBuilder`
registering token handlers for all three (they render fine, they just could not
be saved). Extending the regex to `(The|Slug|FirstCharacter)?` lets every
supported studio-title token pass validation.

#### Screenshot(s) (if UI related)

N/A — backend validation fix.

#### Todos

- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json) — none needed; no new user-facing strings

#### Issues Fixed or Closed by this PR

- Fixes whisparr/whisparr#1079
