### PR TITLE
Fix: Handle Skyhook Timeout and continue refreshing the remaining performers/studios

### DIFF
--- a/src/NzbDrone.Core.Test/PerformerTests/RefreshPerformerServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/PerformerTests/RefreshPerformerServiceFixture.cs
@@ -9,6 +9,7 @@ using NUnit.Framework;
 
 using NzbDrone.Common.Http;
 
+using NzbDrone.Core.Messaging.Commands;
 using NzbDrone.Core.MetadataSource;
 using NzbDrone.Core.Movies;
 using NzbDrone.Core.Movies.Performers;
@@ -111,6 +112,47 @@ namespace NzbDrone.Core.Test.PerformerTests
                     _timedOutPerformer.Id,
                     _successfulPerformer.Id
                 });
+
+            Assert.DoesNotThrow(() => Subject.Execute(command));
+
+            Mocker.GetMock<IProvideMovieInfo>()
+                .Verify(
+                    s => s.GetPerformerWorks(_successfulPerformer.ForeignId),
+                    Times.Once());
+        }
+
+        // The scheduled refresh takes the other branch of Execute, which walks
+        // every performer rather than a caller-supplied list. One bad performer
+        // there used to abort the whole run.
+        [Test]
+        public void should_continue_the_scheduled_refresh_when_skyhook_returns_an_http_error()
+        {
+            // Let the info refresh succeed here so the test is about the works
+            // call; the shared Setup makes it throw for every performer.
+            Mocker.GetMock<IProvideMovieInfo>()
+                .Setup(s => s.GetPerformerInfo(_timedOutPerformer.ForeignId))
+                .Returns(_timedOutPerformer);
+
+            Mocker.GetMock<IProvideMovieInfo>()
+                .Setup(s => s.GetPerformerInfo(_successfulPerformer.ForeignId))
+                .Returns(_successfulPerformer);
+
+            var request = new HttpRequest("https://api.whisparr.com/v4/performer/timed-out/works");
+            var response = new HttpResponse(request, new HttpHeader(), string.Empty, HttpStatusCode.BadGateway);
+
+            Mocker.GetMock<IProvideMovieInfo>()
+                .Setup(s => s.GetPerformerWorks(_timedOutPerformer.ForeignId))
+                .Throws(new HttpException(request, response));
+
+            Mocker.GetMock<IPerformerService>()
+                .Setup(s => s.AllPerformerIdsByLastInfoSync())
+                .Returns(new List<int> { _timedOutPerformer.Id, _successfulPerformer.Id });
+
+            Mocker.GetMock<IPerformerService>()
+                .Setup(s => s.GetPerformers(It.IsAny<IEnumerable<int>>()))
+                .Returns(new List<Performer> { _timedOutPerformer, _successfulPerformer });
+
+            var command = new RefreshPerformersCommand { Trigger = CommandTrigger.Manual };
 
             Assert.DoesNotThrow(() => Subject.Execute(command));
 

--- a/src/NzbDrone.Core.Test/PerformerTests/RefreshPerformerServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/PerformerTests/RefreshPerformerServiceFixture.cs
@@ -7,6 +7,8 @@ using Moq;
 
 using NUnit.Framework;
 
+using NzbDrone.Common.Http;
+
 using NzbDrone.Core.MetadataSource;
 using NzbDrone.Core.Movies;
 using NzbDrone.Core.Movies.Performers;
@@ -83,6 +85,34 @@ namespace NzbDrone.Core.Test.PerformerTests
                 .Verify(
                     s => s.GetPerformerWorks(_timedOutPerformer.ForeignId),
                     Times.Once());
+
+            Mocker.GetMock<IProvideMovieInfo>()
+                .Verify(
+                    s => s.GetPerformerWorks(_successfulPerformer.ForeignId),
+                    Times.Once());
+        }
+
+        // A timeout is only one of the ways this call fails. GetPerformerWorks
+        // suppresses HTTP errors and throws them itself, so anything that is not
+        // a 404 arrives as HttpException, which SyncPerformerItems does not catch.
+        [Test]
+        public void should_continue_refreshing_performers_when_skyhook_returns_an_http_error()
+        {
+            var request = new HttpRequest("https://api.whisparr.com/v4/performer/timed-out/works");
+            var response = new HttpResponse(request, new HttpHeader(), string.Empty, HttpStatusCode.BadGateway);
+
+            Mocker.GetMock<IProvideMovieInfo>()
+                .Setup(s => s.GetPerformerWorks(_timedOutPerformer.ForeignId))
+                .Throws(new HttpException(request, response));
+
+            var command = new RefreshPerformersCommand(
+                new List<int>
+                {
+                    _timedOutPerformer.Id,
+                    _successfulPerformer.Id
+                });
+
+            Assert.DoesNotThrow(() => Subject.Execute(command));
 
             Mocker.GetMock<IProvideMovieInfo>()
                 .Verify(

--- a/src/NzbDrone.Core.Test/PerformerTests/RefreshPerformerServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/PerformerTests/RefreshPerformerServiceFixture.cs
@@ -1,0 +1,93 @@
+using System.Collections.Generic;
+using System.Net;
+
+using FizzWare.NBuilder;
+
+using Moq;
+
+using NUnit.Framework;
+
+using NzbDrone.Core.MetadataSource;
+using NzbDrone.Core.Movies;
+using NzbDrone.Core.Movies.Performers;
+using NzbDrone.Core.Movies.Performers.Commands;
+using NzbDrone.Core.Test.Framework;
+
+namespace NzbDrone.Core.Test.PerformerTests
+{
+    [TestFixture]
+    public class RefreshPerformerServiceFixture : CoreTest<RefreshPerformerService>
+    {
+        private Performer _timedOutPerformer;
+        private Performer _successfulPerformer;
+
+        [SetUp]
+        public void Setup()
+        {
+            _timedOutPerformer = Builder<Performer>.CreateNew()
+                .With(p => p.Id = 1)
+                .With(p => p.ForeignId = "timed-out")
+                .With(p => p.Name = "Timed Out Performer")
+                .With(p => p.Monitored = true)
+                .Build();
+
+            _successfulPerformer = Builder<Performer>.CreateNew()
+                .With(p => p.Id = 2)
+                .With(p => p.ForeignId = "successful")
+                .With(p => p.Name = "Successful Performer")
+                .With(p => p.Monitored = true)
+                .Build();
+
+            Mocker.GetMock<IPerformerService>()
+                .Setup(s => s.GetById(_timedOutPerformer.Id))
+                .Returns(_timedOutPerformer);
+
+            Mocker.GetMock<IPerformerService>()
+                .Setup(s => s.GetById(_successfulPerformer.Id))
+                .Returns(_successfulPerformer);
+
+            Mocker.GetMock<IMovieService>()
+                .Setup(s => s.GetByPerformerForeignId(It.IsAny<string>()))
+                .Returns(new List<Movie>());
+
+            // We don't want metadata refresh to affect this test.
+            Mocker.GetMock<IProvideMovieInfo>()
+                .Setup(s => s.GetPerformerInfo(It.IsAny<string>()))
+                .Throws(new WebException("Http request timed out", WebExceptionStatus.Timeout));
+
+            Mocker.GetMock<IProvideMovieInfo>()
+                .Setup(s => s.GetPerformerWorks(_timedOutPerformer.ForeignId))
+                .Throws(new WebException("Http request timed out", WebExceptionStatus.Timeout));
+
+            Mocker.GetMock<IProvideMovieInfo>()
+                .Setup(s => s.GetPerformerWorks(_successfulPerformer.ForeignId))
+                .Returns((
+                    new List<string>(),
+                    new List<string>(),
+                    new List<int>()));
+        }
+
+        [Test]
+        public void should_continue_refreshing_performers_when_skyhook_times_out()
+        {
+            var command = new RefreshPerformersCommand(
+                new List<int>
+                {
+                    _timedOutPerformer.Id,
+                    _successfulPerformer.Id
+                });
+
+            Assert.DoesNotThrow(() => Subject.Execute(command));
+
+            Mocker.GetMock<IProvideMovieInfo>()
+                .Verify(
+                    s => s.GetPerformerWorks(_timedOutPerformer.ForeignId),
+                    Times.Once());
+
+            Mocker.GetMock<IProvideMovieInfo>()
+                .Verify(
+                    s => s.GetPerformerWorks(_successfulPerformer.ForeignId),
+                    Times.Once());
+        }
+    }
+}

--- a/src/NzbDrone.Core.Test/StudioTests/RefreshStudioServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/StudioTests/RefreshStudioServiceFixture.cs
@@ -10,6 +10,7 @@ using NUnit.Framework;
 using NzbDrone.Common.Http;
 
 using NzbDrone.Core.ImportLists.ImportExclusions;
+using NzbDrone.Core.Messaging.Commands;
 using NzbDrone.Core.MetadataSource;
 using NzbDrone.Core.Movies;
 using NzbDrone.Core.Movies.Studios;
@@ -123,6 +124,37 @@ namespace NzbDrone.Core.Test.StudioTests
                     _timedOutStudio.Id,
                     _successfulStudio.Id
                 });
+
+            Assert.DoesNotThrow(() => Subject.Execute(command));
+
+            Mocker.GetMock<IProvideMovieInfo>()
+                .Verify(
+                    s => s.GetStudioWorks(_successfulStudio.ForeignId),
+                    Times.Once());
+        }
+
+        // The scheduled refresh takes the other branch of Execute, which walks
+        // every studio rather than a caller-supplied list. One bad studio there
+        // used to abort the whole run.
+        [Test]
+        public void should_continue_the_scheduled_refresh_when_skyhook_returns_an_http_error()
+        {
+            var request = new HttpRequest("https://api.whisparr.com/v4/site/timed-out/works");
+            var response = new HttpResponse(request, new HttpHeader(), string.Empty, HttpStatusCode.BadGateway);
+
+            Mocker.GetMock<IProvideMovieInfo>()
+                .Setup(s => s.GetStudioWorks(_timedOutStudio.ForeignId))
+                .Throws(new HttpException(request, response));
+
+            Mocker.GetMock<IStudioService>()
+                .Setup(s => s.AllStudioIdsByLastInfoSync())
+                .Returns(new List<int> { _timedOutStudio.Id, _successfulStudio.Id });
+
+            Mocker.GetMock<IStudioService>()
+                .Setup(s => s.GetStudios(It.IsAny<IEnumerable<int>>()))
+                .Returns(new List<Studio> { _timedOutStudio, _successfulStudio });
+
+            var command = new RefreshStudiosCommand { Trigger = CommandTrigger.Manual };
 
             Assert.DoesNotThrow(() => Subject.Execute(command));
 

--- a/src/NzbDrone.Core.Test/StudioTests/RefreshStudioServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/StudioTests/RefreshStudioServiceFixture.cs
@@ -7,6 +7,8 @@ using Moq;
 
 using NUnit.Framework;
 
+using NzbDrone.Common.Http;
+
 using NzbDrone.Core.ImportLists.ImportExclusions;
 using NzbDrone.Core.MetadataSource;
 using NzbDrone.Core.Movies;
@@ -95,6 +97,34 @@ namespace NzbDrone.Core.Test.StudioTests
                 .Verify(
                     s => s.GetStudioWorks(_timedOutStudio.ForeignId),
                     Times.Once());
+
+            Mocker.GetMock<IProvideMovieInfo>()
+                .Verify(
+                    s => s.GetStudioWorks(_successfulStudio.ForeignId),
+                    Times.Once());
+        }
+
+        // A timeout is only one of the ways this call fails. GetStudioWorks
+        // suppresses HTTP errors and throws them itself, so anything that is not
+        // a 404 arrives as HttpException, which SyncStudioItems does not catch.
+        [Test]
+        public void should_continue_refreshing_studios_when_skyhook_returns_an_http_error()
+        {
+            var request = new HttpRequest("https://api.whisparr.com/v4/site/timed-out/works");
+            var response = new HttpResponse(request, new HttpHeader(), string.Empty, HttpStatusCode.BadGateway);
+
+            Mocker.GetMock<IProvideMovieInfo>()
+                .Setup(s => s.GetStudioWorks(_timedOutStudio.ForeignId))
+                .Throws(new HttpException(request, response));
+
+            var command = new RefreshStudiosCommand(
+                new List<int>
+                {
+                    _timedOutStudio.Id,
+                    _successfulStudio.Id
+                });
+
+            Assert.DoesNotThrow(() => Subject.Execute(command));
 
             Mocker.GetMock<IProvideMovieInfo>()
                 .Verify(

--- a/src/NzbDrone.Core.Test/StudioTests/RefreshStudioServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/StudioTests/RefreshStudioServiceFixture.cs
@@ -1,0 +1,105 @@
+using System.Collections.Generic;
+using System.Net;
+
+using FizzWare.NBuilder;
+
+using Moq;
+
+using NUnit.Framework;
+
+using NzbDrone.Core.ImportLists.ImportExclusions;
+using NzbDrone.Core.MetadataSource;
+using NzbDrone.Core.Movies;
+using NzbDrone.Core.Movies.Studios;
+using NzbDrone.Core.Movies.Studios.Commands;
+using NzbDrone.Core.Test.Framework;
+
+namespace NzbDrone.Core.Test.StudioTests
+{
+    [TestFixture]
+    public class RefreshStudioServiceFixture : CoreTest<RefreshStudioService>
+    {
+        private Studio _timedOutStudio;
+        private Studio _successfulStudio;
+
+        [SetUp]
+        public void Setup()
+        {
+            _timedOutStudio = Builder<Studio>.CreateNew()
+                .With(s => s.Id = 1)
+                .With(s => s.ForeignId = "timed-out")
+                .With(s => s.Title = "Timed Out Studio")
+                .With(s => s.Monitored = true)
+                .Build();
+
+            _successfulStudio = Builder<Studio>.CreateNew()
+                .With(s => s.Id = 2)
+                .With(s => s.ForeignId = "successful")
+                .With(s => s.Title = "Successful Studio")
+                .With(s => s.Monitored = true)
+                .Build();
+
+            Mocker.GetMock<IStudioService>()
+                .Setup(s => s.GetById(_timedOutStudio.Id))
+                .Returns(_timedOutStudio);
+
+            Mocker.GetMock<IStudioService>()
+                .Setup(s => s.GetById(_successfulStudio.Id))
+                .Returns(_successfulStudio);
+
+            Mocker.GetMock<IMovieService>()
+                .Setup(s => s.GetByStudioForeignId(It.IsAny<string>()))
+                .Returns(new List<Movie>());
+
+            Mocker.GetMock<IMovieService>()
+                .Setup(s => s.AllMovieStashIds())
+                .Returns(new List<string>());
+
+            Mocker.GetMock<IImportListExclusionService>()
+                .Setup(s => s.GetAllExclusions())
+                .Returns(new List<ImportListExclusion>());
+
+            Mocker.GetMock<IProvideMovieInfo>()
+                .Setup(s => s.GetStudioInfo(_timedOutStudio.ForeignId))
+                .Returns(_timedOutStudio);
+
+            Mocker.GetMock<IProvideMovieInfo>()
+                .Setup(s => s.GetStudioInfo(_successfulStudio.ForeignId))
+                .Returns(_successfulStudio);
+
+            Mocker.GetMock<IProvideMovieInfo>()
+                .Setup(s => s.GetStudioWorks(_timedOutStudio.ForeignId))
+                .Throws(new WebException("Skyhook timeout"));
+
+            Mocker.GetMock<IProvideMovieInfo>()
+                .Setup(s => s.GetStudioWorks(_successfulStudio.ForeignId))
+                .Returns((
+                    new List<string>(),
+                    new List<string>(),
+                    new List<int>()));
+        }
+
+        [Test]
+        public void should_continue_refreshing_studios_when_skyhook_times_out()
+        {
+            var command = new RefreshStudiosCommand(
+                new List<int>
+                {
+                    _timedOutStudio.Id,
+                    _successfulStudio.Id
+                });
+
+            Assert.DoesNotThrow(() => Subject.Execute(command));
+
+            Mocker.GetMock<IProvideMovieInfo>()
+                .Verify(
+                    s => s.GetStudioWorks(_timedOutStudio.ForeignId),
+                    Times.Once());
+
+            Mocker.GetMock<IProvideMovieInfo>()
+                .Verify(
+                    s => s.GetStudioWorks(_successfulStudio.ForeignId),
+                    Times.Once());
+        }
+    }
+}

--- a/src/NzbDrone.Core/Movies/Performers/RefreshPerformerService.cs
+++ b/src/NzbDrone.Core/Movies/Performers/RefreshPerformerService.cs
@@ -167,10 +167,10 @@ namespace NzbDrone.Core.Movies.Performers
             catch (WebException ex)
             {
                 _logger.Warn(
-                ex,
-                "Unable to refresh works for performer '{0}' ({1}). Skipping performer.",
-                performer.Name,
-                performer.ForeignId);
+                    ex,
+                    "Unable to refresh works for performer '{0}' ({1}). Skipping performer.",
+                    performer.Name,
+                    performer.ForeignId);
 
                 return;
             }

--- a/src/NzbDrone.Core/Movies/Performers/RefreshPerformerService.cs
+++ b/src/NzbDrone.Core/Movies/Performers/RefreshPerformerService.cs
@@ -382,6 +382,10 @@ namespace NzbDrone.Core.Movies.Performers
                         {
                             _logger.Error(ex, "Performer '{0}' (StashDb {1}) was not found, it may have been removed from The Movie Database.", performer.Name, performer.ForeignId);
                         }
+                        catch (Exception e)
+                        {
+                            _logger.Error(e, "Couldn't refresh info for {0}", performer.Name);
+                        }
                     }
                 }
             }

--- a/src/NzbDrone.Core/Movies/Performers/RefreshPerformerService.cs
+++ b/src/NzbDrone.Core/Movies/Performers/RefreshPerformerService.cs
@@ -162,10 +162,7 @@ namespace NzbDrone.Core.Movies.Performers
 
             try
             {
-                if (performer.Monitored || performer.MoviesMonitored)
-                {
-                    performerWork = _movieInfo.GetPerformerWorks(performer.ForeignId);
-                }
+                performerWork = _movieInfo.GetPerformerWorks(performer.ForeignId);
             }
             catch (WebException ex)
             {

--- a/src/NzbDrone.Core/Movies/Performers/RefreshPerformerService.cs
+++ b/src/NzbDrone.Core/Movies/Performers/RefreshPerformerService.cs
@@ -158,7 +158,7 @@ namespace NzbDrone.Core.Movies.Performers
             // Chunk the into smaller lists
             var chunkSize = 10;
 
-            (List<string> StashdbIds, List<string> TpdbIds, List<int> TmdbIds) performerWork = (new List<string>(), new List<string>(), new List<int>());
+            (List<string> StashdbIds, List<string> TpdbIds, List<int> TmdbIds) performerWork;
 
             try
             {
@@ -350,7 +350,18 @@ namespace NzbDrone.Core.Movies.Performers
                         RescanMovie(movie, isNew, trigger);
                     }
 
-                    SyncPerformerItems(performer);
+                    // SyncPerformerItems swallows the timeout itself, but
+                    // GetPerformerWorks throws HttpException for any other HTTP error
+                    // and MovieNotFoundException on a 404. Without this, either one
+                    // drops every performer the user selected after the one that failed.
+                    try
+                    {
+                        SyncPerformerItems(performer);
+                    }
+                    catch (Exception e)
+                    {
+                        _logger.Error(e, "Couldn't sync items for {0}", performer.Name);
+                    }
                 }
             }
             else

--- a/src/NzbDrone.Core/Movies/Performers/RefreshPerformerService.cs
+++ b/src/NzbDrone.Core/Movies/Performers/RefreshPerformerService.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using DryIoc.ImTools;
 using NLog;
 using NzbDrone.Common.Extensions;
@@ -156,7 +157,26 @@ namespace NzbDrone.Core.Movies.Performers
 
             // Chunk the into smaller lists
             var chunkSize = 10;
-            var performerWork = _movieInfo.GetPerformerWorks(performer.ForeignId);
+
+            (List<string> StashdbIds, List<string> TpdbIds, List<int> TmdbIds) performerWork = (new List<string>(), new List<string>(), new List<int>());
+
+            try
+            {
+                if (performer.Monitored || performer.MoviesMonitored)
+                {
+                    performerWork = _movieInfo.GetPerformerWorks(performer.ForeignId);
+                }
+            }
+            catch (WebException ex)
+            {
+                _logger.Warn(
+                ex,
+                "Unable to refresh works for performer '{0}' ({1}). Skipping performer.",
+                performer.Name,
+                performer.ForeignId);
+
+                return;
+            }
 
             if (performer.Monitored)
             {

--- a/src/NzbDrone.Core/Movies/Studios/RefreshStudioService.cs
+++ b/src/NzbDrone.Core/Movies/Studios/RefreshStudioService.cs
@@ -109,7 +109,7 @@ namespace NzbDrone.Core.Movies.Studios
             // Chunk the into smaller lists
             var chunkSize = 10;
 
-            (List<string> StashdbIds, List<string> TpdbIds, List<int> TmdbIds) studioWork = (new List<string>(), new List<string>(), new List<int>());
+            (List<string> StashdbIds, List<string> TpdbIds, List<int> TmdbIds) studioWork;
 
             try
             {
@@ -306,7 +306,18 @@ namespace NzbDrone.Core.Movies.Studios
                         RescanMovie(movie, isNew, trigger);
                     }
 
-                    SyncStudioItems(studio);
+                    // SyncStudioItems swallows the timeout itself, but GetStudioWorks
+                    // throws HttpException for any other HTTP error and
+                    // MovieNotFoundException on a 404. Without this, either one drops
+                    // every studio the user selected after the one that failed.
+                    try
+                    {
+                        SyncStudioItems(studio);
+                    }
+                    catch (Exception e)
+                    {
+                        _logger.Error(e, "Couldn't sync items for {0}", studio.Title);
+                    }
                 }
             }
             else

--- a/src/NzbDrone.Core/Movies/Studios/RefreshStudioService.cs
+++ b/src/NzbDrone.Core/Movies/Studios/RefreshStudioService.cs
@@ -339,6 +339,10 @@ namespace NzbDrone.Core.Movies.Studios
                         {
                             _logger.Error("Studio '{0}' (StashDb {1}) was not found, it may have been removed from The Movie Database.", studio.Title, studio.ForeignId);
                         }
+                        catch (Exception e)
+                        {
+                            _logger.Error(e, "Couldn't refresh info for {0}", studio.Title);
+                        }
                     }
                 }
             }

--- a/src/NzbDrone.Core/Movies/Studios/RefreshStudioService.cs
+++ b/src/NzbDrone.Core/Movies/Studios/RefreshStudioService.cs
@@ -113,10 +113,7 @@ namespace NzbDrone.Core.Movies.Studios
 
             try
             {
-                if (studio.Monitored || studio.MoviesMonitored)
-                {
-                    studioWork = _movieInfo.GetStudioWorks(studio.ForeignId);
-                }
+                studioWork = _movieInfo.GetStudioWorks(studio.ForeignId);
             }
             catch (WebException ex)
             {

--- a/src/NzbDrone.Core/Movies/Studios/RefreshStudioService.cs
+++ b/src/NzbDrone.Core/Movies/Studios/RefreshStudioService.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using NLog;
 using NzbDrone.Common.Instrumentation.Extensions;
 using NzbDrone.Core.Configuration;
@@ -107,12 +108,29 @@ namespace NzbDrone.Core.Movies.Studios
 
             // Chunk the into smaller lists
             var chunkSize = 10;
-            var studioWork = _movieInfo.GetStudioWorks(studio.ForeignId);
+
+            (List<string> StashdbIds, List<string> TpdbIds, List<int> TmdbIds) studioWork = (new List<string>(), new List<string>(), new List<int>());
+
+            try
+            {
+                if (studio.Monitored || studio.MoviesMonitored)
+                {
+                    studioWork = _movieInfo.GetStudioWorks(studio.ForeignId);
+                }
+            }
+            catch (WebException ex)
+            {
+                _logger.Warn(
+                ex,
+                "Unable to refresh works for studio '{0}' ({1}). Skipping studio.",
+                studio.Title,
+                studio.ForeignId);
+
+                return;
+            }
 
             if (studio.Monitored)
             {
-                // var studioWork = _movieInfo.GetStudioWorks(studio.ForeignId);
-
                 var existingScenes = _movieService.AllMovieStashIds();
                 var excludedScenes = _importListExclusionService.GetAllExclusions().Select(e => e.ForeignId);
                 var scenesToAdd = studioWork.StashdbIds.Where(m => !existingScenes.Contains(m)).Where(m => !excludedScenes.Contains(m));

--- a/src/NzbDrone.Core/Movies/Studios/RefreshStudioService.cs
+++ b/src/NzbDrone.Core/Movies/Studios/RefreshStudioService.cs
@@ -118,10 +118,10 @@ namespace NzbDrone.Core.Movies.Studios
             catch (WebException ex)
             {
                 _logger.Warn(
-                ex,
-                "Unable to refresh works for studio '{0}' ({1}). Skipping studio.",
-                studio.Title,
-                studio.ForeignId);
+                    ex,
+                    "Unable to refresh works for studio '{0}' ({1}). Skipping studio.",
+                    studio.Title,
+                    studio.ForeignId);
 
                 return;
             }


### PR DESCRIPTION

#### Database Migration

NO

#### Description

Skip a studio/performer if skyhook timeout happens, and only get the works if it is going to be used.

Do not return empty StudioWorksResource data. Do not delete anything. Do not change the timeout yet.

This makes a timeout on:

https://api.whisparr.com/v4/site/0f1d8e2c-627e-4d05-a52e-c821b26cab0c/works

mean:

New Sensations → metadata timeout → log → skip
Studio 2        → continue
Studio 3        → continue
Studio 4        → continue
...

#### Screenshot(s) (if UI related)

<details>
<!-- paste screenshots below here.-->

<!-- paste screenshots above here.  MAKE SURE THE ARE SFW -->
</details>

#### Todos

- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)

#### Issues Fixed or Closed by this PR

