### PR TITLE
Fix: Rename Files / Tags bulk modals show empty data for scenes

### DIFF
--- a/frontend/src/Movie/Index/MovieIndex.tsx
+++ b/frontend/src/Movie/Index/MovieIndex.tsx
@@ -290,7 +290,7 @@ function MovieIndex() {
           ) : null}
         </PageContentBody>
 
-        {isSelectMode ? <MovieIndexSelectFooter /> : null}
+        {isSelectMode ? <MovieIndexSelectFooter items={items} /> : null}
 
         <InteractiveImportModal
           isOpen={isInteractiveImportModalOpen}

--- a/frontend/src/Movie/Index/Select/MovieIndexSelectFooter.tsx
+++ b/frontend/src/Movie/Index/Select/MovieIndexSelectFooter.tsx
@@ -203,6 +203,7 @@ function MovieIndexSelectFooter({
       <TagsModal
         isOpen={isTagsModalOpen}
         movieIds={movieIds}
+        items={items}
         onApplyTagsPress={onApplyTagsPress}
         onModalClose={onTagsModalClose}
       />

--- a/frontend/src/Movie/Index/Select/MovieIndexSelectFooter.tsx
+++ b/frontend/src/Movie/Index/Select/MovieIndexSelectFooter.tsx
@@ -7,6 +7,7 @@ import { RENAME_MOVIE } from 'Commands/commandNames';
 import SpinnerButton from 'Components/Link/SpinnerButton';
 import PageContentFooter from 'Components/Page/PageContentFooter';
 import { kinds } from 'Helpers/Props';
+import Movie from 'Movie/Movie';
 import { saveMovieEditor } from 'Store/Actions/movieActions';
 import { fetchRootFolders } from 'Store/Actions/rootFolderActions';
 import createCommandExecutingSelector from 'Store/Selectors/createCommandExecutingSelector';
@@ -39,7 +40,13 @@ const sceneEditorSelector = createSelector(
   }
 );
 
-function MovieIndexSelectFooter() {
+interface MovieIndexSelectFooterProps {
+  items: Movie[];
+}
+
+function MovieIndexSelectFooter({
+  items,
+}: Readonly<MovieIndexSelectFooterProps>) {
   const { isSaving: legacyIsSaving } = useSelector(sceneEditorSelector);
   const isOrganizingMovies = useSelector(
     createCommandExecutingSelector(RENAME_MOVIE)
@@ -203,6 +210,7 @@ function MovieIndexSelectFooter() {
       <OrganizeMoviesModal
         isOpen={isOrganizeModalOpen}
         movieIds={movieIds}
+        items={items}
         onModalClose={onOrganizeModalClose}
       />
 

--- a/frontend/src/Movie/Index/Select/Organize/OrganizeMoviesModal.tsx
+++ b/frontend/src/Movie/Index/Select/Organize/OrganizeMoviesModal.tsx
@@ -1,14 +1,16 @@
 import React from 'react';
 import Modal from 'Components/Modal/Modal';
+import Movie from 'Movie/Movie';
 import OrganizeMoviesModalContent from './OrganizeMoviesModalContent';
 
 interface OrganizeMoviesModalProps {
   isOpen: boolean;
   movieIds: number[];
+  items: Movie[];
   onModalClose: () => void;
 }
 
-function OrganizeMoviesModal(props: OrganizeMoviesModalProps) {
+function OrganizeMoviesModal(props: Readonly<OrganizeMoviesModalProps>) {
   const { isOpen, onModalClose, ...otherProps } = props;
 
   return (

--- a/frontend/src/Movie/Index/Select/Organize/OrganizeMoviesModalContent.tsx
+++ b/frontend/src/Movie/Index/Select/Organize/OrganizeMoviesModalContent.tsx
@@ -1,6 +1,6 @@
 import { orderBy } from 'lodash';
 import React, { useCallback, useMemo } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch } from 'react-redux';
 import { RENAME_MOVIE } from 'Commands/commandNames';
 import Alert from 'Components/Alert';
 import Icon from 'Components/Icon';
@@ -12,24 +12,25 @@ import ModalHeader from 'Components/Modal/ModalHeader';
 import { icons, kinds } from 'Helpers/Props';
 import Movie from 'Movie/Movie';
 import { executeCommand } from 'Store/Actions/commandActions';
-import createAllMoviesSelector from 'Store/Selectors/createAllMoviesSelector';
 import translate from 'Utilities/String/translate';
 import styles from './OrganizeMoviesModalContent.css';
 
 interface OrganizeMoviesModalContentProps {
   movieIds: number[];
+  items: Movie[];
   onModalClose: () => void;
 }
 
-function OrganizeMoviesModalContent(props: OrganizeMoviesModalContentProps) {
-  const { movieIds, onModalClose } = props;
+function OrganizeMoviesModalContent(
+  props: Readonly<OrganizeMoviesModalContentProps>
+) {
+  const { movieIds, items, onModalClose } = props;
 
-  const allMovies: Movie[] = useSelector(createAllMoviesSelector());
   const dispatch = useDispatch();
 
   const movieTitles = useMemo(() => {
     const movie = movieIds.reduce((acc: Movie[], id) => {
-      const s = allMovies.find((s) => s.id === id);
+      const s = items.find((s) => s.id === id);
 
       if (s) {
         acc.push(s);
@@ -41,7 +42,7 @@ function OrganizeMoviesModalContent(props: OrganizeMoviesModalContentProps) {
     const sorted = orderBy(movie, ['sortTitle']);
 
     return sorted.map((s) => s.title);
-  }, [movieIds, allMovies]);
+  }, [movieIds, items]);
 
   const onOrganizePress = useCallback(() => {
     dispatch(
@@ -65,7 +66,7 @@ function OrganizeMoviesModalContent(props: OrganizeMoviesModalContentProps) {
         </Alert>
 
         <div className={styles.message}>
-          {translate('OrganizeConfirm', { count: movieTitles.length })}
+          {translate('OrganizeConfirm', { count: movieIds.length })}
         </div>
 
         <ul>

--- a/frontend/src/Movie/Index/Select/Tags/TagsModal.tsx
+++ b/frontend/src/Movie/Index/Select/Tags/TagsModal.tsx
@@ -1,15 +1,17 @@
 import React from 'react';
 import Modal from 'Components/Modal/Modal';
+import Movie from 'Movie/Movie';
 import TagsModalContent from './TagsModalContent';
 
 interface TagsModalProps {
   isOpen: boolean;
   movieIds: number[];
+  items: Movie[];
   onApplyTagsPress: (tags: number[], applyTags: string) => void;
   onModalClose: () => void;
 }
 
-function TagsModal(props: TagsModalProps) {
+function TagsModal(props: Readonly<TagsModalProps>) {
   const { isOpen, onModalClose, ...otherProps } = props;
 
   return (

--- a/frontend/src/Movie/Index/Select/Tags/TagsModalContent.tsx
+++ b/frontend/src/Movie/Index/Select/Tags/TagsModalContent.tsx
@@ -14,21 +14,20 @@ import ModalFooter from 'Components/Modal/ModalFooter';
 import ModalHeader from 'Components/Modal/ModalHeader';
 import { inputTypes, kinds, sizes } from 'Helpers/Props';
 import Movie from 'Movie/Movie';
-import createAllMoviesSelector from 'Store/Selectors/createAllMoviesSelector';
 import createTagsSelector from 'Store/Selectors/createTagsSelector';
 import translate from 'Utilities/String/translate';
 import styles from './TagsModalContent.css';
 
 interface TagsModalContentProps {
   movieIds: number[];
+  items: Movie[];
   onApplyTagsPress: (tags: number[], applyTags: string) => void;
   onModalClose: () => void;
 }
 
 function TagsModalContent(props: TagsModalContentProps) {
-  const { movieIds, onModalClose, onApplyTagsPress } = props;
+  const { movieIds, items, onModalClose, onApplyTagsPress } = props;
 
-  const allMovies: Movie[] = useSelector(createAllMoviesSelector());
   const tagList: Tag[] = useSelector(createTagsSelector());
 
   const [tags, setTags] = useState<number[]>([]);
@@ -36,7 +35,7 @@ function TagsModalContent(props: TagsModalContentProps) {
 
   const movieTags = useMemo(() => {
     const tags = movieIds.reduce((acc: number[], id) => {
-      const s = allMovies.find((s) => s.id === id);
+      const s = items.find((s) => s.id === id);
 
       if (s) {
         acc.push(...s.tags);
@@ -46,7 +45,7 @@ function TagsModalContent(props: TagsModalContentProps) {
     }, []);
 
     return uniq(tags);
-  }, [movieIds, allMovies]);
+  }, [movieIds, items]);
 
   const onTagsChange = useCallback(
     ({ value }: { value: number[] }) => {


### PR DESCRIPTION
#### Database Migration

NO

#### Description

The scene/movie index now loads its items through React Query (`/movie/paged`),
so the items live in the query cache rather than the legacy Redux
`state.movies.items` slice. Two bulk-select modals were still resolving data
through `createAllMoviesSelector`, which reads that now-empty slice:

- **Organize / Rename Files** — no selected id resolved, so the title list came
  out empty and the confirm dialog read *"organize all files in the **0**
  selected movie(s)"*, making bulk rename unusable (issue Whisparr/Whisparr-Eros#832).
- **Tags** — the "Result" preview computes each selection's existing tags the
  same way, so it silently showed nothing for scenes.

Both are fixed by threading the already-loaded React Query `items` down through
the select footer into each modal and resolving titles/tags from them. The
Organize confirm count is now based on `movieIds.length` — the ids the
`RENAME_MOVIE` command actually operates on. "Select all" is per-page, so the
loaded items always contain the selection.

Two commits, kept separate for a normal (non-squash) merge.

#### Screenshot(s) (if UI related)

<details>

<!-- paste screenshots below here.-->

<!-- paste screenshots above here.  MAKE SURE THE ARE SFW -->

</details>

#### Todos

- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)

#### Issues Fixed or Closed by this PR

- Fixes whisparr/whisparr#1094
