### PR TITLE
chore: Bump actions/checkout to v7 across all workflows

### DIFF
--- a/.github/workflows/api_docs.yml
+++ b/.github/workflows/api_docs.yml
@@ -26,7 +26,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup dotnet
         uses: actions/setup-dotnet@v4

--- a/.github/workflows/build_v3.yml
+++ b/.github/workflows/build_v3.yml
@@ -40,7 +40,7 @@ jobs:
       branch: ${{ steps.variables.outputs.branch }}
     steps:
       - name: Check out
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0 # fetches tags; needed to read the version marker
 
@@ -117,7 +117,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -135,7 +135,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -182,7 +182,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -203,7 +203,7 @@ jobs:
         postgres-version: [16, 17, 18]
     steps:
       - name: Check out
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -242,7 +242,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Test

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -63,7 +63,7 @@ jobs:
             build-mode: none
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,7 +49,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Package
         uses: ./.github/actions/package
@@ -69,7 +69,7 @@ jobs:
       contents: write
     steps:
       - name: Check out
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           fetch-tags: true

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -77,10 +77,12 @@ jobs:
         with:
           java-version: 17
           distribution: "zulu"
-      # v5 is the first major that declares node24 natively; v4 declares node20
-      # and only runs because the runner force-upgrades it. allow-unsafe-pr-checkout
-      # is present in v4 through v7, so the gate below is unaffected by the bump.
-      - uses: actions/checkout@v5
+      # v7 refuses to check out fork PR code under pull_request_target or
+      # workflow_run unless allow-unsafe-pr-checkout is set. It is set below,
+      # behind the approve-fork-analysis gate, so this job is unaffected -- but
+      # that input is load-bearing now, not decorative. Do not remove it while
+      # this workflow keeps its pull_request_target trigger.
+      - uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 0


### PR DESCRIPTION
#### Database Migration

NO

#### Description

Moves all eleven `actions/checkout` call sites to v7. This also clears existing skew — `api_docs.yml` and `deploy.yml` were on v4 while everything else was on v5.

| File | Sites | From |
|---|---|---|
| `.github/workflows/api_docs.yml` | 1 | v4 |
| `.github/workflows/build_v3.yml` | 6 | v5 |
| `.github/workflows/codeql.yml` | 1 | v5 |
| `.github/workflows/deploy.yml` | 2 | v4 |
| `.github/workflows/sonarqube.yml` | 1 | v5 |

No composite action under `.github/actions/` uses `checkout`, so that is every call site in the repo.

**The v7 fork-checkout block.** v7's headline change (actions/checkout#2454) is that it refuses to check out fork PR code under `pull_request_target` or `workflow_run` unless `allow-unsafe-pr-checkout` is set — the same change noted in `dependabot.yml` as having previously broken SonarQube on fork PRs. Checked against the current tree:

- Only `sonarqube.yml` and `labeler.yml` use `pull_request_target`; nothing uses `workflow_run`.
- `labeler.yml` has no checkout step.
- `sonarqube.yml` already passes `allow-unsafe-pr-checkout: true`, behind the `approve-fork-analysis` gate, and the input still exists in `action.yml@v7`.

So the trap is already defused. The rationale comment above that step is rewritten, though: it explained why the pin was *v5*, and it described `allow-unsafe-pr-checkout` as merely "present in v4 through v7" when under v7 it is the thing keeping the job running. That distinction is worth having in the file, and it is the one part of this change Dependabot cannot make.

Everything else uses plain `pull_request` (`build_v3.yml`, `codeql.yml`), `workflow_dispatch` (`api_docs.yml`) or `workflow_call` (`deploy.yml`), none of which are affected.

**Crossing v6** relocates persisted credentials out of `.git/config` into a separate included file. Nothing in this repo reads that file or `extraheader` directly, and no call site sets `persist-credentials: false`, so the signed-tag push in the release job is unaffected. v6.0.2's tag-annotation fix is a small win for that job, which creates annotated signed tags and runs with `fetch-tags: true`.

**v5.0.0** requires Actions Runner >= 2.327.1 (Node 24). Every runner in this repo is GitHub-hosted.

Supersedes #400, which was cut before #420 landed and could not update the `sonarqube.yml` comment.

#### Screenshot(s) (if UI related)

n/a

#### Todos

- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)

Neither applies — CI workflow change, no application code and no user-facing strings. Every workflow touched runs on this PR, so the bump is well covered.

One limit worth stating: this PR is a same-repo branch, so `head.repo == base.repo`, `approve-fork-analysis` skips, and v7's fork-checkout block never engages. A green `Build and Analyze` here proves checkout v7 works under `pull_request_target`; it does **not** prove `allow-unsafe-pr-checkout` still rescues a fork PR. That is only confirmed on the next fork PR — the reasoning above rests on the input still being declared in `action.yml`, which I verified directly.

#### Issues Fixed or Closed by this PR

n/a
