### PR TITLE
Chore: Have Dependabot watch the github-actions ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -76,3 +76,24 @@ updates:
     ignore:
       - dependency-name: "SixLabors.ImageSharp"
         update-types: ["version-update:semver-major"]
+  - package-ecosystem: "github-actions"
+    # "/" covers .github/workflows. The composite actions under
+    # .github/actions/*/action.yml pin their own `uses:` versions and drift
+    # independently, so they need their own glob - without it they are invisible
+    # to Dependabot.
+    directories:
+      - "/"
+      - "/.github/actions/*"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"
+    # Same intent as the npm groups above: batch the safe updates, leave majors
+    # ungrouped so each one lands in its own reviewable PR. Action majors have
+    # bitten us before - checkout v7 added the fork-checkout block that broke
+    # SonarQube on every fork PR - so they deserve individual review.
+    groups:
+      actions-minor:
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
#### Database Migration

NO

#### Description

`.github/dependabot.yml` covers `devcontainers`, `npm` and `nuget`, but not `github-actions` — so nothing has been bumping the workflow action pins. They have drifted, and the same action is now pinned at different majors in different files:

| action | pinned as | latest |
| --- | --- | --- |
| `actions/checkout` | v5 ×6, **v4 ×4** | v7 |
| `actions/setup-dotnet` | v5 ×3, **v4 ×1** | v6 |
| `actions/download-artifact` | **v4 ×3, v5 ×2** | v8 |
| `actions/upload-artifact` | v4 ×5 | v7 |
| `actions/cache` | v4 ×2 | v6 |
| `actions/setup-java` | v4 ×1 | v5 |
| `actions/labeler` | v4 ×1 | v7 |

This drift is not cosmetic. `actions/checkout` v7 added the fork-checkout block, which was backported to v4 — that is what broke SonarQube on every fork PR (#375). A pin nobody had touched started failing on its own. Being several majors behind across four workflow files means the next such change lands the same way, discovered the same way: as a red check on someone else's PR.

##### Two directories

`/` covers `.github/workflows`. The composite actions under `.github/actions/*/action.yml` pin their own `uses:` versions and drift independently — they are invisible to Dependabot without their own glob. That is exactly where `download-artifact` ended up pinned at both v4 and v5.

##### Grouping

Follows the convention already documented in this file for npm: minor and patch batch into a single PR, majors match no group and therefore land one per PR where they can be reviewed individually. Given that an action major is what caused #375, that split is the point rather than a nicety.

This changes only what Dependabot *proposes*. Every resulting bump still goes through review and CI.

#### Screenshot(s) (if UI related)

Not UI related.

#### Todos

- [x] Tests — n/a, Dependabot configuration only. YAML validated; schema matches the existing entries.
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json) — n/a, no user-facing strings

#### Issues Fixed or Closed by this PR

<!-- No linked issue -->

Related: #375 (the fork-PR SonarQube gate), which is where this drift surfaced.
