### PR TITLE
Fix: UrlBase dropped by React Query API calls

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -429,7 +429,45 @@ module.exports = [
     },
     rules: {
       ...tsRules,
-      ...prettierConfig.rules
+      ...prettierConfig.rules,
+
+      // API paths must be built with Utilities/Fetch/getQueryPath, which is the
+      // only place that applies the url base. Hardcoding the api root drops it
+      // and breaks every install behind a reverse proxy.
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector: 'Literal[value=/\\/api\\/v\\d/]',
+          message:
+            'Do not hardcode the api root. Build the path with getQueryPath from Utilities/Fetch/getQueryPath.'
+        },
+        {
+          selector: 'TemplateElement[value.raw=/\\/api\\/v\\d/]',
+          message:
+            'Do not hardcode the api root. Build the path with getQueryPath from Utilities/Fetch/getQueryPath.'
+        }
+      ],
+      'no-restricted-imports': [
+        'error',
+        {
+          patterns: [
+            {
+              group: ['**/Utilities/Fetch/fetchJson', 'Utilities/Fetch/fetchJson'],
+              importNames: ['apiRoot', 'urlBase'],
+              message:
+                'fetchJson does not root paths. Use getQueryPath from Utilities/Fetch/getQueryPath instead of assembling one from parts.'
+            }
+          ]
+        }
+      ]
+    }
+  },
+
+  // getQueryPath owns the api root, so the guards above cannot apply to it
+  {
+    files: ['frontend/src/Utilities/Fetch/getQueryPath.ts'],
+    rules: {
+      'no-restricted-syntax': 'off'
     }
   },
 

--- a/frontend/src/Activity/History/useHistory.ts
+++ b/frontend/src/Activity/History/useHistory.ts
@@ -3,10 +3,10 @@ import { queryClient } from 'App/queryClient';
 import { PropertyFilter } from 'Filters/Filter';
 import useApiQuery from 'Helpers/Hooks/useApiQuery';
 import { SortDirection } from 'Helpers/Props/sortDirections';
+import getQueryPath from 'Utilities/Fetch/getQueryPath';
 import History from '../../typings/History';
-import fetchJson, { apiRoot } from '../../Utilities/Fetch/fetchJson';
+import fetchJson from '../../Utilities/Fetch/fetchJson';
 
-const API_ROOT = apiRoot;
 const AUTH_HEADERS = {
   'X-Api-Key': window.Whisparr.apiKey,
   'X-Whisparr-Client': 'Whisparr',
@@ -14,7 +14,7 @@ const AUTH_HEADERS = {
 
 function apiPost<T>(path: string, body: unknown) {
   return fetchJson<T, unknown>({
-    path: `${API_ROOT}${path}`,
+    path: getQueryPath(path),
     method: 'POST',
     headers: AUTH_HEADERS,
     body,

--- a/frontend/src/AddMovie/AddNewMovie/useAddNewMovie.ts
+++ b/frontend/src/AddMovie/AddNewMovie/useAddNewMovie.ts
@@ -17,11 +17,8 @@ import selectSettings from 'Store/Selectors/selectSettings';
 import { InputChanged } from 'typings/inputs';
 import MovieCredit from 'typings/MovieCredit';
 import { ValidationError, ValidationWarning } from 'typings/pending';
-import fetchJson, {
-  ApiError,
-  apiRoot,
-  urlBase,
-} from 'Utilities/Fetch/fetchJson';
+import fetchJson, { ApiError } from 'Utilities/Fetch/fetchJson';
+import getQueryPath from 'Utilities/Fetch/getQueryPath';
 import getNewMovie from 'Utilities/Movie/getNewMovie';
 import parseUrl from 'Utilities/String/parseUrl';
 
@@ -100,7 +97,7 @@ const AUTH_HEADERS = {
 
 function apiPost<T, TBody>(path: string, body: TBody): Promise<T> {
   return fetchJson<T, TBody>({
-    path: `${urlBase}${apiRoot}${path}`,
+    path: getQueryPath(path),
     method: 'POST',
     body,
     headers: AUTH_HEADERS,

--- a/frontend/src/AddMovie/ImportMovie/useImportLookupQueue.ts
+++ b/frontend/src/AddMovie/ImportMovie/useImportLookupQueue.ts
@@ -1,5 +1,6 @@
 import React, { useCallback, useRef, useState } from 'react';
-import fetchJson, { apiRoot, urlBase } from 'Utilities/Fetch/fetchJson';
+import fetchJson from 'Utilities/Fetch/fetchJson';
+import getQueryPath from 'Utilities/Fetch/getQueryPath';
 import { ImportAction, MovieLookupResult } from './ImportMovieTypes';
 
 interface QueueEntry {
@@ -55,7 +56,7 @@ function useImportLookupQueue(
 
     try {
       const results = await fetchJson<MovieLookupResult[], never>({
-        path: `${urlBase}${apiRoot}/movie/lookup?${params.toString()}`,
+        path: getQueryPath(`/movie/lookup?${params.toString()}`),
         method: 'GET',
         headers: {
           'X-Api-Key': globalThis.Whisparr.apiKey,

--- a/frontend/src/Movie/useMovie.ts
+++ b/frontend/src/Movie/useMovie.ts
@@ -1,6 +1,7 @@
 import { useMutation } from '@tanstack/react-query';
 import { queryClient } from 'App/queryClient';
 import useApiQuery from 'Helpers/Hooks/useApiQuery';
+import getQueryPath from 'Utilities/Fetch/getQueryPath';
 import fetchJson, { ApiError } from '../Utilities/Fetch/fetchJson';
 import Movie, { MoviePatchResource } from './Movie';
 
@@ -9,11 +10,10 @@ const AUTH_HEADERS = {
   'X-Api-Key': globalThis.Whisparr.apiKey,
   'X-Whisparr-Client': 'Whisparr',
 };
-const apiRoot = '/api/v3';
 
 function apiPut<T, TBody>(path: string, body: TBody) {
   return fetchJson<T, TBody>({
-    path: `${apiRoot}${path}`,
+    path: getQueryPath(path),
     method: 'PUT',
     body,
     headers: AUTH_HEADERS,
@@ -22,7 +22,7 @@ function apiPut<T, TBody>(path: string, body: TBody) {
 
 function apiPatch<T, TBody>(path: string, body: TBody) {
   return fetchJson<T, TBody>({
-    path: `${apiRoot}${path}`,
+    path: getQueryPath(path),
     method: 'PATCH',
     body,
     headers: AUTH_HEADERS,

--- a/frontend/src/Utilities/Fetch/fetchJson.ts
+++ b/frontend/src/Utilities/Fetch/fetchJson.ts
@@ -32,9 +32,8 @@ export interface FetchJsonOptions<TData> extends Omit<RequestInit, 'body'> {
   timeout?: number;
 }
 
-export const urlBase = window.Whisparr.urlBase;
-export const apiRoot = '/api/v3'; // window.Whisparr.apiRoot;
-
+// `path` is used verbatim — callers must pass an already-rooted path built with
+// `Utilities/Fetch/getQueryPath`.
 async function fetchJson<T, TData>({
   body,
   path,

--- a/frontend/src/Utilities/Fetch/getQueryPath.ts
+++ b/frontend/src/Utilities/Fetch/getQueryPath.ts
@@ -1,7 +1,9 @@
-import { apiRoot, urlBase } from 'Utilities/Fetch/fetchJson';
-
+// The single place an API path is assembled. `window.Whisparr.apiRoot` is
+// injected by the server as `{urlBase}/api/v3`, so it already carries the url
+// base. Never build an API path from parts elsewhere — omitting the url base
+// breaks every install behind a reverse proxy.
 const getQueryPath = (path: string) => {
-  return urlBase + apiRoot + path;
+  return `${window.Whisparr.apiRoot}${path}`;
 };
 
 export default getQueryPath;


### PR DESCRIPTION
#### Database Migration

NO

#### Description

`fetchJson` passes `path` to `fetch()` verbatim — the url base is applied by `getQueryPath`, which only `useApiQuery` / `useApiMutation` called. Any hook calling `fetchJson` directly had to remember the prefix itself, and `fetchJson` exported a **hardcoded** `apiRoot = '/api/v3'` (with the server-injected value commented out) that looks complete but omits the url base.

Three hooks built unprefixed paths, which a reverse proxy never routes to Whisparr:

| Hook | File |
| --- | --- |
| `useSaveMovie` (the reported bug), `useToggleMovieMonitored` | `frontend/src/Movie/useMovie.ts` — local `const apiRoot = '/api/v3'` |
| `useMarkHistoryFailed` | `frontend/src/Activity/History/useHistory.ts` |

`useAddNewMovie` and `useImportLookupQueue` hand-rolled `${urlBase}${apiRoot}` and got it right — correct, but the same trap. The legacy jQuery path was never affected: `createAjaxRequest` uses `window.Whisparr.apiRoot`, which the server already emits as `{urlBase}/api/v3`.

Rather than patching the two call sites and leaving the footgun in place, this makes the prefix impossible to omit:

- `getQueryPath` is now the sole owner of the api root and reads `window.Whisparr.apiRoot` at call time. Reading at call time also removes a latent module-init ordering hazard — `index.ts` overwrites `window.Whisparr` with the `initialize.json` payload before dynamically importing `bootstrap`, so any module-scope capture depended on that import order holding.
- The `apiRoot` / `urlBase` exports are removed from `fetchJson`. Every direct caller now routes through `getQueryPath`.
- Two eslint rules guard the class of bug, since there is no frontend test framework: `no-restricted-syntax` bans hardcoded `/api/vN` literals, and `no-restricted-imports` blocks re-adding the constants. Both were checked against a deliberate violation to confirm they actually fire.

##### Who was affected

Worth noting for triage, because it explains how this got through review:

| Config | Old behaviour |
| --- | --- |
| No UrlBase | `apiRoot` is exactly `/api/v3`, so the buggy code produced the correct URL — genuinely unaffected |
| UrlBase, direct access | Wrong URL, but `UrlBaseMiddleware` 307s to the prefixed path and the browser follows it preserving method and body — worked, at the cost of an extra round trip on every mutation |
| UrlBase behind a proxy | Wrong URL, proxy never routes it — 502, the reported bug |

That middle row means **this cannot be reproduced by connecting directly to the instance**, on localhost or a LAN IP. `UrlBaseMiddleware` only tests whether `Request.PathBase` is empty — there is no host or client-IP condition — and its `Location` is a relative path that resolves against whatever origin was used.

#### Screenshot(s) (if UI related)

<details>

No visual change — request URLs only.

</details>

#### Todos

- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)

No translation keys and no user-facing strings. No tests: the repo has no frontend test framework (no vitest/jest, no `*.test.ts*` under `frontend/`), so the regression guard is the eslint pair described above. Verified manually instead:

- `yarn lint`, `yarn build`, and `tsc --noEmit` pass (only pre-existing `node_modules` type errors).
- No `/api/v3` literal survives anywhere in the built bundle, and the compiled `apiPut` now resolves through `getQueryPath`.
- Ran an `osx-arm64` build with `UrlBase=/whisparr` and confirmed `PUT`/`PATCH /movie/{id}`, `/history` and `/movie/lookup` all return 2xx under the prefix, over both localhost and a LAN IP.
- Re-ran with the base cleared to rule out a double-prefix regression in the default configuration.

#### Issues Fixed or Closed by this PR

- Fixes Whisparr/Whisparr-Eros#843
