### PR TITLE
Fix: Coverage reports from #439 were empty, and unmappable once populated

### DIFF
--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -114,9 +114,25 @@ runs:
         # coverlet.collector is already referenced by every test project
         # (src/Directory.Build.props). Its default output is Cobertura, which
         # the Sonar .NET scanner cannot read, hence Format=opencover.
+        #
+        # ExcludeAssembliesWithoutSources=None is load-bearing. By default
+        # coverlet skips any assembly whose PDB has no locally-resolvable source
+        # document, and src/Directory.Build.props sets
+        # <PathMap>$(MSBuildThisFileDirectory)=./</PathMap>, which rewrites every
+        # document to "./NzbDrone.Core/..." - a path that resolves nowhere,
+        # because the real file lives under src/. The only documents left with
+        # absolute paths are three generated AssemblyInfo files under _temp/obj,
+        # and those point at the machine that BUILT the assemblies. Tests here
+        # run on a different runner against a downloaded artifact, so they do not
+        # exist either, every module gets skipped, and coverlet emits a 363-byte
+        # report containing <Modules />. That is what shipped in #439.
+        #
+        # Include=[Whisparr.*]* then narrows instrumentation back to our own
+        # assemblies; without it, disabling the source check pulls in Dapper,
+        # MonoTorrent and friends and nearly doubles the report for no gain.
         coverage_args=()
         if [ "$COLLECT_COVERAGE" = "true" ]; then
-          coverage_args=(--collect:"XPlat Code Coverage;Format=opencover" --results-directory coverage)
+          coverage_args=(--collect:"XPlat Code Coverage;Format=opencover;ExcludeAssembliesWithoutSources=None;Include=[Whisparr.*]*" --results-directory coverage)
         fi
         dotnet test ./_tests/Whisparr.*.Test.dll --filter "${{ inputs.filter }}" "${coverage_args[@]}" --logger "trx;LogFileName=${{ env.RESULTS_NAME }}.trx" --logger "GitHubActions;summary.includePassedTests=true;summary.includeSkippedTests=true"
 

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -211,6 +211,38 @@ jobs:
           done
           echo "::warning::No coverage artifact for $HEAD_SHA; analysing without it."
 
+      # Instrumenting is only half the job -- the report also has to name files
+      # the scanner can find. <PathMap> makes coverlet record every document as
+      # "./NzbDrone.Core/Foo.cs", but sonar.projectBaseDir is the repo root, so
+      # the scanner looks for "<root>/NzbDrone.Core/Foo.cs" and the real file is
+      # at "<root>/src/NzbDrone.Core/Foo.cs". Nothing matches, and the import
+      # silently contributes zero without logging a single warning.
+      #
+      # Re-rooting the paths at $GITHUB_WORKSPACE/src fixes that. Do NOT solve
+      # it by setting sonar.projectBaseDir=src instead: that would drop the
+      # ~108k ncloc of frontend/ out of the analysis entirely.
+      - name: Re-root coverage source paths
+        shell: bash
+        run: |
+          set -uo pipefail
+          # Git Bash reports GITHUB_WORKSPACE as D:\a\...; forward slashes are
+          # accepted everywhere and keep the sed replacement free of escapes.
+          ws="${GITHUB_WORKSPACE//\\//}"
+          count=0
+          while IFS= read -r f; do
+            # Explicit temp file rather than `sed -i`: BSD sed requires an
+            # argument to -i and GNU sed does not, and this step is the sort of
+            # thing that gets copied to a macOS runner later.
+            sed "s|fullPath=\"\./|fullPath=\"${ws}/src/|g" "$f" > "$f.tmp" \
+              && mv "$f.tmp" "$f"
+            count=$((count + 1))
+          done < <(find coverage -name 'coverage.opencover.xml' 2>/dev/null)
+          if [ "$count" -eq 0 ]; then
+            echo "No coverage reports to re-root."
+          else
+            echo "Re-rooted $count report(s) at ${ws}/src"
+          fi
+
       - name: Finish analysis
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
#### Database Migration

NO

#### Description

Follow-up to #439, which wired coverage through to Sonar but left `new_coverage` at `0.0`. The reports were not mis-parsed — they were **empty at source**: eleven 363-byte files containing `<Modules />` and nothing else.

**Why they were empty.** coverlet skips any assembly whose PDB has no locally-resolvable source document. `src/Directory.Build.props` sets `<PathMap>$(MSBuildThisFileDirectory)=./</PathMap>`, rewriting every document to `./NzbDrone.Core/Foo.cs` — a path that resolves nowhere, because the real file is under `src/`. That leaves only three documents per PDB with absolute paths, all generated `AssemblyInfo` files under `_temp/obj`, and those name the machine that *built* the assemblies. `build_v3.yml` builds on one runner and tests on another against a downloaded artifact, so at test time they don't exist, every module is skipped, and the report is empty.

coverlet says so explicitly, once you ask it for diagnostics:

```
Excluding module from instrumentation: …/Whisparr.Core.dll, pdb without any local source files
```

This works on a developer machine purely by accident — there the three generated files *do* exist, and coverlet needs only one document to resolve before instrumenting a module. `dotnet test` locally produces a 28MB report; the identical artifact from CI produces 363 bytes.

**Fix, part 1 — make coverlet instrument.** `ExcludeAssembliesWithoutSources=None` disables the source check. `Include=[Whisparr.*]*` then keeps instrumentation to our own assemblies; without it Dapper, MonoTorrent and friends come along and nearly double the report for no gain.

Verified against the real `tests-osx-arm64` artifact from run `31842390000`:

| | report size | sequence points |
|---|---|---|
| as merged in #439 | 363 B | 0 |
| `ExcludeAssembliesWithoutSources=None` | 49 MB | 124,400 |
| + `Include=[Whisparr.*]*` | 27.8 MB | 77,257 |

**Fix, part 2 — make the paths mappable.** Populating the report is only half of it. The paths inside are still `./NzbDrone.Core/Foo.cs` while `sonar.projectBaseDir` is the repo root, so the scanner resolves them to `<root>/NzbDrone.Core/Foo.cs`, finds nothing, and imports zero coverage **without logging a warning**. The new step re-roots them at `$GITHUB_WORKSPACE/src`:

| | resolvable |
|---|---|
| before re-rooting | 0 / 2129 |
| after re-rooting | 2116 / 2129 |
| `NzbDrone.Core` files only | **1275 / 1275** |

Setting `sonar.projectBaseDir=src` would also fix the paths, but at the cost of dropping the ~108k ncloc of `frontend/` out of the analysis. There's a comment in the workflow saying so, so nobody "simplifies" it later.

#### Notes for review

- **Same self-validation problem as #439.** `pull_request_target` runs the base branch's workflow file, so this PR's own SonarQube check exercises the *current* `eros-develop`, not this diff. The first honest signal is the post-merge `push` run.
- What is proven here is that the report is populated and its paths point at real files inside the analysis scope. Whether SonarCloud then reports a non-zero percentage can only be confirmed by that post-merge run.
- The re-root step uses an explicit temp file rather than `sed -i`, because BSD sed requires an argument to `-i` and GNU sed does not.

#### Todos

- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)

#### Issues Fixed or Closed by this PR

<!-- none -->
