### PR TITLE
Fix: Respect StashDB import list limits

### DIFF
--- a/src/NzbDrone.Core.Test/ImportListTests/StashDB/StashDBImportFixture.cs
+++ b/src/NzbDrone.Core.Test/ImportListTests/StashDB/StashDBImportFixture.cs
@@ -22,6 +22,7 @@ namespace NzbDrone.Core.Test.ImportListTests.StashDB
     public class StashDBImportFixture : CoreTest
     {
         private const int PageSize = 100;
+        private const int MaxResultsPerQuery = 1000;
 
         private List<int> _requestedPages;
         private int _reportedCount;
@@ -50,6 +51,8 @@ namespace NzbDrone.Core.Test.ImportListTests.StashDB
         [TestCase(typeof(StashDBPerformerImport), 200, 1000, new[] { 1, 1, 2 })]
         [TestCase(typeof(StashDBStudioImport), 200, 1000, new[] { 1, 1, 2 })]
         [TestCase(typeof(StashDBTagsImport), 200, 1000, new[] { 1, 1, 2 })]
+        [TestCase(typeof(StashDBFavoriteImport), 2000, 1500, new[] { 1, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 })]
+        [TestCase(typeof(StashDBTagsImport), 2000, 50000, new[] { 1, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 })]
         public void should_fetch_only_enough_pages_and_respect_limit(Type importType, int reportedCount, int limit, int[] expectedPages)
         {
             _reportedCount = reportedCount;
@@ -60,7 +63,7 @@ namespace NzbDrone.Core.Test.ImportListTests.StashDB
             import.Definition = definition;
 
             var result = import.Fetch();
-            var expectedCount = Math.Min(reportedCount, limit);
+            var expectedCount = Math.Min(Math.Min(reportedCount, limit), MaxResultsPerQuery);
             var expectedStashIds = Enumerable.Range(1, expectedCount).Select(index => $"scene-{index}");
 
             result.AnyFailure.Should().BeFalse();

--- a/src/NzbDrone.Core.Test/ImportListTests/StashDB/StashDBImportFixture.cs
+++ b/src/NzbDrone.Core.Test/ImportListTests/StashDB/StashDBImportFixture.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Linq;
+using DryIoc;
+using FluentAssertions;
+using Moq;
+using Newtonsoft.Json;
+using NUnit.Framework;
+using NzbDrone.Common.Cloud;
+using NzbDrone.Common.Http;
+using NzbDrone.Core.ImportLists;
+using NzbDrone.Core.ImportLists.StashDB;
+using NzbDrone.Core.ImportLists.StashDB.Favorite;
+using NzbDrone.Core.ImportLists.StashDB.Performer;
+using NzbDrone.Core.ImportLists.StashDB.Studio;
+using NzbDrone.Core.Test.Framework;
+
+namespace NzbDrone.Core.Test.ImportListTests.StashDB
+{
+    [TestFixture]
+    public class StashDBImportFixture : CoreTest
+    {
+        [SetUp]
+        public void Setup()
+        {
+            Mocker.GetMock<IWhisparrCloudRequestBuilder>()
+                .SetupGet(v => v.StashDB)
+                .Returns(new HttpRequestBuilder("https://stashdb.org/graphql").CreateFactory());
+
+            var scenes = Enumerable.Range(1, 100)
+                .Select(index => new Scene
+                {
+                    Id = $"scene-{index}",
+                    Title = $"Scene {index}"
+                })
+                .ToList();
+
+            var response = JsonConvert.SerializeObject(new QueryScenesResult
+            {
+                Data = new QuerySceneData
+                {
+                    QueryScenes = new QueryScene
+                    {
+                        Count = 500,
+                        Scenes = scenes
+                    }
+                }
+            });
+
+            Mocker.GetMock<IHttpClient>()
+                .Setup(v => v.Execute(It.IsAny<HttpRequest>()))
+                .Returns<HttpRequest>(request => new HttpResponse(request, new HttpHeader(), response));
+        }
+
+        [TestCase(typeof(StashDBFavoriteImport), 1, 1)]
+        [TestCase(typeof(StashDBPerformerImport), 1, 1)]
+        [TestCase(typeof(StashDBStudioImport), 1, 1)]
+        [TestCase(typeof(StashDBTagsImport), 1, 1)]
+        [TestCase(typeof(StashDBFavoriteImport), 100, 1)]
+        [TestCase(typeof(StashDBFavoriteImport), 101, 2)]
+        public void should_fetch_only_enough_pages_and_respect_limit(Type importType, int limit, int expectedPageCount)
+        {
+            var import = (IImportList)Mocker.Container.Resolve(importType);
+            var definition = (ImportListDefinition)import.DefaultDefinitions.Single();
+            definition.Settings.GetType().GetProperty(nameof(StashDBFavoriteSettings.ApiKey)).SetValue(definition.Settings, "api-key");
+            definition.Settings.GetType().GetProperty(nameof(StashDBFavoriteSettings.Limit)).SetValue(definition.Settings, limit);
+            import.Definition = definition;
+
+            var result = import.Fetch();
+
+            result.AnyFailure.Should().BeFalse();
+            result.Movies.Should().HaveCount(limit);
+            Mocker.GetMock<IHttpClient>()
+                .Verify(v => v.Execute(It.IsAny<HttpRequest>()), Times.Exactly(expectedPageCount + 1));
+        }
+    }
+}

--- a/src/NzbDrone.Core.Test/ImportListTests/StashDB/StashDBImportFixture.cs
+++ b/src/NzbDrone.Core.Test/ImportListTests/StashDB/StashDBImportFixture.cs
@@ -1,9 +1,11 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using DryIoc;
 using FluentAssertions;
 using Moq;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using NUnit.Framework;
 using NzbDrone.Common.Cloud;
 using NzbDrone.Common.Http;
@@ -19,14 +21,63 @@ namespace NzbDrone.Core.Test.ImportListTests.StashDB
     [TestFixture]
     public class StashDBImportFixture : CoreTest
     {
+        private const int PageSize = 100;
+
+        private List<int> _requestedPages;
+        private int _reportedCount;
+
         [SetUp]
         public void Setup()
         {
+            _requestedPages = new List<int>();
+
             Mocker.GetMock<IWhisparrCloudRequestBuilder>()
                 .SetupGet(v => v.StashDB)
                 .Returns(new HttpRequestBuilder("https://stashdb.org/graphql").CreateFactory());
 
-            var scenes = Enumerable.Range(1, 100)
+            Mocker.GetMock<IHttpClient>()
+                .Setup(v => v.Execute(It.IsAny<HttpRequest>()))
+                .Returns<HttpRequest>(CreateResponse);
+        }
+
+        [TestCase(typeof(StashDBFavoriteImport), 500, 1, new[] { 1, 1 })]
+        [TestCase(typeof(StashDBFavoriteImport), 500, 100, new[] { 1, 1 })]
+        [TestCase(typeof(StashDBFavoriteImport), 500, 101, new[] { 1, 1, 2 })]
+        [TestCase(typeof(StashDBPerformerImport), 500, 101, new[] { 1, 1, 2 })]
+        [TestCase(typeof(StashDBStudioImport), 500, 101, new[] { 1, 1, 2 })]
+        [TestCase(typeof(StashDBTagsImport), 500, 101, new[] { 1, 1, 2 })]
+        [TestCase(typeof(StashDBFavoriteImport), 200, 1000, new[] { 1, 1, 2 })]
+        [TestCase(typeof(StashDBPerformerImport), 200, 1000, new[] { 1, 1, 2 })]
+        [TestCase(typeof(StashDBStudioImport), 200, 1000, new[] { 1, 1, 2 })]
+        [TestCase(typeof(StashDBTagsImport), 200, 1000, new[] { 1, 1, 2 })]
+        public void should_fetch_only_enough_pages_and_respect_limit(Type importType, int reportedCount, int limit, int[] expectedPages)
+        {
+            _reportedCount = reportedCount;
+
+            var import = (IImportList)Mocker.Container.Resolve(importType);
+            var definition = (ImportListDefinition)import.DefaultDefinitions.Single();
+            ConfigureSettings(definition.Settings, limit);
+            import.Definition = definition;
+
+            var result = import.Fetch();
+            var expectedCount = Math.Min(reportedCount, limit);
+            var expectedStashIds = Enumerable.Range(1, expectedCount).Select(index => $"scene-{index}");
+
+            result.AnyFailure.Should().BeFalse();
+            result.Movies.Should().HaveCount(expectedCount);
+            result.Movies.Select(movie => movie.StashId).Should().Equal(expectedStashIds);
+            result.Movies.Select(movie => movie.StashId).Should().OnlyHaveUniqueItems();
+            _requestedPages.Should().Equal(expectedPages);
+        }
+
+        private HttpResponse CreateResponse(HttpRequest request)
+        {
+            var page = GetPage(request);
+            _requestedPages.Add(page);
+
+            var firstScene = ((page - 1) * PageSize) + 1;
+            var sceneCount = Math.Min(PageSize, Math.Max(0, _reportedCount - firstScene + 1));
+            var scenes = Enumerable.Range(firstScene, sceneCount)
                 .Select(index => new Scene
                 {
                     Id = $"scene-{index}",
@@ -40,37 +91,55 @@ namespace NzbDrone.Core.Test.ImportListTests.StashDB
                 {
                     QueryScenes = new QueryScene
                     {
-                        Count = 500,
+                        Count = _reportedCount,
                         Scenes = scenes
                     }
                 }
             });
 
-            Mocker.GetMock<IHttpClient>()
-                .Setup(v => v.Execute(It.IsAny<HttpRequest>()))
-                .Returns<HttpRequest>(request => new HttpResponse(request, new HttpHeader(), response));
+            return new HttpResponse(request, new HttpHeader(), response);
         }
 
-        [TestCase(typeof(StashDBFavoriteImport), 1, 1)]
-        [TestCase(typeof(StashDBPerformerImport), 1, 1)]
-        [TestCase(typeof(StashDBStudioImport), 1, 1)]
-        [TestCase(typeof(StashDBTagsImport), 1, 1)]
-        [TestCase(typeof(StashDBFavoriteImport), 100, 1)]
-        [TestCase(typeof(StashDBFavoriteImport), 101, 2)]
-        public void should_fetch_only_enough_pages_and_respect_limit(Type importType, int limit, int expectedPageCount)
+        private static int GetPage(HttpRequest request)
         {
-            var import = (IImportList)Mocker.Container.Resolve(importType);
-            var definition = (ImportListDefinition)import.DefaultDefinitions.Single();
-            definition.Settings.GetType().GetProperty(nameof(StashDBFavoriteSettings.ApiKey)).SetValue(definition.Settings, "api-key");
-            definition.Settings.GetType().GetProperty(nameof(StashDBFavoriteSettings.Limit)).SetValue(definition.Settings, limit);
-            import.Definition = definition;
+            var variables = request.Url.Query
+                .Split('&')
+                .Select(parameter => parameter.Split(new[] { '=' }, 2))
+                .Where(parts => Uri.UnescapeDataString(parts[0]) == "variables")
+                .Select(parts => Uri.UnescapeDataString(parts[1]))
+                .Single();
 
-            var result = import.Fetch();
+            return JObject.Parse(variables)["input"]["page"].Value<int>();
+        }
 
-            result.AnyFailure.Should().BeFalse();
-            result.Movies.Should().HaveCount(limit);
-            Mocker.GetMock<IHttpClient>()
-                .Verify(v => v.Execute(It.IsAny<HttpRequest>()), Times.Exactly(expectedPageCount + 1));
+        private static void ConfigureSettings(object settings, int limit)
+        {
+            switch (settings)
+            {
+                case StashDBFavoriteSettings favoriteSettings:
+                    SetCommonSettings(favoriteSettings, limit);
+                    break;
+                case StashDBPerformerSettings performerSettings:
+                    SetCommonSettings(performerSettings, limit);
+                    performerSettings.Performers = "performer-id";
+                    break;
+                case StashDBStudioSettings studioSettings:
+                    SetCommonSettings(studioSettings, limit);
+                    studioSettings.Studios = "studio-id";
+                    break;
+                case StashDBTagsSettings tagsSettings:
+                    SetCommonSettings(tagsSettings, limit);
+                    break;
+                default:
+                    throw new ArgumentException($"Unsupported StashDB settings type: {settings.GetType().Name}", nameof(settings));
+            }
+        }
+
+        private static void SetCommonSettings<TSettings>(StashDBSettingsBase<TSettings> settings, int limit)
+            where TSettings : StashDBSettingsBase<TSettings>
+        {
+            settings.ApiKey = "api-key";
+            settings.Limit = limit;
         }
     }
 }

--- a/src/NzbDrone.Core.Test/ImportListTests/StashDB/StashDBSettingsValidatorFixture.cs
+++ b/src/NzbDrone.Core.Test/ImportListTests/StashDB/StashDBSettingsValidatorFixture.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using FluentAssertions;
 using NUnit.Framework;
 using NzbDrone.Core.ImportLists.StashDB.Favorite;
@@ -31,6 +32,24 @@ namespace NzbDrone.Core.Test.ImportListTests.StashDB
 
             settings.Validate().IsValid.Should().BeTrue();
             settings.Validate().Errors.Should().NotContain(c => c.PropertyName == "ApiKey");
+        }
+
+        [TestCase(0, false)]
+        [TestCase(1, true)]
+        [TestCase(1000, true)]
+        [TestCase(1001, false)]
+        public void limit_should_validate_within_supported_range(int limit, bool expectedIsValid)
+        {
+            var settings = new StashDBFavoriteSettings
+            {
+                ApiKey = "valid-api-key",
+                Limit = limit
+            };
+
+            var validationResult = settings.Validate();
+
+            validationResult.IsValid.Should().Be(expectedIsValid);
+            validationResult.Errors.Any(error => error.PropertyName == nameof(settings.Limit)).Should().Be(!expectedIsValid);
         }
     }
 }

--- a/src/NzbDrone.Core.Test/ImportListTests/StashDB/StashDBSettingsValidatorFixture.cs
+++ b/src/NzbDrone.Core.Test/ImportListTests/StashDB/StashDBSettingsValidatorFixture.cs
@@ -34,10 +34,14 @@ namespace NzbDrone.Core.Test.ImportListTests.StashDB
             settings.Validate().Errors.Should().NotContain(c => c.PropertyName == "ApiKey");
         }
 
+        // Limits above the fetch ceiling stay valid and are clamped at fetch time. Rejecting them
+        // here would drop existing definitions out of ImportListFactory.Active() on every sync,
+        // silently disabling lists that already work.
         [TestCase(0, false)]
         [TestCase(1, true)]
         [TestCase(1000, true)]
-        [TestCase(1001, false)]
+        [TestCase(1001, true)]
+        [TestCase(50000, true)]
         public void limit_should_validate_within_supported_range(int limit, bool expectedIsValid)
         {
             var settings = new StashDBFavoriteSettings

--- a/src/NzbDrone.Core/ImportLists/StashDB/Favorite/StashDBFavoriteImport.cs
+++ b/src/NzbDrone.Core/ImportLists/StashDB/Favorite/StashDBFavoriteImport.cs
@@ -26,7 +26,7 @@ namespace NzbDrone.Core.ImportLists.StashDB.Favorite
         public override string Name => "StashDB Favorites";
         public override IImportListRequestGenerator GetRequestGenerator()
         {
-            return new StashDBFavoriteRequestGenerator(PageSize, Settings.Limit)
+            return new StashDBFavoriteRequestGenerator(PageSize, EffectiveLimit)
             {
                 RequestBuilder = _requestBuilder,
                 Settings = Settings,

--- a/src/NzbDrone.Core/ImportLists/StashDB/Favorite/StashDBFavoriteRequestGenerator.cs
+++ b/src/NzbDrone.Core/ImportLists/StashDB/Favorite/StashDBFavoriteRequestGenerator.cs
@@ -60,11 +60,7 @@ namespace NzbDrone.Core.ImportLists.StashDB.Favorite
 
             var jsonResponse = JsonConvert.DeserializeObject<QueryScenesResult>(HttpClient.Execute(requestBuilder.Build()).Content);
 
-            var pagesInResponse = (jsonResponse.Data.QueryScenes.Count / _pageSize) + 1;
-
-            var maxPagesAllowed = StashDBPagingHelper.GetPageCount(_maxResultsPerQuery, _pageSize);
-
-            var pages = Math.Min(pagesInResponse, maxPagesAllowed);
+            var pages = StashDBPagingHelper.GetPageCount(Math.Min(jsonResponse.Data.QueryScenes.Count, _maxResultsPerQuery), _pageSize);
 
             var requests = new List<ImportListRequest>();
 

--- a/src/NzbDrone.Core/ImportLists/StashDB/Favorite/StashDBFavoriteRequestGenerator.cs
+++ b/src/NzbDrone.Core/ImportLists/StashDB/Favorite/StashDBFavoriteRequestGenerator.cs
@@ -62,7 +62,7 @@ namespace NzbDrone.Core.ImportLists.StashDB.Favorite
 
             var pagesInResponse = (jsonResponse.Data.QueryScenes.Count / _pageSize) + 1;
 
-            var maxPagesAllowed = _maxResultsPerQuery / _pageSize;
+            var maxPagesAllowed = StashDBPagingHelper.GetPageCount(_maxResultsPerQuery, _pageSize);
 
             var pages = Math.Min(pagesInResponse, maxPagesAllowed);
 

--- a/src/NzbDrone.Core/ImportLists/StashDB/Performer/StashDBPerformerImport.cs
+++ b/src/NzbDrone.Core/ImportLists/StashDB/Performer/StashDBPerformerImport.cs
@@ -27,7 +27,7 @@ namespace NzbDrone.Core.ImportLists.StashDB.Performer
         public override string Name => "StashDB Performer";
         public override IImportListRequestGenerator GetRequestGenerator()
         {
-            return new StashDBPerformerRequestGenerator(PageSize, Settings.Limit)
+            return new StashDBPerformerRequestGenerator(PageSize, EffectiveLimit)
             {
                 RequestBuilder = _requestBuilder,
                 Settings = Settings,

--- a/src/NzbDrone.Core/ImportLists/StashDB/Performer/StashDBPerformerRequestGenerator.cs
+++ b/src/NzbDrone.Core/ImportLists/StashDB/Performer/StashDBPerformerRequestGenerator.cs
@@ -77,11 +77,7 @@ namespace NzbDrone.Core.ImportLists.StashDB.Performer
 
             var jsonResponse = JsonConvert.DeserializeObject<QueryScenesResult>(HttpClient.Execute(requestBuilder.Build()).Content);
 
-            var pagesInResponse = (jsonResponse.Data.QueryScenes.Count / _pageSize) + 1;
-
-            var maxPagesAllowed = StashDBPagingHelper.GetPageCount(_maxResultsPerQuery, _pageSize);
-
-            var pages = Math.Min(pagesInResponse, maxPagesAllowed);
+            var pages = StashDBPagingHelper.GetPageCount(Math.Min(jsonResponse.Data.QueryScenes.Count, _maxResultsPerQuery), _pageSize);
 
             var requests = new List<ImportListRequest>();
 

--- a/src/NzbDrone.Core/ImportLists/StashDB/Performer/StashDBPerformerRequestGenerator.cs
+++ b/src/NzbDrone.Core/ImportLists/StashDB/Performer/StashDBPerformerRequestGenerator.cs
@@ -79,7 +79,7 @@ namespace NzbDrone.Core.ImportLists.StashDB.Performer
 
             var pagesInResponse = (jsonResponse.Data.QueryScenes.Count / _pageSize) + 1;
 
-            var maxPagesAllowed = _maxResultsPerQuery / _pageSize;
+            var maxPagesAllowed = StashDBPagingHelper.GetPageCount(_maxResultsPerQuery, _pageSize);
 
             var pages = Math.Min(pagesInResponse, maxPagesAllowed);
 

--- a/src/NzbDrone.Core/ImportLists/StashDB/StashDBImportBase.cs
+++ b/src/NzbDrone.Core/ImportLists/StashDB/StashDBImportBase.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using NLog;
 using NzbDrone.Common.Http;
 using NzbDrone.Core.Configuration;
@@ -23,6 +24,15 @@ namespace NzbDrone.Core.ImportLists.StashDB
         public override bool EnableAuto => false;
         public override ImportListType ListType => ImportListType.StashDB;
         public override TimeSpan MinRefreshInterval => TimeSpan.FromHours(1);
+
+        public override ImportListFetchResult Fetch()
+        {
+            var result = base.Fetch();
+
+            result.Movies = result.Movies.Take(Settings.Limit).ToList();
+
+            return result;
+        }
 
         public override IParseImportListResponse GetParser()
         {

--- a/src/NzbDrone.Core/ImportLists/StashDB/StashDBImportBase.cs
+++ b/src/NzbDrone.Core/ImportLists/StashDB/StashDBImportBase.cs
@@ -25,11 +25,17 @@ namespace NzbDrone.Core.ImportLists.StashDB
         public override ImportListType ListType => ImportListType.StashDB;
         public override TimeSpan MinRefreshInterval => TimeSpan.FromHours(1);
 
+        // The fetch loop stops at MaxNumResultsPerQuery regardless of the configured limit,
+        // so clamp here rather than rejecting larger limits in the settings validator. Stored
+        // definitions are revalidated on every sync, so a validation rule would silently drop
+        // existing lists out of ImportListFactory.Active() instead of just capping them.
+        protected int EffectiveLimit => Math.Min(Settings.Limit, MaxNumResultsPerQuery);
+
         public override ImportListFetchResult Fetch()
         {
             var result = base.Fetch();
 
-            result.Movies = result.Movies.Take(Settings.Limit).ToList();
+            result.Movies = result.Movies.Take(EffectiveLimit).ToList();
 
             return result;
         }

--- a/src/NzbDrone.Core/ImportLists/StashDB/StashDBPagingHelper.cs
+++ b/src/NzbDrone.Core/ImportLists/StashDB/StashDBPagingHelper.cs
@@ -1,0 +1,12 @@
+namespace NzbDrone.Core.ImportLists.StashDB
+{
+    internal static class StashDBPagingHelper
+    {
+        public static int GetPageCount(int itemCount, int pageSize)
+        {
+            var pageCount = itemCount / pageSize;
+
+            return itemCount % pageSize == 0 ? pageCount : pageCount + 1;
+        }
+    }
+}

--- a/src/NzbDrone.Core/ImportLists/StashDB/StashDBSettingsBase.cs
+++ b/src/NzbDrone.Core/ImportLists/StashDB/StashDBSettingsBase.cs
@@ -16,7 +16,8 @@ namespace NzbDrone.Core.ImportLists.StashDB
 
             RuleFor(c => c.Limit)
                 .GreaterThan(0)
-                .WithMessage("Must be integer greater than 0");
+                .WithMessage("Must be integer greater than 0")
+                .LessThanOrEqualTo(1000);
         }
     }
 

--- a/src/NzbDrone.Core/ImportLists/StashDB/StashDBSettingsBase.cs
+++ b/src/NzbDrone.Core/ImportLists/StashDB/StashDBSettingsBase.cs
@@ -16,8 +16,7 @@ namespace NzbDrone.Core.ImportLists.StashDB
 
             RuleFor(c => c.Limit)
                 .GreaterThan(0)
-                .WithMessage("Must be integer greater than 0")
-                .LessThanOrEqualTo(1000);
+                .WithMessage("Must be integer greater than 0");
         }
     }
 
@@ -37,7 +36,7 @@ namespace NzbDrone.Core.ImportLists.StashDB
         [FieldDefinition(0, Label = "Api Key", Privacy = PrivacyLevel.ApiKey, HelpText = "Your StashDB Api Key")]
         public string ApiKey { get; set; }
 
-        [FieldDefinition(1, Label = "Limit", HelpText = "Limit the number of movies to get")]
+        [FieldDefinition(1, Label = "Limit", HelpText = "Limit the number of movies to get, values above 1000 are capped at 1000")]
         public int Limit { get; set; }
 
         [FieldDefinition(2, Label = "Sort Date Descending", Type = FieldType.Select, SelectOptions = typeof(SceneSort), HelpText = "Descending sort by date style")]

--- a/src/NzbDrone.Core/ImportLists/StashDB/StashDBSettingsBase.cs
+++ b/src/NzbDrone.Core/ImportLists/StashDB/StashDBSettingsBase.cs
@@ -14,7 +14,6 @@ namespace NzbDrone.Core.ImportLists.StashDB
                 .NotEmpty()
                 .WithMessage("Api Key must not be empty");
 
-            // Limit not smaller than 1 and not larger than 100
             RuleFor(c => c.Limit)
                 .GreaterThan(0)
                 .WithMessage("Must be integer greater than 0");

--- a/src/NzbDrone.Core/ImportLists/StashDB/Studio/StashDBStudioImport.cs
+++ b/src/NzbDrone.Core/ImportLists/StashDB/Studio/StashDBStudioImport.cs
@@ -26,7 +26,7 @@ namespace NzbDrone.Core.ImportLists.StashDB.Studio
         public override string Name => "StashDB Studio";
         public override IImportListRequestGenerator GetRequestGenerator()
         {
-            return new StashDBStudioRequestGenerator(PageSize, Settings.Limit)
+            return new StashDBStudioRequestGenerator(PageSize, EffectiveLimit)
             {
                 RequestBuilder = _requestBuilder,
                 Settings = Settings,

--- a/src/NzbDrone.Core/ImportLists/StashDB/Studio/StashDBStudioRequestGenerator.cs
+++ b/src/NzbDrone.Core/ImportLists/StashDB/Studio/StashDBStudioRequestGenerator.cs
@@ -71,7 +71,7 @@ namespace NzbDrone.Core.ImportLists.StashDB.Studio
 
             var pagesInResponse = (jsonResponse.Data.QueryScenes.Count / _pageSize) + 1;
 
-            var maxPagesAllowed = _maxResultsPerQuery / _pageSize;
+            var maxPagesAllowed = StashDBPagingHelper.GetPageCount(_maxResultsPerQuery, _pageSize);
 
             var pages = Math.Min(pagesInResponse, maxPagesAllowed);
 

--- a/src/NzbDrone.Core/ImportLists/StashDB/Studio/StashDBStudioRequestGenerator.cs
+++ b/src/NzbDrone.Core/ImportLists/StashDB/Studio/StashDBStudioRequestGenerator.cs
@@ -69,11 +69,7 @@ namespace NzbDrone.Core.ImportLists.StashDB.Studio
 
             var jsonResponse = JsonConvert.DeserializeObject<QueryScenesResult>(HttpClient.Execute(requestBuilder.Build()).Content);
 
-            var pagesInResponse = (jsonResponse.Data.QueryScenes.Count / _pageSize) + 1;
-
-            var maxPagesAllowed = StashDBPagingHelper.GetPageCount(_maxResultsPerQuery, _pageSize);
-
-            var pages = Math.Min(pagesInResponse, maxPagesAllowed);
+            var pages = StashDBPagingHelper.GetPageCount(Math.Min(jsonResponse.Data.QueryScenes.Count, _maxResultsPerQuery), _pageSize);
 
             var requests = new List<ImportListRequest>();
 

--- a/src/NzbDrone.Core/ImportLists/StashDB/Tags/StashDBTagsImport.cs
+++ b/src/NzbDrone.Core/ImportLists/StashDB/Tags/StashDBTagsImport.cs
@@ -26,7 +26,7 @@ namespace NzbDrone.Core.ImportLists.StashDB.Studio
         public override string Name => "StashDB Tags";
         public override IImportListRequestGenerator GetRequestGenerator()
         {
-            return new StashDBTagsRequestGenerator(PageSize, Settings.Limit)
+            return new StashDBTagsRequestGenerator(PageSize, EffectiveLimit)
             {
                 RequestBuilder = _requestBuilder,
                 Settings = Settings,

--- a/src/NzbDrone.Core/ImportLists/StashDB/Tags/StashDBTagsRequestGenerator.cs
+++ b/src/NzbDrone.Core/ImportLists/StashDB/Tags/StashDBTagsRequestGenerator.cs
@@ -59,11 +59,7 @@ namespace NzbDrone.Core.ImportLists.StashDB.Studio
 
             var jsonResponse = JsonConvert.DeserializeObject<QueryScenesResult>(HttpClient.Execute(requestBuilder.Build()).Content);
 
-            var pagesInResponse = (jsonResponse.Data.QueryScenes.Count / _pageSize) + 1;
-
-            var maxPagesAllowed = StashDBPagingHelper.GetPageCount(_maxResultsPerQuery, _pageSize);
-
-            var pages = Math.Min(pagesInResponse, maxPagesAllowed);
+            var pages = StashDBPagingHelper.GetPageCount(Math.Min(jsonResponse.Data.QueryScenes.Count, _maxResultsPerQuery), _pageSize);
 
             var requests = new List<ImportListRequest>();
 

--- a/src/NzbDrone.Core/ImportLists/StashDB/Tags/StashDBTagsRequestGenerator.cs
+++ b/src/NzbDrone.Core/ImportLists/StashDB/Tags/StashDBTagsRequestGenerator.cs
@@ -61,7 +61,7 @@ namespace NzbDrone.Core.ImportLists.StashDB.Studio
 
             var pagesInResponse = (jsonResponse.Data.QueryScenes.Count / _pageSize) + 1;
 
-            var maxPagesAllowed = _maxResultsPerQuery / _pageSize;
+            var maxPagesAllowed = StashDBPagingHelper.GetPageCount(_maxResultsPerQuery, _pageSize);
 
             var pages = Math.Min(pagesInResponse, maxPagesAllowed);
 


### PR DESCRIPTION
#### Database Migration

NO

#### Description

StashDB import lists rounded configured limits down to whole 100-item pages. This caused limits below 100 to return no results and other non-page-aligned limits to return fewer results than requested.

I rounded the required page count up for all StashDB import list types, then trim the fetched results to the exact configured limit. Tests cover sub-page, exact-page, and cross-page limits.

#### Screenshot(s) (if UI related)

<details>
<summary>Not applicable — backend-only change</summary>
</details>

#### Todos

- [x] Tests
- [x] Translation Keys (not required; no user-facing strings changed)

#### Issues Fixed or Closed by this PR

None.