### PR TITLE
Fix: Rotate SonarQube cache keys so the scanner actually updates

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -89,19 +89,34 @@ jobs:
           # Gated by approve-fork-analysis above. Do not enable this checkout
           # anywhere that is not behind that gate.
           allow-unsafe-pr-checkout: true
+      # Both caches below rotate weekly. An immutable key is always an exact
+      # hit, and actions/cache skips the save on an exact hit, so a fixed key
+      # means the cache is written once and never again. For the scanner that
+      # is not just stale data: the install step below is gated on cache-hit,
+      # so `dotnet tool update` would run exactly once, ever, freezing
+      # dotnet-sonarscanner at whatever version happened to be current the
+      # first time this job ran. The `-` suffixed restore-keys are prefix
+      # fallbacks, so a new week still starts warm from the previous one and
+      # then re-saves under the new key.
+      - name: Compute weekly cache key
+        id: cache-week
+        shell: bash
+        run: echo "week=$(date -u +'%Y-%V')" >> "$GITHUB_OUTPUT"
       - name: Cache SonarQube Cloud packages
         uses: actions/cache@v6
         with:
           path: ~\sonar\cache
-          key: ${{ runner.os }}-sonar
-          restore-keys: ${{ runner.os }}-sonar
+          # "packages", not a bare "-sonar-" prefix: restore-keys matches on
+          # prefix, and "<os>-sonar-" would also match the scanner cache below.
+          key: ${{ runner.os }}-sonar-packages-${{ steps.cache-week.outputs.week }}
+          restore-keys: ${{ runner.os }}-sonar-packages-
       - name: Cache SonarQube Cloud scanner
         id: cache-sonar-scanner
         uses: actions/cache@v6
         with:
           path: ${{ runner.temp }}\scanner
-          key: ${{ runner.os }}-sonar-scanner
-          restore-keys: ${{ runner.os }}-sonar-scanner
+          key: ${{ runner.os }}-sonar-scanner-${{ steps.cache-week.outputs.week }}
+          restore-keys: ${{ runner.os }}-sonar-scanner-
       - name: Setup .NET
         uses: actions/setup-dotnet@v6
         with:
@@ -111,7 +126,10 @@ jobs:
         if: steps.cache-sonar-scanner.outputs.cache-hit != 'true'
         shell: powershell
         run: |
-          New-Item -Path ${{ runner.temp }}\scanner -ItemType Directory
+          # -Force because this step now also runs on a restore-keys partial
+          # hit, where the directory already exists. `dotnet tool update` is
+          # happy to update a tool-path that already holds an older scanner.
+          New-Item -Path ${{ runner.temp }}\scanner -ItemType Directory -Force
           dotnet tool update dotnet-sonarscanner --tool-path ${{ runner.temp }}\scanner
       - name: Build and analyze
         env:

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -90,14 +90,14 @@ jobs:
           # anywhere that is not behind that gate.
           allow-unsafe-pr-checkout: true
       - name: Cache SonarQube Cloud packages
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~\sonar\cache
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
       - name: Cache SonarQube Cloud scanner
         id: cache-sonar-scanner
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ${{ runner.temp }}\scanner
           key: ${{ runner.os }}-sonar-scanner


### PR DESCRIPTION
#### Database Migration

NO

#### Description

Supersedes #427 — it carries dependabot's `actions/cache` v4 → v6 bump unchanged, plus a fix for two problems in the same block that the bump made worth looking at.

**1. `restore-keys` was a no-op in both cache steps.** It was set to the same string as `key`. `restore-keys` is a *prefix fallback* used when the exact key misses; identical to the key, it can never match anything the key had not already matched.

**2. The Sonar scanner has been frozen at one version.** This is the one with teeth. `key: ${{ runner.os }}-sonar-scanner` never changes, so it is always an exact hit. `actions/cache` skips the save on an exact hit, and *Install SonarQube Cloud scanner* is gated on `cache-hit != 'true'` — so `dotnet tool update dotnet-sonarscanner` has run exactly once, ever. The scanner is pinned to whatever version was current the first time this job ran, and analysis quality quietly ages with it. The same freeze applies to the packages cache, where it costs less but is still wrong.

Both keys now rotate weekly (`date -u +'%Y-%V'`) with a prefix `restore-keys`, so a new week starts warm from the previous week's cache and then re-saves under the new key. On a partial hit `cache-hit` is `'false'`, so the install step runs, `dotnet tool update` refreshes the scanner in place, and the result is saved under the current key.

Two details worth calling out for review:

- **The restore-key prefixes have to be disjoint.** The obvious `${{ runner.os }}-sonar-` for the packages cache would *also* prefix-match `Windows-sonar-scanner-…` and restore the scanner cache into `~\sonar\cache`. The packages key is therefore `<os>-sonar-packages-…`.
- **`New-Item` gained `-Force`.** The install step now also runs on a restore-keys partial hit, where `${{ runner.temp }}\scanner` already exists — `New-Item -ItemType Directory` errors on an existing directory. `dotnet tool update` is happy to update a tool-path that already holds an older scanner.

One-time effect: the first run after merge is a cold cache for both paths, because the key names change.

#### Verification

`sonarqube.yml` triggers on `pull_request_target`, which runs the workflow file from the **base** branch — so no PR can test a change to this file. I confirmed that on #427 by pulling its job log, where the green `Build and Analyze` shows `Download action repository 'actions/cache@v4'` despite the PR bumping it to v6.

So this needs watching on the first `Build and Analyze` run on `eros-develop` after merge:

- the *Install SonarQube Cloud scanner* step **runs** (cold cache, new key names) and succeeds
- `Build and analyze` succeeds
- the `Node.js 20 is deprecated … actions/cache@v4` warning is gone

The following week's run is the one that proves the rotation: the install step should run again off a partial hit rather than being skipped.

Locally verified only that the YAML parses and the step graph is intact, and that `date -u +'%Y-%V'` yields `2026-32`.

#### Screenshot(s) (if UI related)

<details>

n/a — CI workflow only.

</details>

#### Todos

- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)

Neither applies: CI workflow change, no application code and no user-facing strings.

#### Issues Fixed or Closed by this PR

<!-- If multiple, put each on a separate line -->

- Supersedes #427
