### PR TITLE
Fix: Year filtering on scene page referencing Movie column that does not exist

### DIFF
--- a/src/Whisparr.Api.V3/Movies/Helpers/Paging.cs
+++ b/src/Whisparr.Api.V3/Movies/Helpers/Paging.cs
@@ -78,7 +78,7 @@ namespace Whisparr.Api.V3.Movies.Helpers
                         break;
 
                     case "year":
-                        NumericFilterInt.Apply(pageSpec, jsonElement, op, p => p.Year);
+                        NumericFilterInt.Apply(pageSpec, jsonElement, op, p => p.MovieMetadata.Value.Year);
                         break;
                 }
             }


### PR DESCRIPTION
#### Database Migration

NO

#### Description

Fix a network error that happens when filtering on _year_. Seems like we filter on `Movie.Year`, but _Movie_ does not have such a column, so we get an exception about this. This PR changes this to instead use the year property on _MovieMetadata_ (as we already do on other filters like "genres" and "runtime")

#### Screenshot(s) (if UI related)

<details>
<img width="1070" height="411" alt="image" src="https://github.com/user-attachments/assets/b5f9625c-c88a-4076-8af5-c2de2efc3600" />

<img width="980" height="106" alt="image" src="https://github.com/user-attachments/assets/ef716d94-0684-4b81-b0c2-45cd75f8653c" />

```json
{
    "message": "SQL logic error\nno such column: Movies.Year",
    "description": "code = Error (1), message = System.Data.SQLite.SQLiteException (0x87AF001F): SQL logic error\nno such column: Movies.Year\n ...
 }
```
</details>

#### Todos

- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)

#### Issues Fixed or Closed by this PR

