### PR TITLE
Fix: Scene title mask eating the release tag block

### DIFF
--- a/src/NzbDrone.Core.Test/ParserTests/ParseMovieTitleFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/ParseMovieTitleFixture.cs
@@ -180,6 +180,14 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("Studio2.24.07.26.Performer.Plain.Title.Words.Here.XXX.1080p.HEVC.x265.PRT", "x265")]
         [TestCase("Studio.22.10.18.Title.XXX.720p.HEVC.x265.PRT[XvX]", "x265")]
         [TestCase("Studio.26.07.09.Performer.Title.XXX.1080p.h264-GROUP", "h264")]
+
+        // The release tokens the title is masked from are only narrowed at a resolution or web
+        // source marker, so a release carrying none of those used to have its whole tag block
+        // masked away along with the title.
+        [TestCase("Studio.20.01.01.Performer.Some.Title.XXX.DVDRip.x264-GRP", "x264")]
+        [TestCase("Studio.20.01.01.Performer.Some.Title.XXX.BluRay.x264-GRP", "x264")]
+        [TestCase("Studio.23.05.12.Performer.Title.HEVC.x265-GROUP", "x265")]
+        [TestCase("Studio.20.01.01.Performer.Title.x264-GRP", "x264")]
         public void should_keep_codec_token_in_simple_release_title(string title, string codec)
         {
             var result = Parser.Parser.ParseMovieTitle(title);
@@ -190,6 +198,9 @@ namespace NzbDrone.Core.Test.ParserTests
 
         [TestCase("Studio.26.07.09.Performer.Its.Great.In.The.Sample.XXX.1080p.x265-GROUP", "Studio.26.07.09.A.Movie.XXX.1080p.x265-GROUP")]
         [TestCase("Studio.26.07.09.Performer.Title.XXX.1080p.x265-GROUP", "Studio.26.07.09.A.Movie.XXX.1080p.x265-GROUP")]
+        [TestCase("Studio.20.01.01.Performer.Some.Title.XXX.DVDRip.x264-GRP", "Studio.20.01.01.A.Movie.XXX.DVDRip.x264-GRP")]
+        [TestCase("Studio.23.05.12.Performer.Title.HEVC.x265-GROUP", "Studio.23.05.12.A.Movie.HEVC.x265-GROUP")]
+        [TestCase("Brazzers.19.11.02.Some.One.Scene.Name.XXX.SD.MP4-KLEENEX", "Brazzers.19.11.02.A.Movie.XXX.SD.MP4-KLEENEX")]
         public void should_replace_only_the_title_tokens_in_simple_release_title(string title, string expected)
         {
             var result = Parser.Parser.ParseMovieTitle(title);

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -208,6 +208,11 @@ namespace NzbDrone.Core.Parser
         private static readonly Regex SpecialEpisodeTitleRegex = new Regex(@"(?<episodetitle>.+?)(?:\[.*(?:480p|720p|1080p|2160p|HDTV|WEB|WEBRip|WEB-?DL).*\]|[. ]XXX[. ](?:480p|720p|1080p|2160p|HDTV|WEB|WEBRip|WEB-?DL).*|(?:480p|720p|1080p|2160p|HDTV|WEB|WEBRip|WEB-?DL)|$)",
                           RegexOptions.Compiled);
 
+        // Marks where the release tag block starts, so masking the scene title out of the simple
+        // release title can't reach into the quality, codec and release group behind it.
+        private static readonly Regex ReleaseTagBoundaryRegex = new Regex(@"[-_. ](?:XXX|\d{3,4}[ip]|WEB[-_. ]?DL|WEBRip|WEB|BluRay|BDRip|BRRip|DVDRip|DVD|HDTV|HDRip|SDTV|SD|HEVC|AVC|AV1|VP9|XviD|DivX|[xh][-_. ]?26[45]|AAC|AC3|DTS|MP3|mp4|mkv|avi|wmv|m4v)(?![a-z0-9])",
+                                                                         RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
         private static readonly Regex StashIdRegex = new Regex(@"(?<stashid>.{8}-.{4}-.{4}-.{4}-.{12})", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
         private static readonly Regex SimpleReleaseTitleRegex = new Regex(@"\s*(?:[<>?*|])", RegexOptions.Compiled | RegexOptions.IgnoreCase);
@@ -353,6 +358,18 @@ namespace NzbDrone.Core.Parser
                                     var titleReplacement = simpleTitleReplaceString.Contains('.') ? "A.Movie" : "A Movie";
                                     var releaseTokens = result.ReleaseTokens?.Trim('.', ' ', '-', '_');
 
+                                    // ReleaseTokens is only narrowed at a resolution or web source marker, so for any
+                                    // other tag block (DVDRip, BluRay, SD, a bare codec) it still runs to the end of the
+                                    // release title. Cut it back to where the tags start, or the mask takes them with it.
+                                    var releaseTagBoundary = releaseTokens.IsNotNullOrWhiteSpace()
+                                        ? ReleaseTagBoundaryRegex.Match(releaseTokens)
+                                        : Match.Empty;
+
+                                    if (releaseTagBoundary.Success)
+                                    {
+                                        releaseTokens = releaseTokens.Substring(0, releaseTagBoundary.Index).Trim('.', ' ', '-', '_');
+                                    }
+
                                     // For a scene release the "title" capture runs to the end of the string, so it spans
                                     // the quality block as well as the title, and its offsets count characters in
                                     // simpleTitle, which has had the quality and codec tokens deleted. Replacing on those
@@ -361,7 +378,7 @@ namespace NzbDrone.Core.Parser
                                     // value keeps the quality block intact for custom formats to match against.
                                     if (releaseTokens.IsNotNullOrWhiteSpace() && simpleReleaseTitle.Contains(releaseTokens))
                                     {
-                                        simpleReleaseTitle = simpleReleaseTitle.Replace(releaseTokens, titleReplacement);
+                                        simpleReleaseTitle = simpleReleaseTitle.Replace(releaseTokens, releaseTokens.Contains('.') ? "A.Movie" : "A Movie");
                                     }
                                     else if (match[0].Groups["title"].Success && match[0].Groups["title"].Index < simpleReleaseTitle.Length)
                                     {


### PR DESCRIPTION
#### Database Migration

NO

#### Description

`ParseMovieTitle` masks the scene title out of `SimpleReleaseTitle` by replacing
`result.ReleaseTokens` with `A.Movie`. `ReleaseTokens` is narrowed by
`SpecialEpisodeTitleRegex`, whose marker list is only
`480p|720p|1080p|2160p|HDTV|WEB|WEBRip|WEB-?DL`. When a release carries none of those
literals the trailing `$` alternative makes `ReleaseTokens` run to the end of the
title, so the mask took the entire tag block along with the scene title:

```
Studio.20.01.01.Performer.Some.Title.XXX.DVDRip.x264-GRP  -> Studio.20.01.01.A.Movie
Studio.23.05.12.Performer.Title.HEVC.x265-GROUP           -> Studio.23.05.12.A.Movie
Brazzers.19.11.02.Some.One.Scene.Name.XXX.SD.MP4-KLEENEX  -> Brazzers.19.11.02.A.Movie
Tushy.22.02.02.Performer.Title.XXX.1080p.MP4-WRB          -> ...A.Movie.XXX.1080p.MP4-WRB  (unaffected)
```

`SimpleReleaseTitle` has two consumers: `ReleaseTitleSpecification` and
`AggregateLanguages`. `DownloadDecisionMaker` grades releases off the same string via
`remoteMovie.ParsedMovieInfo`, so this affected custom format scores at grab time, not
only what history and the queue displayed. Language tokens sitting in the tag block
were lost the same way.

The fix cuts the masked value back to the start of the tag block, via a new
`ReleaseTagBoundaryRegex` applied to `ReleaseTokens` before the replacement. The
replacement style (`A.Movie` vs `A Movie`) is now taken from the value actually being
masked, which also fixes a dotted title yielding a spaced `A Movie`.

`SpecialEpisodeTitleRegex` and `result.ReleaseTokens` are deliberately left untouched.
`ReleaseTokens` also feeds `MovieService.FuzzyMatchReleaseTokens` for scene matching,
and widening it there is a separate change with a much larger blast radius. Bounding
only the mask confines this to `SimpleReleaseTitle`.

This is a different defect from the one #327 fixed — that was an offset overrun, and
all of its test cases contain `1080p` or `720p`, so this shape was never covered. Its
expectations still hold byte-for-byte.

#### Screenshot(s) (if UI related)

n/a — parser only.

#### Todos

- [x] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)

Extends the two fixtures added by #327 in `ParseMovieTitleFixture` — rows added, no
assertion removed or relaxed:

- `should_keep_codec_token_in_simple_release_title` — `DVDRip`, `BluRay`, `HEVC`-only
  and bare-codec shapes.
- `should_replace_only_the_title_tokens_in_simple_release_title` — exact outputs for
  the same, plus a case pinning release group survival.

All 7 new cases fail on `eros-develop` and pass with the change. Full `ParserTests`:
1242 passed, 0 failed. Full `NzbDrone.Core.Test` (excluding integration, automation,
manual and DB categories): 3792 passed, 0 failed, 34 skipped.

No new user-facing strings.

#### Issues Fixed or Closed by this PR

<!-- No issue filed; found while investigating whisparr/whisparr#1049, which is a
     separate cause fixed in Whisparr/Whisparr-Eros#372. -->
