### PR TITLE
Chore: Gate SonarQube fork PR analysis behind a maintainer approval

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -10,21 +10,83 @@ on:
   workflow_dispatch:
 
 jobs:
+  # Approval gate for fork PRs.
+  #
+  # SonarQube's .NET scanner needs SONAR_TOKEN at both `begin` and `end`, and C#
+  # analysis needs a real `dotnet build`. A build executes whatever the head
+  # branch says it should: Directory.Build.props/.targets, csproj PreBuild
+  # targets, nuget.config feeds. Under pull_request_target that runs in the base
+  # repo's context, with the base repo's secrets, which is the "pwn request"
+  # shape that actions/checkout now refuses by default (see
+  # https://gh.io/securely-using-pull_request_target).
+  #
+  # There is no way to analyse fork code automatically AND safely: a public
+  # repo never exposes secrets to `pull_request` from a fork, by design. So the
+  # unsafe checkout below is allowed only behind a human. The built-in "require
+  # approval for fork pull requests" setting does NOT cover pull_request_target,
+  # so the gate has to be an Environment with required reviewers.
+  #
+  # This job holds the environment and nothing else - it never checks out head
+  # code, so it is safe to run before approval. Same-repo PRs, pushes and manual
+  # dispatch skip it entirely and analysis proceeds unattended as before.
+  #
+  # REVIEWERS: the payload for a build-time attack lives in the build files, not
+  # in the C# you would normally read. Before approving a fork run, read any
+  # change to *.csproj, Directory.Build.*, nuget.config, global.json, build.sh,
+  # package.json scripts or .github/ line by line.
+  approve-fork-analysis:
+    name: Approve fork analysis
+    if: >-
+      github.repository == 'Whisparr/Whisparr-Eros' &&
+      github.event_name == 'pull_request_target' &&
+      github.event.pull_request.head.repo.full_name != github.repository
+    runs-on: ubuntu-latest
+    # This job only records the approval, so it needs no token scopes at all.
+    permissions: {}
+    # Create this in Settings > Environments with the maintainers as required
+    # reviewers. Without required reviewers configured, the gate is a no-op.
+    environment: sonar-fork-analysis
+    steps:
+      - name: Record approval
+        # Via env, not inline interpolation - never expand webhook-controlled
+        # values straight into a shell.
+        env:
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          echo "Approved analysis of fork code from $HEAD_REPO@$HEAD_SHA"
+
   analyze:
     name: Build and Analyze
+    needs: [approve-fork-analysis]
     # prevent runs outside default repo
-    if: github.repository == 'Whisparr/Whisparr-Eros'
+    # 'skipped' is the same-repo / push / dispatch path, where no gate applies.
+    if: >-
+      !cancelled() &&
+      github.repository == 'Whisparr/Whisparr-Eros' &&
+      (needs.approve-fork-analysis.result == 'success' ||
+       needs.approve-fork-analysis.result == 'skipped')
     runs-on: windows-latest
+    # pull_request_target hands the job a write-scoped GITHUB_TOKEN by default.
+    # Analysis only ever needs to read the tree, so clamp it.
+    permissions:
+      contents: read
     steps:
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
           java-version: 17
           distribution: "zulu"
-      - uses: actions/checkout@v4
+      # v5 is the first major that declares node24 natively; v4 declares node20
+      # and only runs because the runner force-upgrades it. allow-unsafe-pr-checkout
+      # is present in v4 through v7, so the gate below is unaffected by the bump.
+      - uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 0
+          # Gated by approve-fork-analysis above. Do not enable this checkout
+          # anywhere that is not behind that gate.
+          allow-unsafe-pr-checkout: true
       - name: Cache SonarQube Cloud packages
         uses: actions/cache@v4
         with:


### PR DESCRIPTION
#### Database Migration

NO

#### Description

SonarQube analysis has been failing on every fork PR (e.g. #374) since `actions/checkout` started refusing to check out head code from a `pull_request_target` workflow:

> Refusing to check out fork pull request code from a 'pull_request_target' workflow.

Setting `allow-unsafe-pr-checkout: true` on its own would restore a genuine vulnerability rather than a working check. The .NET scanner needs `SONAR_TOKEN` at both `begin` and `end`, and C# analysis needs a real `dotnet build` — which executes whatever the head branch says it should (`Directory.Build.props`/`.targets`, csproj `PreBuild` targets, `nuget.config` feeds) in the base repo's context, with the base repo's secrets and, by default, a write-scoped `GITHUB_TOKEN`. That is the "pwn request" shape `actions/checkout` now blocks by default, and it was live here before the block landed.

A public repo never exposes secrets to `pull_request` from a fork, by design, so there is **no** configuration that analyses fork code both automatically and safely. This puts the unsafe checkout behind a human instead:

- Adds an `approve-fork-analysis` job holding a `sonar-fork-analysis` environment. It checks out nothing and carries `permissions: {}`, so it is safe to run before approval. Only fork PRs trigger it — pushes, same-repo PRs and manual dispatch skip it and analysis proceeds unattended exactly as before.
- Makes `analyze` depend on that gate, proceeding on `success` or `skipped`. `!cancelled()` is required because a skipped `needs` dependency otherwise skips its dependents.
- Clamps `analyze` to `permissions: contents: read`, since `pull_request_target` otherwise grants write.
- Enables `allow-unsafe-pr-checkout` now that it is gated.

The built-in *"Require approval for fork pull requests"* setting does **not** cover `pull_request_target` — that is why the gate has to be an Environment with required reviewers.

Also bumps `actions/checkout` v4 → v5 on the one step whose inputs are changing here. v4 declares `node20` and only runs because the runner force-upgrades it to `node24` (the build logs warn about this); v5 declares `node24` natively. `allow-unsafe-pr-checkout` is present in v4 through v7, verified against each ref's `action.yml`, so the gate is unaffected. This matches the six call sites already on v5 elsewhere in `.github/workflows`.

##### Deliberately not in scope

`setup-java@v4` and `cache@v4` in this same file, and the trailing versions in `api_docs.yml` / `deploy.yml`, are left alone. They are unrelated to the gate, and — more to the point — this workflow **cannot be tested before merge** (see below), so the blast radius is kept to the one step already being edited. The root cause is that `.github/dependabot.yml` has no `github-actions` ecosystem, which is a separate PR.

#### Required repo-settings change

This is inert without it: create a **`sonar-fork-analysis`** environment under Settings → Environments with the maintainers as required reviewers. Until that exists the gate approves instantly and you get the unsafe checkout with no human — strictly worse than today. Admin bypass should be left **off**, since the review is the security control rather than a convenience wait.

#### How to verify (cannot be tested from this PR)

`pull_request_target` always executes the workflow definition from the **base branch**, so this change has no effect until it merges. The SonarQube check on this very PR will fail exactly as it does today; that is expected and not a reason to hold it.

After merge:

1. The `push` to `eros-develop` fires immediately — gate job skips, `Build and Analyze` runs. Smoke-tests the trusted path.
2. Get a **fresh** `pull_request_target` event on a fork PR — #374 is the obvious candidate (open, fork-based, currently red). Note that *re-running* the existing failed run will **not** work: a re-run replays the workflow definition from the original run, so it will still use the pre-gate version. Either wait for the author to push to #374 (fires `synchronize`), or close and reopen it (fires `reopened`).
3. `Approve fork analysis` should then sit in *Waiting* with a **Review deployments** button. Approve, and confirm `Build and Analyze` proceeds and uploads PR analysis.

If step 3 shows the gate *skipped* rather than waiting, the fork detection in the `if:` is wrong.

#### Note for reviewers of future fork PRs

The payload for a build-time attack lives in the build files, not in the C# you would normally read. Before approving a fork run, read any change to `*.csproj`, `Directory.Build.*`, `nuget.config`, `global.json`, `build.sh`, `package.json` scripts or `.github/` line by line. This is also stated in a comment in the workflow.

Sonar will raise hotspot `S7631` ("Make sure that no untrusted code is executed from a fork") on the checkout step once it analyses itself. That is correct and intended — mark it Safe with the gate as justification rather than suppressing it.

#### Screenshot(s) (if UI related)

Not UI related.

#### Todos

- [x] Tests — n/a, CI configuration only. Validated with `actionlint` (clean) and by reading `action.yml` at refs v4–v7 to confirm `allow-unsafe-pr-checkout` survives the bump.
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json) — n/a, no user-facing strings

#### Issues Fixed or Closed by this PR

<!-- No linked issue -->
