### PR TITLE
Fix: Scene import failing with "Can't update model with ID 0"

### DIFF
--- a/src/NzbDrone.Core.Test/MediaFiles/MediaInfo/UpdateMediaInfoServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/MediaInfo/UpdateMediaInfoServiceFixture.cs
@@ -276,6 +276,31 @@ namespace NzbDrone.Core.Test.MediaFiles.MediaInfo
         }
 
         [Test]
+        public void should_not_persist_media_info_for_unsaved_movie_file()
+        {
+            // During import the file name is built (triggering a media info update) before the
+            // MovieFile is inserted, so its Id is still 0. Persisting it would throw
+            // "Can't update model with ID 0" (whisparr/whisparr#1075).
+            var movieFile = Builder<MovieFile>.CreateNew()
+                .With(v => v.Id = 0)
+                .With(v => v.Path = null)
+                .With(v => v.RelativePath = "media.mkv")
+                .With(v => v.MediaInfo = null)
+                .Build();
+
+            GivenFileExists();
+            GivenSuccessfulScan();
+
+            Subject.Update(movieFile, _movie);
+
+            Mocker.GetMock<IMediaFileService>()
+                .Verify(v => v.Update(It.IsAny<MovieFile>()), Times.Never());
+
+            movieFile.MediaInfo.Should().NotBeNull();
+            ExceptionVerification.IgnoreWarns();
+        }
+
+        [Test]
         public void should_not_update_media_info_if_new_info_is_null()
         {
             var movieFile = Builder<MovieFile>.CreateNew()

--- a/src/NzbDrone.Core/MediaFiles/MediaInfo/UpdateMediaInfoService.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaInfo/UpdateMediaInfoService.cs
@@ -108,7 +108,14 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
                 movieFile.Quality = localMovie.Quality;
             }
 
-            _mediaFileService.Update(movieFile);
+            // Only persist when the file already exists in the DB. During import the file name is
+            // built (which can trigger a media info update) before the MovieFile is inserted, so its
+            // Id is still 0. The in-memory MediaInfo/Quality set above is persisted by the later Add.
+            if (movieFile.Id > 0)
+            {
+                _mediaFileService.Update(movieFile);
+            }
+
             _logger.Debug("Updated MediaInfo for '{0}'", path);
 
             return true;


### PR DESCRIPTION
#### Database Migration

NO

#### Description

Scene imports could fail with `InvalidOperationException: Can't update model with ID 0`.

During import, the destination file name is built (via `FileNameBuilder`) before the `MovieFile` is inserted into the database, so its `Id` is still `0`. When the Scene naming format contains a MediaInfo token and the file's media info is missing/stale (e.g. importing an existing file with MediaInfo analysis disabled), building the name triggers `UpdateMediaInfoService.UpdateMediaInfo`, which unconditionally called `IMediaFileService.Update(movieFile)` — and `BasicRepository.Update` throws for an ID-0 record.

The fix guards the persist call so it only runs for files already in the DB (`Id > 0`). The in-memory `MediaInfo`/`Quality` are still applied, so the naming token resolves correctly and the subsequent `Add` persists them. The other callers (`MovieScannedEvent` handler, `DiskScanService`, `SceneDiskScanService`) all operate on files loaded from the DB, so they are unaffected.

#### Screenshot(s) (if UI related)

N/A

#### Todos

- [x] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)

#### Issues Fixed or Closed by this PR

- Fixes whisparr/whisparr#1075
