### PR TITLE
chore: Bump actions/setup-dotnet to v6 across all call sites

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -24,7 +24,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup .NET
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@v6
 
     - name: Setup NuGet registry source
       shell: bash

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -29,7 +29,7 @@ runs:
   using: 'composite'
   steps:
     - name: Setup .NET
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@v6
 
     - name: Setup Postgres
       if: ${{ inputs.use_postgres }}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -108,6 +108,20 @@ updates:
           - "major"
           - "minor"
           - "patch"
+      # Same one-PR-per-file problem, different cause: setup-dotnet is pinned in
+      # .github/workflows plus two composite actions, so a single major arrived
+      # as three PRs. Grouping it keeps the "one PR per action major" intent the
+      # comment above describes - the split was never wanted, it just falls out
+      # of `directories`. Only actions pinned in more than one directory need an
+      # entry here; checkout lives solely in .github/workflows and is fine
+      # ungrouped.
+      setup-dotnet:
+        patterns:
+          - "actions/setup-dotnet"
+        update-types:
+          - "major"
+          - "minor"
+          - "patch"
       actions-minor:
         update-types:
           - "minor"

--- a/.github/workflows/api_docs.yml
+++ b/.github/workflows/api_docs.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Setup dotnet
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         id: setup-dotnet
 
       - name: Create openapi.json

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -103,7 +103,7 @@ jobs:
           key: ${{ runner.os }}-sonar-scanner
           restore-keys: ${{ runner.os }}-sonar-scanner
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@v6
         with:
           cache: true
           cache-dependency-path: src/**/*.csproj


### PR DESCRIPTION
#### Database Migration

NO

#### Description

Moves all four `actions/setup-dotnet` pins to v6, clearing the skew where `api_docs.yml` sat on v4 while everything else was on v5.

| File:line | From | Superseded PR |
|---|---|---|
| `.github/workflows/api_docs.yml:32` | v4 | #401 |
| `.github/workflows/sonarqube.yml:106` | v5 | #401 |
| `.github/actions/build/action.yml:27` | v5 | #403 |
| `.github/actions/test/action.yml:32` | v5 | #409 |

**v5.0.0** requires Actions Runner >= 2.327.1 (Node 24); every runner here is GitHub-hosted. Its "remove support for older .NET versions" change only drops long-dead SDKs — `global.json` pins `10.0.101` with `rollForward: latestFeature`.

**v6.0.0** is an ESM migration plus `@actions/cache` 6.2.0, with no interface change. Checked `action.yml@v6` directly: `cache` and `cache-dependency-path` — which `sonarqube.yml` relies on — are unchanged, as are the `cache-hit` and `dotnet-version` outputs. The other three sites pass no inputs at all and simply read `global.json`.

Three of the four sites are exercised by CI on this PR: the `build` and `test` composites run in every backend/unit/integration job, and `sonarqube.yml` runs `Build and Analyze`.

**Dependabot group.** Unlike `artifact-actions` in #420, there is no coupling constraint between setup-dotnet call sites. The group exists purely because the action is pinned across three of the configured `directories`, so a single major arrives as three PRs — which cuts against the config's own stated intent of one reviewable PR per action major. Only actions pinned in more than one directory need an entry; `checkout` lives solely in `.github/workflows` and stays ungrouped, which is why #400 arrived correctly as a single PR.

#### Screenshot(s) (if UI related)

n/a

#### Todos

- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)

Neither applies — CI configuration change, no application code and no user-facing strings.

#### Issues Fixed or Closed by this PR

n/a

---

Note, not addressed here: the `api_docs.yml` call site cannot be verified in this repo. That job is guarded by `if: github.repository == 'Whisparr/Whisparr'`, which is never true in `Whisparr/Whisparr-Eros`, so it has never run here. Flipping the guard would not be enough to make it work — `scripts/docs.sh` does not exist in this repo, and neither `OPENAPI_PAT` nor `DISCORD_WEBHOOK_URL` is configured. Raised separately; the bump on that line is harmless either way and keeps the pins uniform.
