### PR TITLE
chore: Align upload/download-artifact across all workflows

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -220,7 +220,7 @@ runs:
         runtime: ${{ inputs.runtime }}
 
     - name: Upload Artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: build-${{ inputs.runtime }}
         path: _artifacts/**/*

--- a/.github/actions/package/action.yml
+++ b/.github/actions/package/action.yml
@@ -25,13 +25,13 @@ runs:
   using: "composite"
   steps:
     - name: Download Artifact
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: ${{ inputs.artifact }}
         path: _output
 
     - name: Download UI Artifact
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: build_ui
         path: _output/UI
@@ -67,7 +67,7 @@ runs:
         build.bat
 
     - name: Upload Artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: release-${{ inputs.runtime }}
         compression-level: 0

--- a/.github/actions/publish-test-artifact/action.yml
+++ b/.github/actions/publish-test-artifact/action.yml
@@ -12,7 +12,7 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       with:
         name: tests-${{ inputs.runtime }}
         path: _tests/${{ inputs.framework }}/${{ inputs.runtime }}/publish/**/*

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -52,14 +52,14 @@ runs:
         echo "Whisparr__Postgres__Password=postgres" >> "$GITHUB_ENV"
 
     - name: Download Tests Artifact
-      uses: actions/download-artifact@v5
+      uses: actions/download-artifact@v8
       with:
         name: ${{ inputs.artifact }}
         path: _tests
 
     - name: Download Binary Artifact
       if: ${{ inputs.integration_tests }}
-      uses: actions/download-artifact@v5
+      uses: actions/download-artifact@v8
       with:
         name: ${{ inputs.binary_artifact }}
         path: _output
@@ -105,7 +105,7 @@ runs:
 
     - name: Upload Test Results
       if: ${{ !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: results-${{ env.RESULTS_NAME }}
         path: TestResults/*.trx

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -92,7 +92,22 @@ updates:
     # ungrouped so each one lands in its own reviewable PR. Action majors have
     # bitten us before - checkout v7 added the fork-checkout block that broke
     # SonarQube on every fork PR - so they deserve individual review.
+    #
+    # First match wins, so coupled families go before the catch-all.
     groups:
+      # upload/download-artifact have to move together: the download side must
+      # be able to read what the upload side wrote, and each directory above is
+      # a separate Dependabot run, so without this group a single bump arrives
+      # as one PR per file - eight of them, half of which collide on the same
+      # file. Majors are included here deliberately, unlike the rule below.
+      artifact-actions:
+        patterns:
+          - "actions/upload-artifact"
+          - "actions/download-artifact"
+        update-types:
+          - "major"
+          - "minor"
+          - "patch"
       actions-minor:
         update-types:
           - "minor"

--- a/.github/workflows/build_v3.yml
+++ b/.github/workflows/build_v3.yml
@@ -155,7 +155,7 @@ jobs:
         run: yarn build --env production
 
       - name: Publish UI Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: build_ui
           path: _output/UI/**/*

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -75,7 +75,7 @@ jobs:
           fetch-tags: true
 
       - name: Download release artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: _artifacts
           pattern: release-*


### PR DESCRIPTION
#### Database Migration

NO

#### Description

Dependabot's `github-actions` config runs each entry in `directories` as a separate update job, so a single artifact-action major arrived as eight PRs — #398, #399, #402, #404, #405, #406, #407, #408. Three of them moved `download-artifact` to a different version than the others, and two pairs collided on the same file (#404/#405 on `package/action.yml`, #407/#408 on `test/action.yml`), so merging them in sequence would have forced a rebase and a full matrix re-run at every step.

This moves every call site at once instead:

| File | Action | From | To |
|---|---|---|---|
| `.github/workflows/deploy.yml:78` | download-artifact | v4 | v8 |
| `.github/actions/package/action.yml:28,34` | download-artifact | v4 | v8 |
| `.github/actions/test/action.yml:55,62` | download-artifact | v5 | v8 |
| `.github/workflows/build_v3.yml:158` | upload-artifact | v4 | v7 |
| `.github/actions/build/action.yml:223` | upload-artifact | v4 | v7 |
| `.github/actions/package/action.yml:70` | upload-artifact | v4 | v7 |
| `.github/actions/publish-test-artifact/action.yml:15` | upload-artifact | v4 | v7 |
| `.github/actions/test/action.yml:108` | upload-artifact | v4 | v7 |

**The two have to move together.** `download-artifact@v8` defaults `digest-mismatch` to `error` (it previously only warned), and it is `upload-artifact@v7` that records the SHA-256 digest being verified against — so v7 + v8 is the matched pair. Bumping only the download side, as #398 did on its own, would have put a v8 consumer in front of v4-produced artifacts on the one code path CI never runs (`deploy / release` is gated on `github.ref_name`, so it is skipped on every PR).

Compatibility checked against the upstream `action.yml` at each new tag rather than the release notes:

- Inputs in use — `name`, `path`, `pattern`, `merge-multiple`, `compression-level`, `if-no-files-found` — all exist unchanged, with unchanged defaults.
- No call site passes `artifact-ids`, so `download-artifact` v5's breaking change to single-artifact path nesting does not apply anywhere.
- `upload-artifact@v7`'s new `archive` input defaults to `true`, so artifacts are still zipped; `download-artifact@v8`'s new Content-Type check therefore still unzips them as before.
- Both actions now run on Node 24 and require Actions Runner >= 2.327.1. Every `runs-on` in this repo is GitHub-hosted, so this is satisfied.

Also adds an `artifact-actions` Dependabot group, ordered before `actions-minor` so it wins the first-match rule, with majors explicitly included. Future bumps of these two should arrive as a single PR across all directories instead of eight.

Supersedes #398, #399, #402, #404, #405, #406, #407, #408.

#### Screenshot(s) (if UI related)

n/a

#### Todos

- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)

Neither applies — this is a CI workflow change with no application code and no user-facing strings. The change is exercised by the existing pipeline: the `build`, `test` and `package` composite actions all run on PRs, so `frontend`, `unit_test`, `integration_test` and `deploy / package` cover the new pins directly.

#### Issues Fixed or Closed by this PR

n/a
