### PR TITLE
Fix: Custom formats missing on disk scan history rows

### DIFF
--- a/src/NzbDrone.Core.Test/CustomFormats/CustomFormatCalculationServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/CustomFormats/CustomFormatCalculationServiceFixture.cs
@@ -1,0 +1,99 @@
+using System.Collections.Generic;
+using FizzWare.NBuilder;
+using FluentAssertions;
+using NUnit.Framework;
+using NzbDrone.Core.CustomFormats;
+using NzbDrone.Core.History;
+using NzbDrone.Core.Languages;
+using NzbDrone.Core.MediaFiles;
+using NzbDrone.Core.Movies;
+using NzbDrone.Core.Qualities;
+using NzbDrone.Core.Test.Framework;
+
+namespace NzbDrone.Core.Test.CustomFormats
+{
+    [TestFixture]
+    public class CustomFormatCalculationServiceFixture : CoreTest<CustomFormatCalculationService>
+    {
+        private const string SceneName = "Vixen.23.12.18.Performer.Title.XXX.1080p.x264-GRP";
+
+        private Movie _movie;
+
+        [SetUp]
+        public void Setup()
+        {
+            _movie = Builder<Movie>.CreateNew()
+                                   .With(m => m.MovieMetadata.Value.Title = "Performer Title")
+                                   .Build();
+
+            Mocker.GetMock<ICustomFormatService>()
+                  .Setup(s => s.All())
+                  .Returns(new List<CustomFormat>
+                  {
+                      new CustomFormat("x264", new ReleaseTitleSpecification { Value = "x264" }) { Id = 1 }
+                  });
+        }
+
+        private MovieHistory GivenHistory(string sourceTitle)
+        {
+            return new MovieHistory
+            {
+                EventType = MovieHistoryEventType.DiskScanImported,
+                SourceTitle = sourceTitle,
+                Quality = new QualityModel(Quality.WEBDL1080p),
+                Languages = new List<Language> { Language.English },
+                MovieId = _movie.Id
+            };
+        }
+
+        private MovieFile GivenMovieFile(string sceneName, string relativePath)
+        {
+            return new MovieFile
+            {
+                MovieId = _movie.Id,
+                SceneName = sceneName,
+                RelativePath = relativePath,
+                Quality = new QualityModel(Quality.WEBDL1080p),
+                Languages = new List<Language> { Language.English }
+            };
+        }
+
+        [Test]
+        public void should_match_history_with_a_release_name_source_title()
+        {
+            Subject.ParseCustomFormat(GivenHistory(SceneName), _movie)
+                   .Should().ContainSingle(f => f.Name == "x264");
+        }
+
+        // Disk scan and file events record a path rather than a release name. Parsing one masks the
+        // scene title out of the simple release title, which can take the codec token with it, so
+        // the specifications have to be able to fall back to the file name.
+        [TestCase("/data/scenes/Vixen/Vixen.23.12.18.Performer.Title.XXX.1080p.x264-GRP.mkv")]
+        [TestCase("/mnt/user/data/Brazzers/Brazzers.19.11.02.Some.One.Scene.Name.XXX.SD.x264-KLEENEX.mp4")]
+        public void should_match_history_with_a_file_path_source_title(string sourceTitle)
+        {
+            Subject.ParseCustomFormat(GivenHistory(sourceTitle), _movie)
+                   .Should().ContainSingle(f => f.Name == "x264");
+        }
+
+        // The reported symptom: the files table on the movie detail page showed the format while the
+        // history row for the very same file did not.
+        [Test]
+        public void should_match_the_same_formats_for_history_and_movie_file()
+        {
+            var movieFile = GivenMovieFile(SceneName, $"{SceneName}.mkv");
+            var history = GivenHistory(movieFile.GetSceneOrFileName());
+
+            Subject.ParseCustomFormat(history, _movie)
+                   .Should().BeEquivalentTo(Subject.ParseCustomFormat(movieFile, _movie));
+        }
+
+        [Test]
+        public void should_not_match_when_neither_the_release_name_nor_the_file_name_has_the_token()
+        {
+            var history = GivenHistory("Vixen - 2023-12-18 - Performer Title [WEBDL-1080p].mkv");
+
+            Subject.ParseCustomFormat(history, _movie).Should().BeEmpty();
+        }
+    }
+}

--- a/src/NzbDrone.Core.Test/HistoryTests/MovieFileScannedImportHistoryHandlerFixture.cs
+++ b/src/NzbDrone.Core.Test/HistoryTests/MovieFileScannedImportHistoryHandlerFixture.cs
@@ -93,7 +93,10 @@ namespace NzbDrone.Core.Test.HistoryTests
             var history = HandleScan(importedMovie);
 
             history.SourceTitle.Should().NotBe(importedMovie.Path);
-            history.Data["ImportedPath"].Should().Be(importedMovie.Path);
+
+            // Asserted by suffix because the handler builds this with Path.Combine, whose separator
+            // is platform specific.
+            history.Data["ImportedPath"].Should().EndWith(importedMovie.RelativePath);
         }
     }
 }

--- a/src/NzbDrone.Core.Test/HistoryTests/MovieFileScannedImportHistoryHandlerFixture.cs
+++ b/src/NzbDrone.Core.Test/HistoryTests/MovieFileScannedImportHistoryHandlerFixture.cs
@@ -1,0 +1,99 @@
+using System.Collections.Generic;
+using FizzWare.NBuilder;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+using NzbDrone.Core.History;
+using NzbDrone.Core.Languages;
+using NzbDrone.Core.MediaFiles;
+using NzbDrone.Core.MediaFiles.Events;
+using NzbDrone.Core.Movies;
+using NzbDrone.Core.Parser.Model;
+using NzbDrone.Core.Qualities;
+using NzbDrone.Core.Test.Framework;
+
+namespace NzbDrone.Core.Test.HistoryTests
+{
+    [TestFixture]
+    public class MovieFileScannedImportHistoryHandlerFixture : CoreTest<MovieFileScannedImportHistoryHandler>
+    {
+        private Movie _movie;
+
+        [SetUp]
+        public void Setup()
+        {
+            _movie = Builder<Movie>.CreateNew()
+                                   .With(m => m.Path = "/data/scenes/Vixen")
+                                   .Build();
+        }
+
+        private MovieHistory HandleScan(MovieFile importedMovie)
+        {
+            MovieHistory inserted = null;
+
+            Mocker.GetMock<IHistoryRepository>()
+                  .Setup(r => r.Insert(It.IsAny<MovieHistory>()))
+                  .Callback<MovieHistory>(h => inserted = h)
+                  .Returns<MovieHistory>(h => h);
+
+            var localMovie = new LocalMovie
+            {
+                Movie = _movie,
+                Path = $"{_movie.Path}/{importedMovie.RelativePath}",
+                Quality = new QualityModel(Quality.WEBDL1080p),
+                Languages = new List<Language>()
+            };
+
+            Subject.Handle(new MovieFileImportedEvent(localMovie, importedMovie, new List<DeletedMovieFile>(), false, null));
+
+            inserted.Should().NotBeNull();
+
+            return inserted;
+        }
+
+        [Test]
+        public void should_use_scene_name_as_source_title()
+        {
+            var importedMovie = new MovieFile
+            {
+                MovieId = _movie.Id,
+                SceneName = "Vixen.23.12.18.Performer.Title.XXX.1080p.x264-GRP",
+                RelativePath = "Vixen - 2023-12-18 - Performer Title [WEBDL-1080p].mkv",
+                Path = "/data/scenes/Vixen/Vixen - 2023-12-18 - Performer Title [WEBDL-1080p].mkv"
+            };
+
+            HandleScan(importedMovie).SourceTitle.Should().Be(importedMovie.SceneName);
+        }
+
+        [Test]
+        public void should_fall_back_to_file_name_when_there_is_no_scene_name()
+        {
+            var importedMovie = new MovieFile
+            {
+                MovieId = _movie.Id,
+                RelativePath = "Vixen.23.12.18.Performer.Title.XXX.1080p.x264-GRP.mkv",
+                Path = "/data/scenes/Vixen/Vixen.23.12.18.Performer.Title.XXX.1080p.x264-GRP.mkv"
+            };
+
+            HandleScan(importedMovie).SourceTitle.Should().Be("Vixen.23.12.18.Performer.Title.XXX.1080p.x264-GRP");
+        }
+
+        // The absolute path is what broke custom format matching on these rows; it stays available
+        // through the event data instead.
+        [Test]
+        public void should_not_use_the_absolute_path_as_source_title()
+        {
+            var importedMovie = new MovieFile
+            {
+                MovieId = _movie.Id,
+                RelativePath = "Vixen.23.12.18.Performer.Title.XXX.1080p.x264-GRP.mkv",
+                Path = "/data/scenes/Vixen/Vixen.23.12.18.Performer.Title.XXX.1080p.x264-GRP.mkv"
+            };
+
+            var history = HandleScan(importedMovie);
+
+            history.SourceTitle.Should().NotBe(importedMovie.Path);
+            history.Data["ImportedPath"].Should().Be(importedMovie.Path);
+        }
+    }
+}

--- a/src/NzbDrone.Core/CustomFormats/CustomFormatCalculationService.cs
+++ b/src/NzbDrone.Core/CustomFormats/CustomFormatCalculationService.cs
@@ -109,7 +109,11 @@ namespace NzbDrone.Core.CustomFormats
                 Movie = movie,
                 Size = size,
                 Languages = history.Languages,
-                IndexerFlags = indexerFlags
+                IndexerFlags = indexerFlags,
+
+                // Import and file events record a path rather than a release name, so give the
+                // specifications the file name to match on the same way the movie file does.
+                Filename = Path.GetFileName(history.SourceTitle)
             };
 
             return ParseCustomFormat(input);

--- a/src/NzbDrone.Core/History/MovieFileScannedImportHistoryHandler.cs
+++ b/src/NzbDrone.Core/History/MovieFileScannedImportHistoryHandler.cs
@@ -33,7 +33,7 @@ namespace NzbDrone.Core.History
                 Date = DateTime.UtcNow,
                 Quality = message.MovieInfo.Quality,
                 Languages = message.MovieInfo.Languages,
-                SourceTitle = message.ImportedMovie.Path ?? message.ImportedMovie.RelativePath,
+                SourceTitle = message.ImportedMovie.GetSceneOrFileName(),
                 MovieId = movie.Id
             };
 


### PR DESCRIPTION
#### Database Migration

NO

#### Description

`GET /api/v3/history?page=1` returned `customFormats: []` and `customFormatScore: 0`
for "Movie file was added during disk scan" rows, while the files table on the same
movie's detail page showed the format (e.g. `x264 +1000`). Interactive search was
never affected — `GET /api/v3/release?movieId=…` returns populated formats — which
rules out the shared parsing logic and points at the inputs each caller passes.

`DiskScanImported` is the only import event that stored an absolute filesystem path
as `SourceTitle`; `Grabbed` stores the release title and `DownloadFolderImported`
stores `SceneName ?? filename`. Meanwhile the files table calculates formats from the
movie file, which prefers `SceneName` and additionally passes a `Filename` that
`ReleaseTitleSpecification` matches against — the history overload passed no
`Filename` at all. So one side matched on the release name and the other on the
on-disk path, which after renaming is `… - Scene Title [WEBDL-1080p].mkv` with no
codec token in it.

Two changes:

- `MovieFileScannedImportHistoryHandler` now stores `ImportedMovie.GetSceneOrFileName()`,
  the existing helper, whose precedence (`SceneName` → relative path file name → path
  file name) is the same one the files-table calculator uses. The absolute path is
  still on the row via `Data["ImportedPath"]` / `Data["DroppedPath"]`.
- `ParseCustomFormat(MovieHistory, Movie)` now sets `Filename`, matching the
  `MovieFile` and `LocalMovie` overloads. This is what repairs rows already in the
  database, which keep their stored path until re-import.

Two things worth flagging for review:

- The `Filename` change also populates formats on `movieFileDeleted` /
  `movieFileRenamed` rows, whose `SourceTitle` is likewise a path. Consistent and
  arguably correct, but it is a visible change beyond the reported symptom.
- For a renamed file whose `SceneName` is null, the on-disk name genuinely carries no
  codec token, so no format matches. The files table behaves identically in that case,
  so history and the files table still agree — which is the goal.

Not addressed here, worth its own issue: the scene-title mask in `ParseMovieTitle`
replaces `ReleaseTokens` with `A.Movie`, and `ReleaseTokens` is only narrowed by
`SpecialEpisodeTitleRegex`, whose marker list is `480p|720p|1080p|2160p|HDTV|WEB|WEBRip|WEB-?DL`.
A release with none of those literals loses its quality, codec and release group
(`Studio.20.01.01.Performer.Some.Title.XXX.DVDRip.x264-GRP` → `Studio.20.01.01.A.Movie`).
That affects grab-time scoring in `DownloadDecisionMaker`, not just display.

#### Screenshot(s) (if UI related)

n/a — API/backend only.

#### Todos

- [x] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)

Two new fixtures:

- `CustomFormatCalculationServiceFixture` — pins that a history row and the movie file
  for the same import produce the same formats, including path-shaped source titles.
- `MovieFileScannedImportHistoryHandlerFixture` — pins that the inserted row carries
  the scene name (or bare file name), never the absolute path.

Both were verified to fail without the source changes: stashing the two source files
and re-running turns 4 of the 8 new assertions red. Wider run across `CustomFormats`,
`HistoryTests`, `ParserTests`, `DecisionEngineTests`, `MediaFiles` and `Blocklist`:
1906 passed, 0 failed, 9 skipped.

No new user-facing strings.

#### Issues Fixed or Closed by this PR

- Fixes whisparr/whisparr#1049
