### PR TITLE
Chore: Run CodeQL on fork PRs via advanced setup

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,77 @@
+name: CodeQL
+
+# Replaces code scanning "default setup", which does not analyse fork pull
+# requests at all. GitHub documents the default setup PR trigger as:
+#
+#   "When creating or committing to a pull request based against the
+#    repository's default branch, or any protected branch, excluding pull
+#    requests from forks"
+#
+# So every outside-contributor PR merged so far has had zero CodeQL coverage -
+# no run, no check, silently. Advanced setup is a normal workflow, so it runs on
+# fork PRs the same way build_v3.yml already does, subject to the repository's
+# first-time-contributor approval gate.
+#
+# Default setup must be DISABLED (Settings > Advanced Security > Code scanning)
+# before this lands, or the two configurations fight and PR alert diffing
+# reports "configurations not found".
+#
+# Language and build-mode selection mirrors what default setup was running:
+# actions, csharp and javascript-typescript at the default query suite, with C#
+# in build-mode none. Buildless analysis means fork code is never executed here,
+# which is what makes this safe on pull_request where SonarQube is not.
+
+on:
+  push:
+    branches:
+      - eros-develop
+      - eros
+  pull_request:
+    branches:
+      - eros-develop
+      - eros
+  schedule:
+    # Keeps parity with the weekly scan default setup performed.
+    - cron: "27 4 * * 1"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    # prevent runs outside default repo
+    if: github.repository == 'Whisparr/Whisparr-Eros'
+    runs-on: ubuntu-latest
+    permissions:
+      # Required to upload results to the code scanning API.
+      security-events: write
+      # Required by the CodeQL action to read workflow run metadata.
+      actions: read
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: actions
+            build-mode: none
+          - language: csharp
+            build-mode: none
+          - language: javascript-typescript
+            build-mode: none
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
#### Database Migration

NO

#### Description

**Code scanning has never analysed a fork pull request in this repository.** Not once. It fails silently — no run is created, no check appears, and the only visible trace is the code scanning results check reporting *"3 configurations not found"* because there is no PR analysis to diff against the base branch.

This is documented, by-design behaviour of code scanning **default setup**. Per [About setup types for code scanning](https://docs.github.com/en/code-security/concepts/code-scanning/setup-types), its pull request trigger is:

> "When creating or committing to a pull request based against the repository's default branch, or any protected branch, **excluding pull requests from forks**"

##### Evidence

Every fork PR the repo has had, versus same-repo PRs over the same period:

| PR | author | fork? | CodeQL run |
| --- | --- | --- | --- |
| #338 | Ai-Shihab | **yes** | **none** |
| #374 | h2nkm5vydg-oss | **yes** | **none** |
| #372, #373 | plz12345 | no | ran |
| #375, #376 | plz12345 | no | ran |

Neither fork PR had a run *held for approval* either — checked, there were no `action_required` runs — so this is **not** the `first_time_contributors` approval gate. The runs were never created at all. Note that #374 changed `Parser.cs`, i.e. squarely analysable C#, and still got nothing.

##### Fix

Advanced setup is an ordinary workflow file, so it runs on fork PRs exactly the way `build_v3.yml` already does — still subject to the repository's first-time-contributor approval gate, which is the desired behaviour rather than a problem.

Analysis is **buildless** (`build-mode: none`) for all three languages, so fork code is never executed. That is what makes this safe on `pull_request`, where SonarQube is not — Sonar needs a real `dotnet build` and a token, which is why it needed the approval environment added in #375.

Language selection, build mode and query suite mirror exactly what default setup was already running, so alert volume should not shift: `actions`, `csharp` and `javascript-typescript` at the default suite, C# in `build-mode: none`. The weekly schedule is kept for parity.

#### Required repo-settings change

**Default setup must be disabled at merge time** — Settings → Advanced Security → Code scanning → default setup → Disable. Leaving both enabled makes the two configurations fight and breaks PR alert diffing (it is the same "configurations not found" failure mode, from the other direction). Existing alerts are retained across the switch.

#### Not a bug, for the record

While investigating: CodeQL correctly skips lockfile-only Dependabot PRs (#367, #377) — nothing analysable changed. #354 bumped a dependency the same way *but also touched 13 `.ts`/`.tsx` files*, and was analysed. That is right, and this PR does not change it.

#### How to verify after merge

1. Push to `eros-develop` → three `Analyze (…)` jobs run and upload.
2. Confirm alert counts are in the same ballpark as the last default-setup run on `eros-develop` (117 results / 52 rules for csharp, 0 for javascript-typescript).
3. On the next fork PR — #374 when it gets a push — confirm `Analyze (…)` appears at all, which is the entire point.

#### Screenshot(s) (if UI related)

Not UI related.

#### Todos

- [x] Tests — n/a, CI configuration only. `actionlint` clean.
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json) — n/a, no user-facing strings

#### Issues Fixed or Closed by this PR

<!-- No linked issue -->

Related: #375 (SonarQube fork-PR gate). Together these mean an outside-contributor PR gets static analysis at all — previously it got none from either tool.
