### PR TITLE
Fix: Make the SonarQube quality gate measure something real

### DIFF
--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -24,6 +24,14 @@ inputs:
     description: 'Binary artifact for integration tests'
   binary_path:
     description: 'Path within binary artifact for integration tests'
+  collect_coverage:
+    description: >-
+      Collect OpenCover coverage and publish it as the `coverage-<results name>`
+      artifact, for sonarqube.yml to consume. Enabled on exactly one leg - see
+      build_v3.yml - because Sonar needs one consistent report, not a matrix of
+      them. Coverage is produced HERE, in the untrusted `pull_request` context
+      with no secrets in scope, precisely so that sonarqube.yml never has to run
+      fork test code while holding SONAR_TOKEN.
 
 runs:
   using: 'composite'
@@ -100,8 +108,17 @@ runs:
 
     - name: Run tests
       shell: bash
+      env:
+        COLLECT_COVERAGE: ${{ inputs.collect_coverage }}
       run: |
-        dotnet test ./_tests/Whisparr.*.Test.dll --filter "${{ inputs.filter }}" --logger "trx;LogFileName=${{ env.RESULTS_NAME }}.trx" --logger "GitHubActions;summary.includePassedTests=true;summary.includeSkippedTests=true"
+        # coverlet.collector is already referenced by every test project
+        # (src/Directory.Build.props). Its default output is Cobertura, which
+        # the Sonar .NET scanner cannot read, hence Format=opencover.
+        coverage_args=()
+        if [ "$COLLECT_COVERAGE" = "true" ]; then
+          coverage_args=(--collect:"XPlat Code Coverage;Format=opencover" --results-directory coverage)
+        fi
+        dotnet test ./_tests/Whisparr.*.Test.dll --filter "${{ inputs.filter }}" "${coverage_args[@]}" --logger "trx;LogFileName=${{ env.RESULTS_NAME }}.trx" --logger "GitHubActions;summary.includePassedTests=true;summary.includeSkippedTests=true"
 
     - name: Upload Test Results
       if: ${{ !cancelled() }}
@@ -109,3 +126,14 @@ runs:
       with:
         name: results-${{ env.RESULTS_NAME }}
         path: TestResults/*.trx
+
+    # Consumed by sonarqube.yml. Uploaded even on failure: a red suite still
+    # produces valid coverage for the tests that did run, and Sonar reporting
+    # 0% because of an unrelated test failure is worse than a partial figure.
+    - name: Upload Coverage
+      if: ${{ !cancelled() && inputs.collect_coverage == 'true' }}
+      uses: actions/upload-artifact@v7
+      with:
+        name: coverage-${{ env.RESULTS_NAME }}
+        path: coverage/**/coverage.opencover.xml
+        if-no-files-found: error

--- a/.github/workflows/build_v3.yml
+++ b/.github/workflows/build_v3.yml
@@ -179,6 +179,12 @@ jobs:
             artifact: tests-win-x64
             binary_artifact: build-win-x64
             filter: TestCategory!=ManualTest&TestCategory!=LINUX&TestCategory!=IntegrationTest&TestCategory!=AutomationTest
+            # Sonar wants one coverage report, not three. Windows is the leg
+            # that produces it because sonarqube.yml analyses on windows-latest
+            # too, so the source paths in the report match the ones the scanner
+            # records. Collecting on a different OS than the analysis risks
+            # coverage that imports but maps to nothing.
+            collect_coverage: true
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out
@@ -193,6 +199,7 @@ jobs:
           artifact: ${{ matrix.artifact }}
           pattern: Whisparr.*.Test.dll
           filter: ${{ matrix.filter }}
+          collect_coverage: ${{ matrix.collect_coverage }}
 
   unit_test_postgres:
     needs: backend

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -34,6 +34,13 @@ jobs:
   # in the C# you would normally read. Before approving a fork run, read any
   # change to *.csproj, Directory.Build.*, nuget.config, global.json, build.sh,
   # package.json scripts or .github/ line by line.
+  #
+  # What this gate covers is deliberately kept to `dotnet build` and nothing
+  # else. Coverage is collected in build_v3.yml, which runs under
+  # `pull_request` with no secrets, and crosses over as an XML artifact -- so
+  # fork *test* code never executes here. Keep it that way: do not add test
+  # runs, `yarn install`, or any other fork-controlled execution to the analyze
+  # job. Each one widens what a reviewer is implicitly approving.
   approve-fork-analysis:
     name: Approve fork analysis
     if: >-
@@ -68,9 +75,11 @@ jobs:
        needs.approve-fork-analysis.result == 'skipped')
     runs-on: windows-latest
     # pull_request_target hands the job a write-scoped GITHUB_TOKEN by default.
-    # Analysis only ever needs to read the tree, so clamp it.
+    # Analysis only ever needs to read the tree, plus `actions: read` to pull
+    # build_v3.yml's coverage artifact. Clamp it to that.
     permissions:
       contents: read
+      actions: read
     steps:
       - name: Set up JDK 17
         uses: actions/setup-java@v5
@@ -131,6 +140,13 @@ jobs:
           # happy to update a tool-path that already holds an older scanner.
           New-Item -Path ${{ runner.temp }}\scanner -ItemType Directory -Force
           dotnet tool update dotnet-sonarscanner --tool-path ${{ runner.temp }}\scanner
+
+      # NOTE: do not add an ESLint report import here. It would always be empty
+      # -- build_v3.yml fails the frontend job on any lint finding, so every
+      # commit that reaches analysis is already clean -- and generating it means
+      # `yarn install` running fork-controlled lifecycle scripts in this job,
+      # which holds SONAR_TOKEN. Sonar applies its own JS/TS rules to the ~108k
+      # frontend ncloc regardless; that analysis needs no node toolchain here.
       - name: Build and analyze
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
@@ -143,7 +159,12 @@ jobs:
           $beginArgs = @(
             "/k:Whisparr_Whisparr-Eros",
             "/o:whisparr-eros",
-            "/d:sonar.token=$env:SONAR_TOKEN"
+            "/d:sonar.token=$env:SONAR_TOKEN",
+            # 45 near-identical translation files, ~49.6k ncloc -- 17% of the
+            # project, and a large share of the duplication figure. Excluding
+            # them makes both ncloc and duplicated_lines_density mean something.
+            "/d:sonar.exclusions=src/NzbDrone.Core/Localization/Core/**,**/node_modules/**,_output/**,_temp/**,_tests/**",
+            "/d:sonar.cs.opencover.reportsPaths=coverage/**/coverage.opencover.xml"
           )
           if ($env:EVENT_NAME -eq 'pull_request_target') {
             $beginArgs += "/d:sonar.pullrequest.key=$env:PR_NUMBER"
@@ -152,4 +173,47 @@ jobs:
           }
           & ${{ runner.temp }}\scanner\dotnet-sonarscanner begin @beginArgs
           dotnet build src/Whisparr.sln
+
+      # Coverage is NOT produced here. It comes from build_v3.yml's windows test
+      # leg, which runs under `pull_request` with no secrets in scope -- so fork
+      # test code never executes while this job holds SONAR_TOKEN. What crosses
+      # the boundary is an XML report, i.e. data the scanner parses, not code it
+      # runs. That keeps the approve-fork-analysis gate covering exactly what it
+      # covered before: `dotnet build`, and nothing more.
+      #
+      # The two workflows are independent runs of the same commit with no
+      # ordering guarantee, hence the wait. Missing coverage is not fatal: some
+      # PRs never trigger build_v3.yml at all (it has paths-ignore for
+      # localization and openapi.json), and analysis without coverage still
+      # beats no analysis.
+      - name: Download coverage from build_v3
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          REPO: ${{ github.repository }}
+        shell: bash
+        run: |
+          set -uo pipefail
+          mkdir -p coverage
+          deadline=$(( SECONDS + 1500 ))
+          while (( SECONDS < deadline )); do
+            run_id=$(gh run list --repo "$REPO" --workflow build_v3.yml \
+              --commit "$HEAD_SHA" --limit 1 \
+              --json databaseId,status \
+              --jq '.[] | select(.status=="completed") | .databaseId' || true)
+            if [ -n "$run_id" ] && gh run download "$run_id" --repo "$REPO" \
+                 --pattern 'coverage-*' --dir coverage; then
+              echo "Coverage downloaded from build_v3 run $run_id"
+              find coverage -name 'coverage.opencover.xml'
+              exit 0
+            fi
+            sleep 30
+          done
+          echo "::warning::No coverage artifact for $HEAD_SHA; analysing without it."
+
+      - name: Finish analysis
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        shell: powershell
+        run: |
           ${{ runner.temp }}\scanner\dotnet-sonarscanner end /d:sonar.token="$env:SONAR_TOKEN"


### PR DESCRIPTION
#### Database Migration

NO

#### Description

The SonarQube quality gate has been in `ERROR` on `eros-develop` for a while, failing 4 of 6 conditions. Two of those were configuration problems rather than real debt, and this fixes both.

**Coverage was never uploaded.** `coverlet.collector` is already referenced by every test project, but nothing ever passed `--collect`, so Sonar saw `new_coverage: 0.0` against an 80% threshold. The 80% new-code rule in `CONTRIBUTING.md` could not be enforced even in principle. The test action now collects OpenCover — coverlet's default is Cobertura, which the .NET scanner cannot read — and publishes it as an artifact for `sonarqube.yml` to consume.

**Localization JSON was inflating everything.** `src/NzbDrone.Core/Localization/Core` is 45 near-identical translation files totalling ~49.6k ncloc — 17% of the entire analysed project — and a large share of the duplication that fails the 3% new-code threshold. Now excluded, along with `node_modules`, `_output`, `_temp` and `_tests`.

**Coverage is collected in `build_v3.yml`, not in the analyze job, deliberately.** `build_v3.yml` runs under `pull_request` with no secrets in scope, so fork test code never executes while `SONAR_TOKEN` is held. What crosses the boundary is an XML report — data the scanner parses, not code it runs. This keeps the `approve-fork-analysis` gate covering exactly what it covered before: a `dotnet build`, and nothing more. The header comment in `sonarqube.yml` now says so explicitly, so the next person doesn't reintroduce test runs or a `yarn install` into that job.

It is collected on the **windows** leg specifically, because the analyze job also runs on `windows-latest`. A coverage report whose source paths were recorded on a different OS imports cleanly and then maps to nothing.

#### Notes for review

- **This PR cannot validate itself.** `pull_request_target` runs the *base* branch's copy of the workflow, so the SonarQube check on this PR executes the current `eros-develop` file, not the one in this diff. A green check here proves nothing about these changes. First real exercise is the `push` run on `eros-develop` after merge.
- **`PathMap` is the likeliest follow-up.** `src/Directory.Build.props` sets `<PathMap>$(MSBuildThisFileDirectory)=./</PathMap>`, which rewrites source paths in the PDBs, and coverage inherits that. If Sonar still reports 0% after merge — with no error — that is where to look. Budget one follow-up commit.
- The analyze job waits up to 25 minutes for `build_v3.yml`'s test leg, since the two are independent runs of the same commit with no ordering guarantee. Missing coverage warns rather than fails: `build_v3.yml` has `paths-ignore` for localization and `openapi.json`, so some PRs legitimately never produce it.
- An ESLint report import was considered and deliberately left out — `build_v3.yml` already fails the frontend job on any lint finding, so the report would always be empty, and generating it would mean `yarn install` running fork-controlled lifecycle scripts in the token-bearing job. There is a comment recording this.

#### Not addressed here

The remaining gate failures are debt, not config, and need a human:

- 237 security hotspots at 14.4% reviewed — **all 237 are `csharpsquid:S6444`** (regex without a match timeout). Given how regex-heavy the Parser is, worth treating as a real finding rather than a bulk dismissal.
- `new_reliability_rating` and `new_security_rating` are both C.

#### Todos

- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)

#### Issues Fixed or Closed by this PR

<!-- none -->
