### PR TITLE
Fix: Pass a match timeout to every regex

### DIFF
--- a/src/NzbDrone.Common/Disk/OsPath.cs
+++ b/src/NzbDrone.Common/Disk/OsPath.cs
@@ -10,7 +10,7 @@ namespace NzbDrone.Common.Disk
         private readonly string _path;
         private readonly OsPathKind _kind;
 
-        private static readonly Regex UncPathRegex = new Regex(@"(?<unc>^\\\\(?:\?\\UNC\\)?[^\\]+\\[^\\]+)(?:\\|$)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private static readonly Regex UncPathRegex = new Regex(@"(?<unc>^\\\\(?:\?\\UNC\\)?[^\\]+\\[^\\]+)(?:\\|$)", RegexOptions.Compiled | RegexOptions.IgnoreCase, RegexDefaults.Timeout);
 
         public OsPath(string path)
         {

--- a/src/NzbDrone.Common/EnsureThat/EnsureStringExtensions.cs
+++ b/src/NzbDrone.Common/EnsureThat/EnsureStringExtensions.cs
@@ -76,7 +76,7 @@ namespace NzbDrone.Common.EnsureThat
         [DebuggerStepThrough]
         public static Param<string> Matches(this Param<string> param, string match)
         {
-            return Matches(param, new Regex(match));
+            return Matches(param, new Regex(match, RegexOptions.None, RegexDefaults.Timeout));
         }
 
         [DebuggerStepThrough]

--- a/src/NzbDrone.Common/Extensions/PathExtensions.cs
+++ b/src/NzbDrone.Common/Extensions/PathExtensions.cs
@@ -138,7 +138,7 @@ namespace NzbDrone.Common.Extensions
             return false;
         }
 
-        private static readonly Regex WindowsPathWithDriveRegex = new Regex(@"^[a-zA-Z]:\\", RegexOptions.Compiled);
+        private static readonly Regex WindowsPathWithDriveRegex = new Regex(@"^[a-zA-Z]:\\", RegexOptions.Compiled, RegexDefaults.Timeout);
 
         public static bool IsPathValid(this string path, PathValidationType validationType)
         {

--- a/src/NzbDrone.Common/Extensions/StringExtensions.cs
+++ b/src/NzbDrone.Common/Extensions/StringExtensions.cs
@@ -11,7 +11,7 @@ namespace NzbDrone.Common.Extensions
 {
     public static class StringExtensions
     {
-        private static readonly Regex CamelCaseRegex = new Regex("(?<!^)[A-Z]", RegexOptions.Compiled);
+        private static readonly Regex CamelCaseRegex = new Regex("(?<!^)[A-Z]", RegexOptions.Compiled, RegexDefaults.Timeout);
 
         public static string NullSafe(this string target)
         {
@@ -53,7 +53,7 @@ namespace NzbDrone.Common.Extensions
             return string.Format(format, formattingArgs);
         }
 
-        private static readonly Regex CollapseSpace = new Regex(@"\s+", RegexOptions.Compiled);
+        private static readonly Regex CollapseSpace = new Regex(@"\s+", RegexOptions.Compiled, RegexDefaults.Timeout);
 
         public static string Replace(this string text, int index, int length, string replacement)
         {

--- a/src/NzbDrone.Common/Http/HttpUri.cs
+++ b/src/NzbDrone.Common/Http/HttpUri.cs
@@ -8,7 +8,7 @@ namespace NzbDrone.Common.Http
 {
     public class HttpUri : IEquatable<HttpUri>
     {
-        private static readonly Regex RegexUri = new Regex(@"^(?:(?<scheme>[a-z]+):)?(?://(?<host>[-_A-Z0-9.]+|\[[[A-F0-9:]+\])(?::(?<port>[0-9]{1,5}))?)?(?<path>(?:(?:(?<=^)|/+)[^/?#\r\n]+)+/*|/+)?(?:\?(?<query>[^#\r\n]*))?(?:\#(?<fragment>.*))?$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private static readonly Regex RegexUri = new Regex(@"^(?:(?<scheme>[a-z]+):)?(?://(?<host>[-_A-Z0-9.]+|\[[[A-F0-9:]+\])(?::(?<port>[0-9]{1,5}))?)?(?<path>(?:(?:(?<=^)|/+)[^/?#\r\n]+)+/*|/+)?(?:\?(?<query>[^#\r\n]*))?(?:\#(?<fragment>.*))?$", RegexOptions.Compiled | RegexOptions.IgnoreCase, RegexDefaults.Timeout);
 
         private readonly string _uri;
         public string FullUri => _uri;

--- a/src/NzbDrone.Common/RegexDefaults.cs
+++ b/src/NzbDrone.Common/RegexDefaults.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace NzbDrone.Common
+{
+    public static class RegexDefaults
+    {
+        // Circuit breaker against catastrophic backtracking, passed as the matchTimeout argument to
+        // every Regex in the codebase. Legitimate input matches in microseconds, so this only fires on
+        // a pathological pattern/input pair; it is deliberately generous so a loaded or CPU-throttled
+        // host can't trip it on a release title that would otherwise parse.
+        //
+        // Note for callers: static readonly fields initialise in textual order, so a regex field that
+        // is initialised inline must be declared after any local copy of this value.
+        public static readonly TimeSpan Timeout = TimeSpan.FromSeconds(5);
+    }
+}

--- a/src/NzbDrone.Core.Test/HealthCheck/Checks/MountCheckFixture.cs
+++ b/src/NzbDrone.Core.Test/HealthCheck/Checks/MountCheckFixture.cs
@@ -4,6 +4,7 @@ using System.Text.RegularExpressions;
 using FluentAssertions;
 using Moq;
 using NUnit.Framework;
+using NzbDrone.Common;
 using NzbDrone.Common.Disk;
 using NzbDrone.Core.HealthCheck.Checks;
 using NzbDrone.Core.Localization;
@@ -129,7 +130,7 @@ namespace NzbDrone.Core.Test.HealthCheck.Checks
             var result = Subject.Check();
 
             result.ShouldBeError();
-            Regex.Matches(result.Message, "ReadOnlyMount").Count.Should().Be(1);
+            Regex.Matches(result.Message, "ReadOnlyMount", RegexOptions.None, RegexDefaults.Timeout).Count.Should().Be(1);
         }
 
         [Test]

--- a/src/NzbDrone.Core/Backup/BackupService.cs
+++ b/src/NzbDrone.Core/Backup/BackupService.cs
@@ -39,7 +39,7 @@ namespace NzbDrone.Core.Backup
 
         private string _backupTempFolder;
 
-        public static readonly Regex BackupFileRegex = new Regex(@"(nzbdrone|whisparr)_backup_v?[._0-9]+\.zip", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        public static readonly Regex BackupFileRegex = new Regex(@"(nzbdrone|whisparr)_backup_v?[._0-9]+\.zip", RegexOptions.Compiled | RegexOptions.IgnoreCase, RegexDefaults.Timeout);
 
         public BackupService(IMainDatabase maindDb,
                              IMakeDatabaseBackup makeDatabaseBackup,

--- a/src/NzbDrone.Core/Configuration/ConfigFileProvider.cs
+++ b/src/NzbDrone.Core/Configuration/ConfigFileProvider.cs
@@ -6,6 +6,7 @@ using System.Text.RegularExpressions;
 using System.Xml;
 using System.Xml.Linq;
 using Microsoft.Extensions.Options;
+using NzbDrone.Common;
 using NzbDrone.Common.Cache;
 using NzbDrone.Common.Disk;
 using NzbDrone.Common.EnvironmentInfo;
@@ -86,7 +87,7 @@ namespace NzbDrone.Core.Configuration
         private readonly LogOptions _logOptions;
 
         private readonly string _configFile;
-        private static readonly Regex HiddenCharacterRegex = new Regex("[^a-z0-9]", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private static readonly Regex HiddenCharacterRegex = new Regex("[^a-z0-9]", RegexOptions.Compiled | RegexOptions.IgnoreCase, RegexDefaults.Timeout);
 
         private static readonly object Mutex = new object();
 

--- a/src/NzbDrone.Core/Configuration/DeploymentInfoProvider.cs
+++ b/src/NzbDrone.Core/Configuration/DeploymentInfoProvider.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Text.RegularExpressions;
+using NzbDrone.Common;
 using NzbDrone.Common.Disk;
 using NzbDrone.Common.EnvironmentInfo;
 using NzbDrone.Common.Extensions;
@@ -73,7 +74,7 @@ namespace NzbDrone.Core.Configuration
 
         private static string ReadValue(string fileData, string key, string defaultValue = null)
         {
-            var match = Regex.Match(fileData, "^" + key + "=(.*)$", RegexOptions.Multiline);
+            var match = Regex.Match(fileData, "^" + key + "=(.*)$", RegexOptions.Multiline, RegexDefaults.Timeout);
             if (match.Success)
             {
                 return match.Groups[1].Value.Trim();

--- a/src/NzbDrone.Core/CustomFormats/Specifications/RegexSpecificationBase.cs
+++ b/src/NzbDrone.Core/CustomFormats/Specifications/RegexSpecificationBase.cs
@@ -1,5 +1,6 @@
 using System.Text.RegularExpressions;
 using FluentValidation;
+using NzbDrone.Common;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Annotations;
 using NzbDrone.Core.Validation;
@@ -31,7 +32,7 @@ namespace NzbDrone.Core.CustomFormats
 
                 if (value.IsNotNullOrWhiteSpace())
                 {
-                    _regex = new Regex(value, RegexOptions.Compiled | RegexOptions.IgnoreCase);
+                    _regex = new Regex(value, RegexOptions.Compiled | RegexOptions.IgnoreCase, RegexDefaults.Timeout);
                 }
             }
         }

--- a/src/NzbDrone.Core/Datastore/Migration/000_database_engine_version_check.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/000_database_engine_version_check.cs
@@ -2,6 +2,7 @@ using System.Data;
 using System.Text.RegularExpressions;
 using FluentMigrator;
 using NLog;
+using NzbDrone.Common;
 using NzbDrone.Common.Instrumentation;
 
 namespace NzbDrone.Core.Datastore.Migration
@@ -53,7 +54,7 @@ namespace NzbDrone.Core.Datastore.Migration
                     while (reader.Read())
                     {
                         var version = reader.GetString(0);
-                        var cleanVersion = Regex.Replace(version, @"\(.*?\)", "");
+                        var cleanVersion = Regex.Replace(version, @"\(.*?\)", "", RegexOptions.None, RegexDefaults.Timeout);
 
                         _logger.Info("Postgres {0}", cleanVersion);
                     }

--- a/src/NzbDrone.Core/Datastore/Migration/Framework/NzbDroneSQLiteProcessor.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/Framework/NzbDroneSQLiteProcessor.cs
@@ -118,7 +118,7 @@ namespace NzbDrone.Core.Datastore.Migration.Framework
             {
                 if (index.Name.StartsWith("IX_"))
                 {
-                    index.Name = Regex.Replace(index.Name, "(?<=_)" + Regex.Escape(expression.OldName) + "(?=_|$)", Regex.Escape(expression.NewName));
+                    index.Name = Regex.Replace(index.Name, "(?<=_)" + Regex.Escape(expression.OldName) + "(?=_|$)", Regex.Escape(expression.NewName), RegexOptions.None, NzbDrone.Common.RegexDefaults.Timeout);
                 }
 
                 foreach (var column in index.Columns)

--- a/src/NzbDrone.Core/Datastore/SqlBuilder.cs
+++ b/src/NzbDrone.Core/Datastore/SqlBuilder.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 using Dapper;
+using NzbDrone.Common;
 
 namespace NzbDrone.Core.Datastore
 {
@@ -73,7 +74,7 @@ namespace NzbDrone.Core.Datastore
 
         public class Template
         {
-            private static readonly Regex _regex = new Regex(@"\/\*\*.+?\*\*\/", RegexOptions.Compiled | RegexOptions.Multiline);
+            private static readonly Regex _regex = new Regex(@"\/\*\*.+?\*\*\/", RegexOptions.Compiled | RegexOptions.Multiline, RegexDefaults.Timeout);
 
             private readonly string _sql;
             private readonly SqlBuilder _builder;

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/RawDiskSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/RawDiskSpecification.cs
@@ -1,6 +1,7 @@
 using System.Linq;
 using System.Text.RegularExpressions;
 using NLog;
+using NzbDrone.Common;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.IndexerSearch.Definitions;
 using NzbDrone.Core.Parser.Model;
@@ -11,9 +12,9 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
     {
         private static readonly Regex[] DiscRegex = new[]
                                                     {
-                                                        new Regex(@"(?:dis[ck])(?:[-_. ]\d+[-_. ])(?:(?:(?:480|720|1080|2160)[ip]|)[-_. ])?(?:Blu\-?ray)", RegexOptions.Compiled | RegexOptions.IgnoreCase),
-                                                        new Regex(@"(?:(?:480|720|1080|2160)[ip]|)[-_. ](?:full)[-_. ](?:Blu\-?ray)", RegexOptions.Compiled | RegexOptions.IgnoreCase),
-                                                        new Regex(@"(?:\d?x?M?DVD-?[R59])(?:[ ._]|$)", RegexOptions.Compiled | RegexOptions.IgnoreCase)
+                                                        new Regex(@"(?:dis[ck])(?:[-_. ]\d+[-_. ])(?:(?:(?:480|720|1080|2160)[ip]|)[-_. ])?(?:Blu\-?ray)", RegexOptions.Compiled | RegexOptions.IgnoreCase, RegexDefaults.Timeout),
+                                                        new Regex(@"(?:(?:480|720|1080|2160)[ip]|)[-_. ](?:full)[-_. ](?:Blu\-?ray)", RegexOptions.Compiled | RegexOptions.IgnoreCase, RegexDefaults.Timeout),
+                                                        new Regex(@"(?:\d?x?M?DVD-?[R59])(?:[ ._]|$)", RegexOptions.Compiled | RegexOptions.IgnoreCase, RegexDefaults.Timeout)
                                                     };
 
         private static readonly string[] _dvdContainerTypes = new[] { "vob", "iso" };

--- a/src/NzbDrone.Core/DiskSpace/DiskSpaceService.cs
+++ b/src/NzbDrone.Core/DiskSpace/DiskSpaceService.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
 using NLog;
+using NzbDrone.Common;
 using NzbDrone.Common.Disk;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Movies;
@@ -23,7 +24,7 @@ namespace NzbDrone.Core.DiskSpace
         private readonly IDiskProvider _diskProvider;
         private readonly Logger _logger;
 
-        private static readonly Regex _regexSpecialDrive = new Regex(@"^/var/lib/(docker|rancher|kubelet)(/|$)|^/(boot|etc)(/|$)|/docker(/var)?/aufs(/|$)|/\.timemachine", RegexOptions.Compiled);
+        private static readonly Regex _regexSpecialDrive = new Regex(@"^/var/lib/(docker|rancher|kubelet)(/|$)|^/(boot|etc)(/|$)|/docker(/var)?/aufs(/|$)|/\.timemachine", RegexOptions.Compiled, RegexDefaults.Timeout);
 
         public DiskSpaceService(IMovieService movieService, IRootFolderService rootFolderService, IDiskProvider diskProvider, Logger logger)
         {

--- a/src/NzbDrone.Core/Download/Clients/Sabnzbd/Sabnzbd.cs
+++ b/src/NzbDrone.Core/Download/Clients/Sabnzbd/Sabnzbd.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using FluentValidation.Results;
 using NLog;
+using NzbDrone.Common;
 using NzbDrone.Common.Disk;
 using NzbDrone.Common.EnvironmentInfo;
 using NzbDrone.Common.Extensions;
@@ -35,7 +36,7 @@ namespace NzbDrone.Core.Download.Clients.Sabnzbd
         }
 
         // patch can be a number (releases) or 'x' (git)
-        private static readonly Regex VersionRegex = new Regex(@"(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+|x)", RegexOptions.Compiled);
+        private static readonly Regex VersionRegex = new Regex(@"(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+|x)", RegexOptions.Compiled, RegexDefaults.Timeout);
 
         protected override string AddFromNzbFile(RemoteMovie remoteMovie, string filename, byte[] fileContent)
         {

--- a/src/NzbDrone.Core/Download/Clients/Transmission/Transmission.cs
+++ b/src/NzbDrone.Core/Download/Clients/Transmission/Transmission.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using FluentValidation.Results;
 using NLog;
+using NzbDrone.Common;
 using NzbDrone.Common.Disk;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Common.Http;
@@ -78,7 +79,7 @@ namespace NzbDrone.Core.Download.Clients.Transmission
 
             _logger.Debug("Transmission version information: {0}", versionString);
 
-            var versionResult = Regex.Match(versionString, @"(?<!\(|(\d|\.)+)(\d|\.)+(?!\)|(\d|\.)+)").Value;
+            var versionResult = Regex.Match(versionString, @"(?<!\(|(\d|\.)+)(\d|\.)+(?!\)|(\d|\.)+)", RegexOptions.None, RegexDefaults.Timeout).Value;
             var version = Version.Parse(versionResult);
 
             if (version < new Version(2, 40))

--- a/src/NzbDrone.Core/Download/Clients/Transmission/TransmissionBase.cs
+++ b/src/NzbDrone.Core/Download/Clients/Transmission/TransmissionBase.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using FluentValidation.Results;
 using NLog;
+using NzbDrone.Common;
 using NzbDrone.Common.Disk;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Common.Http;
@@ -350,7 +351,7 @@ namespace NzbDrone.Core.Download.Clients.Transmission
         {
             var rawVersion = _proxy.GetClientVersion(Settings);
 
-            var versionResult = Regex.Match(rawVersion, @"(?<!\(|(\d|\.)+)(\d|\.)+(?!\)|(\d|\.)+)").Value;
+            var versionResult = Regex.Match(rawVersion, @"(?<!\(|(\d|\.)+)(\d|\.)+(?!\)|(\d|\.)+)", RegexOptions.None, RegexDefaults.Timeout).Value;
             var clientVersion = Version.Parse(versionResult);
 
             return clientVersion >= new Version(major, minor);

--- a/src/NzbDrone.Core/Extras/Metadata/Consumers/Xbmc/XbmcMetadata.cs
+++ b/src/NzbDrone.Core/Extras/Metadata/Consumers/Xbmc/XbmcMetadata.cs
@@ -45,8 +45,8 @@ namespace NzbDrone.Core.Extras.Metadata.Consumers.Xbmc
             _tagRepository = tagRepository;
         }
 
-        private static readonly Regex MovieImagesRegex = new Regex(@"^(?<type>poster|banner|fanart|clearart|discart|keyart|landscape|logo|backdrop|clearlogo)\.(?:png|jpe?g)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
-        private static readonly Regex MovieFileImageRegex = new Regex(@"(?<type>-thumb|-poster|-banner|-fanart|-clearart|-discart|-keyart|-landscape|-logo|-backdrop|-clearlogo)\.(?:png|jpe?g)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private static readonly Regex MovieImagesRegex = new Regex(@"^(?<type>poster|banner|fanart|clearart|discart|keyart|landscape|logo|backdrop|clearlogo)\.(?:png|jpe?g)", RegexOptions.Compiled | RegexOptions.IgnoreCase, RegexDefaults.Timeout);
+        private static readonly Regex MovieFileImageRegex = new Regex(@"(?<type>-thumb|-poster|-banner|-fanart|-clearart|-discart|-keyart|-landscape|-logo|-backdrop|-clearlogo)\.(?:png|jpe?g)", RegexOptions.Compiled | RegexOptions.IgnoreCase, RegexDefaults.Timeout);
 
         public override string Name => "Kodi (XBMC) / Emby";
 
@@ -450,7 +450,7 @@ namespace NzbDrone.Core.Extras.Metadata.Consumers.Xbmc
 
             var fileContent = _diskProvider.ReadAllText(fullPath);
 
-            return Regex.IsMatch(fileContent, "<watched>true</watched>");
+            return Regex.IsMatch(fileContent, "<watched>true</watched>", RegexOptions.None, RegexDefaults.Timeout);
         }
     }
 }

--- a/src/NzbDrone.Core/Extras/Metadata/Consumers/Xbmc/XbmcNfoDetector.cs
+++ b/src/NzbDrone.Core/Extras/Metadata/Consumers/Xbmc/XbmcNfoDetector.cs
@@ -1,4 +1,5 @@
 using System.Text.RegularExpressions;
+using NzbDrone.Common;
 using NzbDrone.Common.Disk;
 using NzbDrone.Common.Extensions;
 
@@ -13,7 +14,7 @@ namespace NzbDrone.Core.Extras.Metadata.Consumers.Xbmc
     {
         private readonly IDiskProvider _diskProvider;
 
-        private readonly Regex _regex = new Regex("<(movie|tvshow|episodedetails|artist|album|musicvideo)>", RegexOptions.Compiled);
+        private readonly Regex _regex = new Regex("<(movie|tvshow|episodedetails|artist|album|musicvideo)>", RegexOptions.Compiled, RegexDefaults.Timeout);
 
         public XbmcNfoDetector(IDiskProvider diskProvider)
         {

--- a/src/NzbDrone.Core/HealthCheck/HealthCheck.cs
+++ b/src/NzbDrone.Core/HealthCheck/HealthCheck.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Text.RegularExpressions;
+using NzbDrone.Common;
 using NzbDrone.Common.Http;
 using NzbDrone.Core.Datastore;
 
@@ -7,7 +8,7 @@ namespace NzbDrone.Core.HealthCheck
 {
     public class HealthCheck : ModelBase
     {
-        private static readonly Regex CleanFragmentRegex = new Regex("[^a-z ]", RegexOptions.Compiled);
+        private static readonly Regex CleanFragmentRegex = new Regex("[^a-z ]", RegexOptions.Compiled, RegexDefaults.Timeout);
 
         public Type Source { get; set; }
         public HealthCheckResult Type { get; set; }

--- a/src/NzbDrone.Core/Http/CloudFlare/CloudFlareHttpInterceptor.cs
+++ b/src/NzbDrone.Core/Http/CloudFlare/CloudFlareHttpInterceptor.cs
@@ -1,6 +1,7 @@
 ﻿using System.Net;
 using System.Text.RegularExpressions;
 using NLog;
+using NzbDrone.Common;
 using NzbDrone.Common.Http;
 
 namespace NzbDrone.Core.Http.CloudFlare
@@ -9,7 +10,7 @@ namespace NzbDrone.Core.Http.CloudFlare
     {
         private const string _cloudFlareChallengeScript = "cdn-cgi/scripts/cf.challenge.js";
         private readonly Logger _logger;
-        private static readonly Regex _cloudFlareRegex = new Regex(@"data-ray=""(?<Ray>[\w-_]+)"".*?data-sitekey=""(?<SiteKey>[\w-_]+)"".*?data-stoken=""(?<SecretToken>[\w-_]+)""", RegexOptions.Compiled);
+        private static readonly Regex _cloudFlareRegex = new Regex(@"data-ray=""(?<Ray>[\w-_]+)"".*?data-sitekey=""(?<SiteKey>[\w-_]+)"".*?data-stoken=""(?<SecretToken>[\w-_]+)""", RegexOptions.Compiled, RegexDefaults.Timeout);
 
         public CloudFlareHttpInterceptor(Logger logger)
         {

--- a/src/NzbDrone.Core/ImportLists/RSSImport/RSSImportParser.cs
+++ b/src/NzbDrone.Core/ImportLists/RSSImport/RSSImportParser.cs
@@ -7,6 +7,7 @@ using System.Text.RegularExpressions;
 using System.Xml;
 using System.Xml.Linq;
 using NLog;
+using NzbDrone.Common;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Common.Http;
 using NzbDrone.Core.ImportLists.Exceptions;
@@ -22,7 +23,7 @@ namespace NzbDrone.Core.ImportLists.RSSImport
         private readonly Logger _logger;
         private ImportListResponse _importResponse;
 
-        private static readonly Regex ReplaceEntities = new Regex("&[a-z]+;", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private static readonly Regex ReplaceEntities = new Regex("&[a-z]+;", RegexOptions.Compiled | RegexOptions.IgnoreCase, RegexDefaults.Timeout);
 
         public RSSImportParser(RSSImportSettings settings,
                                Logger logger)

--- a/src/NzbDrone.Core/IndexerSearch/Definitions/SearchCriteriaBase.cs
+++ b/src/NzbDrone.Core/IndexerSearch/Definitions/SearchCriteriaBase.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
+using NzbDrone.Common;
 using NzbDrone.Common.EnsureThat;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Movies;
@@ -9,9 +10,9 @@ namespace NzbDrone.Core.IndexerSearch.Definitions
 {
     public abstract class SearchCriteriaBase
     {
-        private static readonly Regex SpecialCharacter = new Regex(@"['.\u0060\u00B4\u2018\u2019]", RegexOptions.IgnoreCase | RegexOptions.Compiled);
-        private static readonly Regex NonWord = new Regex(@"[\W]", RegexOptions.IgnoreCase | RegexOptions.Compiled);
-        private static readonly Regex BeginningThe = new Regex(@"^the\s", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        private static readonly Regex SpecialCharacter = new Regex(@"['.\u0060\u00B4\u2018\u2019]", RegexOptions.IgnoreCase | RegexOptions.Compiled, RegexDefaults.Timeout);
+        private static readonly Regex NonWord = new Regex(@"[\W]", RegexOptions.IgnoreCase | RegexOptions.Compiled, RegexDefaults.Timeout);
+        private static readonly Regex BeginningThe = new Regex(@"^the\s", RegexOptions.IgnoreCase | RegexOptions.Compiled, RegexDefaults.Timeout);
 
         public Movie Movie { get; set; }
         public List<string> SceneTitles { get; set; }
@@ -32,7 +33,7 @@ namespace NzbDrone.Core.IndexerSearch.Definitions
             cleanTitle = NonWord.Replace(cleanTitle, "+");
 
             // remove any repeating +s
-            cleanTitle = Regex.Replace(cleanTitle, @"\+{2,}", "+");
+            cleanTitle = Regex.Replace(cleanTitle, @"\+{2,}", "+", RegexOptions.None, RegexDefaults.Timeout);
             cleanTitle = cleanTitle.RemoveAccent();
             return cleanTitle.Trim('+', ' ');
         }

--- a/src/NzbDrone.Core/Indexers/IPTorrents/IPTorrentsSettings.cs
+++ b/src/NzbDrone.Core/Indexers/IPTorrents/IPTorrentsSettings.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using Equ;
 using FluentValidation;
+using NzbDrone.Common;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Annotations;
 using NzbDrone.Core.Languages;
@@ -21,7 +22,7 @@ namespace NzbDrone.Core.Indexers.IPTorrents
 
             RuleFor(c => c.BaseUrl).Matches(@"(?:/|t\.)rss\?.+;download(?:;|$)")
                 .WithMessage("Use Direct Download Url (;download)")
-                .When(v => v.BaseUrl.IsNotNullOrWhiteSpace() && Regex.IsMatch(v.BaseUrl, @"(?:/|t\.)rss\?.+$"));
+                .When(v => v.BaseUrl.IsNotNullOrWhiteSpace() && Regex.IsMatch(v.BaseUrl, @"(?:/|t\.)rss\?.+$", RegexOptions.None, RegexDefaults.Timeout));
 
             RuleFor(c => c.SeedCriteria).SetValidator(_ => new SeedCriteriaSettingsValidator());
         }

--- a/src/NzbDrone.Core/Indexers/Newznab/NewznabRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Newznab/NewznabRequestGenerator.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
+using NzbDrone.Common;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Common.Http;
 using NzbDrone.Core.IndexerSearch.Definitions;
@@ -225,7 +226,7 @@ namespace NzbDrone.Core.Indexers.Newznab
                 {
                     if (releaseDateString.Key.IsNotNullOrWhiteSpace() && releaseDateString.Value.IsNotNullOrWhiteSpace())
                     {
-                        newtitle = Regex.Replace(newtitle, $"{releaseDateString.Key}", $"{releaseDateString.Value}");
+                        newtitle = Regex.Replace(newtitle, $"{releaseDateString.Key}", $"{releaseDateString.Value}", RegexOptions.None, RegexDefaults.Timeout);
                     }
                 }
             }

--- a/src/NzbDrone.Core/Indexers/RssParser.cs
+++ b/src/NzbDrone.Core/Indexers/RssParser.cs
@@ -8,6 +8,7 @@ using System.Text.RegularExpressions;
 using System.Xml;
 using System.Xml.Linq;
 using NLog;
+using NzbDrone.Common;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Common.Http;
 using NzbDrone.Common.Instrumentation;
@@ -19,7 +20,7 @@ namespace NzbDrone.Core.Indexers
 {
     public class RssParser : IParseIndexerResponse
     {
-        private static readonly Regex ReplaceEntities = new Regex("&[a-z]+;", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private static readonly Regex ReplaceEntities = new Regex("&[a-z]+;", RegexOptions.Compiled | RegexOptions.IgnoreCase, RegexDefaults.Timeout);
         public const string NzbEnclosureMimeType = "application/x-nzb";
         public const string TorrentEnclosureMimeType = "application/x-bittorrent";
         public const string MagnetEnclosureMimeType = "application/x-bittorrent;x-scheme-handler/magnet";
@@ -363,7 +364,8 @@ namespace NzbDrone.Core.Indexers
         }
 
         private static readonly Regex ParseSizeRegex = new Regex(@"(?<value>(?<!\.\d*)(?:\d+,)*\d+(?:\.\d{1,3})?)\W?(?<unit>[KMG]i?B)(?![\w/])",
-            RegexOptions.IgnoreCase | RegexOptions.Compiled);
+            RegexOptions.IgnoreCase | RegexOptions.Compiled,
+            RegexDefaults.Timeout);
 
         public static long ParseSize(string sizeString, bool defaultToBinaryPrefix)
         {
@@ -381,7 +383,7 @@ namespace NzbDrone.Core.Indexers
 
             if (match.Count != 0)
             {
-                var value = decimal.Parse(Regex.Replace(match[0].Groups["value"].Value, "\\,", ""), CultureInfo.InvariantCulture);
+                var value = decimal.Parse(Regex.Replace(match[0].Groups["value"].Value, "\\,", "", RegexOptions.None, RegexDefaults.Timeout), CultureInfo.InvariantCulture);
 
                 var unit = match[0].Groups["unit"].Value.ToLower();
 

--- a/src/NzbDrone.Core/Indexers/TorrentRssParser.cs
+++ b/src/NzbDrone.Core/Indexers/TorrentRssParser.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using System.Xml.Linq;
 using MonoTorrent;
+using NzbDrone.Common;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Parser.Model;
 
@@ -189,8 +190,8 @@ namespace NzbDrone.Core.Indexers
             return size;
         }
 
-        private static readonly Regex ParseSeedersRegex = new Regex(@"(Seeder)s?:\s+(?<value>\d+)|(?<value>\d+)\s+(seeder)s?", RegexOptions.IgnoreCase | RegexOptions.Compiled);
-        private static readonly Regex ParseLeechersRegex = new Regex(@"(Leecher)s?:\s+(?<value>\d+)|(?<value>\d+)\s+(leecher)s?", RegexOptions.IgnoreCase | RegexOptions.Compiled);
-        private static readonly Regex ParsePeersRegex = new Regex(@"(Peer)s?:\s+(?<value>\d+)|(?<value>\d+)\s+(peer)s?", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        private static readonly Regex ParseSeedersRegex = new Regex(@"(Seeder)s?:\s+(?<value>\d+)|(?<value>\d+)\s+(seeder)s?", RegexOptions.IgnoreCase | RegexOptions.Compiled, RegexDefaults.Timeout);
+        private static readonly Regex ParseLeechersRegex = new Regex(@"(Leecher)s?:\s+(?<value>\d+)|(?<value>\d+)\s+(leecher)s?", RegexOptions.IgnoreCase | RegexOptions.Compiled, RegexDefaults.Timeout);
+        private static readonly Regex ParsePeersRegex = new Regex(@"(Peer)s?:\s+(?<value>\d+)|(?<value>\d+)\s+(peer)s?", RegexOptions.IgnoreCase | RegexOptions.Compiled, RegexDefaults.Timeout);
     }
 }

--- a/src/NzbDrone.Core/Indexers/XElementExtensions.cs
+++ b/src/NzbDrone.Core/Indexers/XElementExtensions.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using System.Xml.Linq;
 using NLog;
+using NzbDrone.Common;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Common.Instrumentation;
 
@@ -14,7 +15,7 @@ namespace NzbDrone.Core.Indexers
     {
         private static readonly Logger Logger = NzbDroneLogger.GetLogger(typeof(XmlExtensions));
 
-        public static readonly Regex RemoveTimeZoneRegex = new Regex(@"\s[A-Z]{2,4}$", RegexOptions.Compiled);
+        public static readonly Regex RemoveTimeZoneRegex = new Regex(@"\s[A-Z]{2,4}$", RegexOptions.Compiled, RegexDefaults.Timeout);
 
         public static string Title(this XElement item)
         {

--- a/src/NzbDrone.Core/Indexers/XmlCleaner.cs
+++ b/src/NzbDrone.Core/Indexers/XmlCleaner.cs
@@ -1,12 +1,13 @@
 ﻿using System.Net;
 using System.Text.RegularExpressions;
+using NzbDrone.Common;
 
 namespace NzbDrone.Core.Indexers
 {
     public static class XmlCleaner
     {
-        private static readonly Regex ReplaceEntitiesRegex = new Regex("&[a-z]+;", RegexOptions.Compiled | RegexOptions.IgnoreCase);
-        private static readonly Regex ReplaceUnicodeRegex = new Regex(@"[^\x09\x0A\x0D\u0020-\uD7FF\uE000-\uFFFD]", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private static readonly Regex ReplaceEntitiesRegex = new Regex("&[a-z]+;", RegexOptions.Compiled | RegexOptions.IgnoreCase, RegexDefaults.Timeout);
+        private static readonly Regex ReplaceUnicodeRegex = new Regex(@"[^\x09\x0A\x0D\u0020-\uD7FF\uE000-\uFFFD]", RegexOptions.Compiled | RegexOptions.IgnoreCase, RegexDefaults.Timeout);
 
         public static string ReplaceEntities(string content)
         {

--- a/src/NzbDrone.Core/Localization/LocalizationService.cs
+++ b/src/NzbDrone.Core/Localization/LocalizationService.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using NLog;
+using NzbDrone.Common;
 using NzbDrone.Common.Cache;
 using NzbDrone.Common.EnvironmentInfo;
 using NzbDrone.Common.Extensions;
@@ -29,7 +30,8 @@ namespace NzbDrone.Core.Localization
     {
         private const string DefaultCulture = "en";
         private static readonly Regex TokenRegex = new Regex(@"(?:\{)(?<token>[a-z0-9]+)(?:\})",
-            RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+            RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant,
+            RegexDefaults.Timeout);
 
         private readonly ICached<Dictionary<string, string>> _cache;
 

--- a/src/NzbDrone.Core/MediaFiles/DiskScanService.cs
+++ b/src/NzbDrone.Core/MediaFiles/DiskScanService.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading;
 using NLog;
+using NzbDrone.Common;
 using NzbDrone.Common.Disk;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Configuration;
@@ -76,10 +77,10 @@ namespace NzbDrone.Core.MediaFiles
             _logger = logger;
         }
 
-        private static readonly Regex ExcludedExtrasSubFolderRegex = new Regex(@"(?:\\|\/|^)(?:extras|extrafanart|behind the scenes|deleted scenes|featurettes|interviews|other|scenes|sample[s]?|shorts|trailers)(?:\\|\/)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
-        private static readonly Regex ExcludedSubFoldersRegex = new Regex(@"(?:\\|\/|^)(?:@eadir|\.@__thumb|plex versions|\.[^\\/]+)(?:\\|\/)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
-        private static readonly Regex ExcludedExtraFilesRegex = new Regex(@"(-(trailer|other|behindthescenes|deleted|featurette|interview|scene|short)\.[^.]+$)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
-        private static readonly Regex ExcludedFilesRegex = new Regex(@"^\.(_|unmanic|DS_Store$)|^Thumbs\.db$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private static readonly Regex ExcludedExtrasSubFolderRegex = new Regex(@"(?:\\|\/|^)(?:extras|extrafanart|behind the scenes|deleted scenes|featurettes|interviews|other|scenes|sample[s]?|shorts|trailers)(?:\\|\/)", RegexOptions.Compiled | RegexOptions.IgnoreCase, RegexDefaults.Timeout);
+        private static readonly Regex ExcludedSubFoldersRegex = new Regex(@"(?:\\|\/|^)(?:@eadir|\.@__thumb|plex versions|\.[^\\/]+)(?:\\|\/)", RegexOptions.Compiled | RegexOptions.IgnoreCase, RegexDefaults.Timeout);
+        private static readonly Regex ExcludedExtraFilesRegex = new Regex(@"(-(trailer|other|behindthescenes|deleted|featurette|interview|scene|short)\.[^.]+$)", RegexOptions.Compiled | RegexOptions.IgnoreCase, RegexDefaults.Timeout);
+        private static readonly Regex ExcludedFilesRegex = new Regex(@"^\.(_|unmanic|DS_Store$)|^Thumbs\.db$", RegexOptions.Compiled | RegexOptions.IgnoreCase, RegexDefaults.Timeout);
 
         public void Scan(Movie movie, bool manual = false)
         {

--- a/src/NzbDrone.Core/MediaFiles/MediaInfo/MediaInfoFormatter.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaInfo/MediaInfoFormatter.cs
@@ -2,6 +2,7 @@ using System.Globalization;
 using System.Linq;
 using System.Text.RegularExpressions;
 using NLog;
+using NzbDrone.Common;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Common.Instrumentation;
 using NzbDrone.Common.Instrumentation.Extensions;
@@ -12,7 +13,7 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
     {
         private const string VideoDynamicRangeHdr = "HDR";
 
-        private static readonly Regex PositionRegex = new Regex(@"(?<position>^\d\.\d)", RegexOptions.Compiled);
+        private static readonly Regex PositionRegex = new Regex(@"(?<position>^\d\.\d)", RegexOptions.Compiled, RegexDefaults.Timeout);
 
         private static readonly Logger Logger = NzbDroneLogger.GetLogger(typeof(MediaInfoFormatter));
 

--- a/src/NzbDrone.Core/MediaFiles/MovieImport/Identification/IdentificationService.cs
+++ b/src/NzbDrone.Core/MediaFiles/MovieImport/Identification/IdentificationService.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
 using NLog;
+using NzbDrone.Common;
 using NzbDrone.Common.Disk;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Configuration;
@@ -92,7 +93,8 @@ namespace NzbDrone.Core.MediaFiles.MovieImport
 
             // Try to see if the scene has been organized into a folder already
             var folderRegex = new Regex(@"(?<airyear>\d{2}|\d{4})[-_. ]+(?<airmonth>[0-1][0-9])[-_. ]+(?<airday>[0-3][0-9])",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled);
+                RegexOptions.IgnoreCase | RegexOptions.Compiled,
+                RegexDefaults.Timeout);
             var folder = Directory.GetParent(file).Name;
             var match = folderRegex.Match(folder);
 

--- a/src/NzbDrone.Core/MediaFiles/MovieImport/Specifications/NotMultiPartSpecification.cs
+++ b/src/NzbDrone.Core/MediaFiles/MovieImport/Specifications/NotMultiPartSpecification.cs
@@ -1,6 +1,7 @@
 using System.Linq;
 using System.Text.RegularExpressions;
 using NLog;
+using NzbDrone.Common;
 using NzbDrone.Common.Disk;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Download;
@@ -12,8 +13,8 @@ namespace NzbDrone.Core.MediaFiles.MovieImport.Specifications
     {
         private static readonly Regex[] MovieMultiPartRegex = new[]
         {
-            new Regex(@"(?<!^)(?<identifier>[ _.-]*(?:cd|dvd|p(?:(?:ar)?t)?|dis[ck])[ _.-]*[0-9]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase),
-            new Regex(@"(?<!^)(?<identifier>[ _.-]*(?:cd|dvd|p(?:(?:ar)?t)?|dis[ck])[ _.-]*[a-d]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase),
+            new Regex(@"(?<!^)(?<identifier>[ _.-]*(?:cd|dvd|p(?:(?:ar)?t)?|dis[ck])[ _.-]*[0-9]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase, RegexDefaults.Timeout),
+            new Regex(@"(?<!^)(?<identifier>[ _.-]*(?:cd|dvd|p(?:(?:ar)?t)?|dis[ck])[ _.-]*[a-d]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase, RegexDefaults.Timeout),
         };
 
         private readonly IDiskProvider _diskProvider;

--- a/src/NzbDrone.Core/MediaFiles/SceneDiskScanService.cs
+++ b/src/NzbDrone.Core/MediaFiles/SceneDiskScanService.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
 using NLog;
+using NzbDrone.Common;
 using NzbDrone.Common.Disk;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Common.Instrumentation.Extensions;
@@ -82,10 +83,10 @@ namespace NzbDrone.Core.MediaFiles
             _logger = logger;
         }
 
-        private static readonly Regex ExcludedExtrasSubFolderRegex = new Regex(@"(?:\\|\/|^)(?:extras|extrafanart|behind the scenes|deleted scenes|featurettes|interviews|scenes|sample[s]?|shorts|trailers)(?:\\|\/)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
-        private static readonly Regex ExcludedSubFoldersRegex = new Regex(@"(?:\\|\/|^)(?:@eadir|\.@__thumb|plex versions|\.[^\\/]+)(?:\\|\/)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
-        private static readonly Regex ExcludedExtraFilesRegex = new Regex(@"(-(trailer|other|behindthescenes|deleted|featurette|interview|scene|short)\.[^.]+$)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
-        private static readonly Regex ExcludedFilesRegex = new Regex(@"^\._|^Thumbs\.db$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private static readonly Regex ExcludedExtrasSubFolderRegex = new Regex(@"(?:\\|\/|^)(?:extras|extrafanart|behind the scenes|deleted scenes|featurettes|interviews|scenes|sample[s]?|shorts|trailers)(?:\\|\/)", RegexOptions.Compiled | RegexOptions.IgnoreCase, RegexDefaults.Timeout);
+        private static readonly Regex ExcludedSubFoldersRegex = new Regex(@"(?:\\|\/|^)(?:@eadir|\.@__thumb|plex versions|\.[^\\/]+)(?:\\|\/)", RegexOptions.Compiled | RegexOptions.IgnoreCase, RegexDefaults.Timeout);
+        private static readonly Regex ExcludedExtraFilesRegex = new Regex(@"(-(trailer|other|behindthescenes|deleted|featurette|interview|scene|short)\.[^.]+$)", RegexOptions.Compiled | RegexOptions.IgnoreCase, RegexDefaults.Timeout);
+        private static readonly Regex ExcludedFilesRegex = new Regex(@"^\._|^Thumbs\.db$", RegexOptions.Compiled | RegexOptions.IgnoreCase, RegexDefaults.Timeout);
 
         public void Scan(List<string> folders = null)
         {

--- a/src/NzbDrone.Core/MediaFiles/ScriptImportDecider.cs
+++ b/src/NzbDrone.Core/MediaFiles/ScriptImportDecider.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
 using NLog;
+using NzbDrone.Common;
 using NzbDrone.Common.Disk;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Common.Processes;
@@ -47,7 +48,7 @@ namespace NzbDrone.Core.MediaFiles
             _logger = logger;
         }
 
-        private static readonly Regex OutputRegex = new Regex(@"^(?:\[(?:(?<mediaFile>MediaFile)|(?<extraFile>ExtraFile))\]\s?(?<fileName>.+)|(?<preventExtraImport>\[PreventExtraImport\])|\[MoveStatus\]\s?(?:(?<deferMove>DeferMove)|(?<moveComplete>MoveComplete)|(?<renameRequested>RenameRequested)))$", RegexOptions.Compiled);
+        private static readonly Regex OutputRegex = new Regex(@"^(?:\[(?:(?<mediaFile>MediaFile)|(?<extraFile>ExtraFile))\]\s?(?<fileName>.+)|(?<preventExtraImport>\[PreventExtraImport\])|\[MoveStatus\]\s?(?:(?<deferMove>DeferMove)|(?<moveComplete>MoveComplete)|(?<renameRequested>RenameRequested)))$", RegexOptions.Compiled, RegexDefaults.Timeout);
 
         private ScriptImportInfo ProcessOutput(List<ProcessOutputLine> processOutputLines)
         {

--- a/src/NzbDrone.Core/MetadataSource/SearchMovieComparer.cs
+++ b/src/NzbDrone.Core/MetadataSource/SearchMovieComparer.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
+using NzbDrone.Common;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Movies;
 
@@ -8,9 +9,9 @@ namespace NzbDrone.Core.MetadataSource
 {
     public class SearchMovieComparer : IComparer<Movie>
     {
-        private static readonly Regex RegexCleanPunctuation = new Regex("[-._:]", RegexOptions.Compiled);
-        private static readonly Regex RegexCleanCountryYearPostfix = new Regex(@"(?<=.+)( \([A-Z]{2}\)| \(\d{4}\)| \([A-Z]{2}\) \(\d{4}\))$", RegexOptions.Compiled);
-        private static readonly Regex ArticleRegex = new Regex(@"^(a|an|the)\s", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        private static readonly Regex RegexCleanPunctuation = new Regex("[-._:]", RegexOptions.Compiled, RegexDefaults.Timeout);
+        private static readonly Regex RegexCleanCountryYearPostfix = new Regex(@"(?<=.+)( \([A-Z]{2}\)| \(\d{4}\)| \([A-Z]{2}\) \(\d{4}\))$", RegexOptions.Compiled, RegexDefaults.Timeout);
+        private static readonly Regex ArticleRegex = new Regex(@"^(a|an|the)\s", RegexOptions.IgnoreCase | RegexOptions.Compiled, RegexDefaults.Timeout);
 
         public string SearchQuery { get; private set; }
 
@@ -21,7 +22,7 @@ namespace NzbDrone.Core.MetadataSource
         {
             SearchQuery = searchQuery;
 
-            var match = Regex.Match(SearchQuery, @"^(?<query>.+)\s+(?:\((?<year>\d{4})\)|(?<year>\d{4}))$");
+            var match = Regex.Match(SearchQuery, @"^(?<query>.+)\s+(?:\((?<year>\d{4})\)|(?<year>\d{4}))$", RegexOptions.None, RegexDefaults.Timeout);
             if (match.Success)
             {
                 _searchQueryWithoutYear = match.Groups["query"].Value.ToLowerInvariant();

--- a/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
+++ b/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
@@ -6,6 +6,7 @@ using System.Net;
 using System.Text.RegularExpressions;
 using Newtonsoft.Json;
 using NLog;
+using NzbDrone.Common;
 using NzbDrone.Common.Cloud;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Common.Http;
@@ -823,7 +824,7 @@ namespace NzbDrone.Core.MetadataSource.SkyHook
         {
             try
             {
-                var regex = new Regex("^https://www.themoviedb.org/movie/(?<tmdbid>[0-9]+).*$");
+                var regex = new Regex("^https://www.themoviedb.org/movie/(?<tmdbid>[0-9]+).*$", RegexOptions.None, RegexDefaults.Timeout);
                 var match = regex.Match(title);
 
                 if (match.Success)
@@ -982,7 +983,7 @@ namespace NzbDrone.Core.MetadataSource.SkyHook
                 lowerTitle = lowerTitle.Replace(".", "");
 
                 // Allow search to accept a full StashDB URL
-                var regex = new Regex(@"^https://theporndb\.net/movies/(?<tpdbid>[A-Za-z0-9\-]+).*$", RegexOptions.Compiled);
+                var regex = new Regex(@"^https://theporndb\.net/movies/(?<tpdbid>[A-Za-z0-9\-]+).*$", RegexOptions.Compiled, RegexDefaults.Timeout);
                 var match = regex.Match(title);
 
                 if (match.Success)
@@ -1087,7 +1088,7 @@ namespace NzbDrone.Core.MetadataSource.SkyHook
                 lowerTitle = lowerTitle.Replace(".", "");
 
                 // Allow search to accept a full StashDB URL
-                var regex = new Regex(@"^https://stashdb\.org/scenes/(?<stashid>[A-Za-z0-9\-]+).*$", RegexOptions.Compiled);
+                var regex = new Regex(@"^https://stashdb\.org/scenes/(?<stashid>[A-Za-z0-9\-]+).*$", RegexOptions.Compiled, RegexDefaults.Timeout);
                 var match = regex.Match(title);
 
                 if (match.Success)
@@ -1185,7 +1186,7 @@ namespace NzbDrone.Core.MetadataSource.SkyHook
                 lowerTitle = lowerTitle.Replace(".", "");
 
                 // Allow search to accept a full StashDB URL
-                var regex = new Regex(@"^https://stashdb\.org/performers/(?<stashid>[A-Za-z0-9\-]+).*$", RegexOptions.Compiled);
+                var regex = new Regex(@"^https://stashdb\.org/performers/(?<stashid>[A-Za-z0-9\-]+).*$", RegexOptions.Compiled, RegexDefaults.Timeout);
                 var match = regex.Match(title);
 
                 if (match.Success)
@@ -1269,7 +1270,7 @@ namespace NzbDrone.Core.MetadataSource.SkyHook
                 lowerTitle = lowerTitle.Replace(".", "");
 
                 // Allow search to accept a full StashDB URL
-                var regex = new Regex(@"^https://stashdb\.org/studios/(?<stashid>[A-Za-z0-9\-]+).*$", RegexOptions.Compiled);
+                var regex = new Regex(@"^https://stashdb\.org/studios/(?<stashid>[A-Za-z0-9\-]+).*$", RegexOptions.Compiled, RegexDefaults.Timeout);
                 var match = regex.Match(title);
 
                 if (match.Success)

--- a/src/NzbDrone.Core/Movies/MovieService.cs
+++ b/src/NzbDrone.Core/Movies/MovieService.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using DryIoc.ImTools;
 using NLog;
+using NzbDrone.Common;
 using NzbDrone.Common.Cache;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.AutoTagging;
@@ -956,7 +957,7 @@ namespace NzbDrone.Core.Movies
                             matches.Add(movie, MovieParseMatchType.Episode);
                             continue;
                         }
-                        else if (int.TryParse(code, out var codeNumber) && int.TryParse(Regex.Match(episode, @"\d+").Value, out var episodeNumber))
+                        else if (int.TryParse(code, out var codeNumber) && int.TryParse(Regex.Match(episode, @"\d+", RegexOptions.None, RegexDefaults.Timeout).Value, out var episodeNumber))
                         {
                             if (codeNumber == episodeNumber)
                             {
@@ -1137,7 +1138,7 @@ namespace NzbDrone.Core.Movies
                         var code = match.Key.MovieMetadata.Value.Code;
                         if (!episode.Equals(code, StringComparison.InvariantCultureIgnoreCase))
                         {
-                            if (int.TryParse(code, out var codeNumber) && int.TryParse(Regex.Match(episode, @"\d+").Value, out var episodeNumber))
+                            if (int.TryParse(code, out var codeNumber) && int.TryParse(Regex.Match(episode, @"\d+", RegexOptions.None, RegexDefaults.Timeout).Value, out var episodeNumber))
                             {
                                 if (codeNumber != episodeNumber)
                                 {

--- a/src/NzbDrone.Core/Notifications/Plex/Server/PlexServerService.cs
+++ b/src/NzbDrone.Core/Notifications/Plex/Server/PlexServerService.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using FluentValidation.Results;
 using NLog;
+using NzbDrone.Common;
 using NzbDrone.Common.Cache;
 using NzbDrone.Common.Disk;
 using NzbDrone.Common.Extensions;
@@ -90,7 +91,7 @@ namespace NzbDrone.Core.Notifications.Plex.Server
             _logger.Debug("Getting version from Plex host: {0}", settings.Host);
 
             var rawVersion = _plexServerProxy.Version(settings);
-            var version = new Version(Regex.Match(rawVersion, @"^(\d+[.-]){4}").Value.Trim('.', '-'));
+            var version = new Version(Regex.Match(rawVersion, @"^(\d+[.-]){4}", RegexOptions.None, RegexDefaults.Timeout).Value.Trim('.', '-'));
 
             return version;
         }

--- a/src/NzbDrone.Core/Notifications/Pushsafer/PushsaferSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Pushsafer/PushsaferSettings.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using FluentValidation;
+using NzbDrone.Common;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Annotations;
 using NzbDrone.Core.Validation;
@@ -18,7 +19,7 @@ namespace NzbDrone.Core.Notifications.Pushsafer
             RuleFor(c => c.Sound).ValidParsedStringRange(0, 62).When(c => c.Sound.IsNotNullOrWhiteSpace());
             RuleFor(c => c.Vibration).ValidParsedStringRange(1, 3).When(c => c.Vibration.IsNotNullOrWhiteSpace());
             RuleFor(c => c.Icon).ValidParsedStringRange(1, 181).When(c => c.Icon.IsNotNullOrWhiteSpace());
-            RuleFor(c => c.IconColor).Matches(new Regex("^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$")).When(c => c.IconColor.IsNotNullOrWhiteSpace());
+            RuleFor(c => c.IconColor).Matches(new Regex("^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$", RegexOptions.None, RegexDefaults.Timeout)).When(c => c.IconColor.IsNotNullOrWhiteSpace());
         }
     }
 

--- a/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using Diacritical;
 using NLog;
+using NzbDrone.Common;
 using NzbDrone.Common.EnsureThat;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.CustomFormats;
@@ -46,37 +47,43 @@ namespace NzbDrone.Core.Organizer
         private int _trimEnd;
 
         private static readonly Regex TitleRegex = new Regex(@"(?<tag>\{(?:imdb-|edition-))?\{(?<prefix>[- ._\[(]*)(?<token>(?:[a-z0-9]+)(?:(?<separator>[- ._]+)(?:[a-z0-9]+))?)(?::(?<customFormat>[ ,a-z0-9|+-]+(?<![- ])))?(?<suffix>[-} ._)\]]*)\}",
-                                                             RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+                                                             RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant,
+                                                             RegexDefaults.Timeout);
 
         public static readonly Regex MovieTitleRegex = new Regex(@"(?<token>\{((?:(Movie|Original))(?<separator>[- ._])(Clean)?(Original)?(Title|Filename)(The)?)(?::(?<customFormat>[a-z0-9|-]+))?\})",
-                                                                            RegexOptions.Compiled | RegexOptions.IgnoreCase);
+                                                                            RegexOptions.Compiled | RegexOptions.IgnoreCase,
+                                                                            RegexDefaults.Timeout);
 
         public static readonly Regex SceneFolderRegex = new Regex(@"(?<token>\{((?:(Studio|Original))(?<separator>[- ._])(Clean)?(Original)?(Title|Filename)(The|Slug|FirstCharacter)?)(?::(?<customFormat>[a-z0-9|-]+))?\})",
-                                                                            RegexOptions.Compiled | RegexOptions.IgnoreCase);
+                                                                            RegexOptions.Compiled | RegexOptions.IgnoreCase,
+                                                                            RegexDefaults.Timeout);
 
         // Matches any of the four scene title tokens: {Scene Title}, {Scene CleanTitle}, {Scene CleanTitleNoSeasonEpisode}, {Scene TitleThe},
         // each optionally carrying a truncation suffix, ex. {Scene CleanTitle:100} or {Scene CleanTitle:-30}
         public static readonly Regex SceneTitleTokenRegex = new Regex(@"\{Scene( |\.|-|_)(CleanTitleNoSeasonEpisode|CleanTitle|TitleThe|Title)(?::(?<customFormat>[a-z0-9|-]+))?\}",
-                                          RegexOptions.Compiled | RegexOptions.IgnoreCase);
+                                          RegexOptions.Compiled | RegexOptions.IgnoreCase,
+                                          RegexDefaults.Timeout);
 
         public static readonly Regex MainFolderRegex = new Regex(@"^(?<main>(?:[a-zA-Z0-9]+(?:\\|\/)))",
-                                                                            RegexOptions.Compiled | RegexOptions.IgnoreCase);
+                                                                            RegexOptions.Compiled | RegexOptions.IgnoreCase,
+                                                                            RegexDefaults.Timeout);
 
         public static readonly Regex SceneTitleRegex = new Regex(@"(?<token>\{((?:(Scene|Original))(?<separator>[- ._])(Clean)?(Original)?(Title|Filename)(The)?(NoSeasonEpisode)?)(?::(?<customFormat>[a-z0-9|-]+))?\})",
-                                                                            RegexOptions.Compiled | RegexOptions.IgnoreCase);
+                                                                            RegexOptions.Compiled | RegexOptions.IgnoreCase,
+                                                                            RegexDefaults.Timeout);
 
-        private static readonly Regex FileNameCleanupRegex = new Regex(@"([- ._])(\1)+", RegexOptions.Compiled);
-        private static readonly Regex TrimSeparatorsRegex = new Regex(@"[- ._]+$", RegexOptions.Compiled);
+        private static readonly Regex FileNameCleanupRegex = new Regex(@"([- ._])(\1)+", RegexOptions.Compiled, RegexDefaults.Timeout);
+        private static readonly Regex TrimSeparatorsRegex = new Regex(@"[- ._]+$", RegexOptions.Compiled, RegexDefaults.Timeout);
 
-        private static readonly Regex ScenifyRemoveChars = new Regex(@"(?<=\s)(,|<|>|\/|\\|;|:|'|""|\||`|’|~|!|\?|@|$|%|^|\*|-|_|=){1}(?=\s)|('|`|’|:|\?|,)(?=(?:(?:s|m|t|ve|ll|d|re)\s)|\s|$)|(\(|\)|\[|\]|\{|\})", RegexOptions.Compiled | RegexOptions.IgnoreCase);
-        private static readonly Regex ScenifyReplaceChars = new Regex(@"[\/]", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private static readonly Regex ScenifyRemoveChars = new Regex(@"(?<=\s)(,|<|>|\/|\\|;|:|'|""|\||`|’|~|!|\?|@|$|%|^|\*|-|_|=){1}(?=\s)|('|`|’|:|\?|,)(?=(?:(?:s|m|t|ve|ll|d|re)\s)|\s|$)|(\(|\)|\[|\]|\{|\})", RegexOptions.Compiled | RegexOptions.IgnoreCase, RegexDefaults.Timeout);
+        private static readonly Regex ScenifyReplaceChars = new Regex(@"[\/]", RegexOptions.Compiled | RegexOptions.IgnoreCase, RegexDefaults.Timeout);
 
-        private static readonly Regex EmojiRegex = new Regex(@"\p{Cs}", RegexOptions.Compiled);
-        private static readonly Regex WordDelimiterRegex = new Regex(@"(’|')+", RegexOptions.Compiled);
+        private static readonly Regex EmojiRegex = new Regex(@"\p{Cs}", RegexOptions.Compiled, RegexDefaults.Timeout);
+        private static readonly Regex WordDelimiterRegex = new Regex(@"(’|')+", RegexOptions.Compiled, RegexDefaults.Timeout);
 
-        private static readonly Regex TitlePrefixRegex = new Regex(@"^(The|An|A) (.*?)((?: *\([^)]+\))*)$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private static readonly Regex TitlePrefixRegex = new Regex(@"^(The|An|A) (.*?)((?: *\([^)]+\))*)$", RegexOptions.Compiled | RegexOptions.IgnoreCase, RegexDefaults.Timeout);
 
-        private static readonly Regex ReservedDeviceNamesRegex = new Regex(@"^(?:aux|com[1-9]|con|lpt[1-9]|nul|prn)\.", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private static readonly Regex ReservedDeviceNamesRegex = new Regex(@"^(?:aux|com[1-9]|con|lpt[1-9]|nul|prn)\.", RegexOptions.Compiled | RegexOptions.IgnoreCase, RegexDefaults.Timeout);
 
         // generated from https://www.loc.gov/standards/iso639-2/ISO-639-2_utf-8.txt
         public static readonly ImmutableDictionary<string, string> Iso639BTMap = new Dictionary<string, string>
@@ -342,9 +349,9 @@ namespace NzbDrone.Core.Organizer
 
             title = CleanTitle(title);
 
-            title = Regex.Replace(title, @"\s*-?\s*S\d+:E\d+\s*", "", RegexOptions.IgnoreCase);
+            title = Regex.Replace(title, @"\s*-?\s*S\d+:E\d+\s*", "", RegexOptions.IgnoreCase, RegexDefaults.Timeout);
 
-            title = Regex.Replace(title, @"\s+", " ").Trim();
+            title = Regex.Replace(title, @"\s+", " ", RegexOptions.None, RegexDefaults.Timeout).Trim();
 
             return title;
         }
@@ -756,8 +763,8 @@ namespace NzbDrone.Core.Organizer
         {
             var edition = CultureInfo.CurrentCulture.TextInfo.ToTitleCase(movieFile.Edition.ToLowerInvariant());
 
-            edition = Regex.Replace(edition, @"((?:\b|_)\d{1,3}(?:st|th|rd|nd)(?:\b|_))", match => match.Groups[1].Value.ToLowerInvariant(), RegexOptions.IgnoreCase);
-            edition = Regex.Replace(edition, @"((?:\b|_)(?:IMAX|3D|SDR|HDR|DV)(?:\b|_))", match => match.Groups[1].Value.ToUpperInvariant(), RegexOptions.IgnoreCase);
+            edition = Regex.Replace(edition, @"((?:\b|_)\d{1,3}(?:st|th|rd|nd)(?:\b|_))", match => match.Groups[1].Value.ToLowerInvariant(), RegexOptions.IgnoreCase, RegexDefaults.Timeout);
+            edition = Regex.Replace(edition, @"((?:\b|_)(?:IMAX|3D|SDR|HDR|DV)(?:\b|_))", match => match.Groups[1].Value.ToUpperInvariant(), RegexOptions.IgnoreCase, RegexDefaults.Timeout);
 
             return edition;
         }

--- a/src/NzbDrone.Core/Organizer/FileNameBuilderTokenEqualityComparer.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameBuilderTokenEqualityComparer.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Text.RegularExpressions;
+using NzbDrone.Common;
 
 namespace NzbDrone.Core.Organizer
 {
@@ -7,7 +8,7 @@ namespace NzbDrone.Core.Organizer
     {
         public static readonly FileNameBuilderTokenEqualityComparer Instance = new FileNameBuilderTokenEqualityComparer();
 
-        private static readonly Regex SimpleTokenRegex = new Regex(@"\s|_|\W", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private static readonly Regex SimpleTokenRegex = new Regex(@"\s|_|\W", RegexOptions.Compiled | RegexOptions.IgnoreCase, RegexDefaults.Timeout);
 
         private FileNameBuilderTokenEqualityComparer()
         {

--- a/src/NzbDrone.Core/Parser/LanguageParser.cs
+++ b/src/NzbDrone.Core/Parser/LanguageParser.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
 using NLog;
+using NzbDrone.Common;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Common.Instrumentation;
 using NzbDrone.Core.Languages;
@@ -41,7 +42,8 @@ namespace NzbDrone.Core.Parser
                                                                             (?<mongolian>\b(?:mongolian|khalkha)\b)|
                                                                             (?<georgian>\b(?:georgian|geo|ka|kat)\b)|
                                                                             (?<original>\b(?:orig|original)\b)",
-                                                                RegexOptions.IgnoreCase | RegexOptions.Compiled | RegexOptions.IgnorePatternWhitespace);
+                                                                RegexOptions.IgnoreCase | RegexOptions.Compiled | RegexOptions.IgnorePatternWhitespace,
+                                                                RegexDefaults.Timeout);
 
         private static readonly Regex CaseSensitiveLanguageRegex = new Regex(@"(?:(?i)(?<!SUB[\W|_|^]))(?:(?<english>\bEN\b)|
                                                                                                           (?<lithuanian>\bLT\b)|
@@ -51,12 +53,13 @@ namespace NzbDrone.Core.Parser
                                                                                                           (?<slovak>\bSK\b)|
                                                                                                           (?<german>\bDE\b)|
                                                                                                           (?<spanish>\b(?<!DTS[._ -])ES\b))(?:(?i)(?![\W|_|^]SUB))",
-                                                                RegexOptions.Compiled | RegexOptions.IgnorePatternWhitespace);
+                                                                RegexOptions.Compiled | RegexOptions.IgnorePatternWhitespace,
+                                                                RegexDefaults.Timeout);
 
         private static readonly Regex GermanDualLanguageRegex = new (@"(?<!WEB[-_. ]?)\bDL\b", RegexOptions.Compiled | RegexOptions.IgnoreCase);
         private static readonly Regex GermanMultiLanguageRegex = new (@"\bML\b", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
-        private static readonly Regex SubtitleLanguageRegex = new Regex(".+?[-_. ](?<iso_code>[a-z]{2,3})([-_. ](?<tags>full|forced|foreign|default|cc|psdh|sdh))*$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private static readonly Regex SubtitleLanguageRegex = new Regex(".+?[-_. ](?<iso_code>[a-z]{2,3})([-_. ](?<tags>full|forced|foreign|default|cc|psdh|sdh))*$", RegexOptions.Compiled | RegexOptions.IgnoreCase, RegexDefaults.Timeout);
 
         public static List<Language> ParseLanguages(string title)
         {

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
 using NLog;
+using NzbDrone.Common;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Common.Instrumentation;
 using NzbDrone.Core.MediaFiles;
@@ -17,12 +18,13 @@ namespace NzbDrone.Core.Parser
     {
         private static readonly Logger Logger = NzbDroneLogger.GetLogger(typeof(Parser));
 
-        private static readonly Regex EditionRegex = new Regex(@"\(?\b(?<edition>(((Recut.|Extended.|Ultimate.)?(Director.?s|Collector.?s|Theatrical|Ultimate|Extended|Despecialized|(Special|Rouge|Final|Assembly|Imperial|Diamond|Signature|Hunter|Rekall)(?=(.(Cut|Edition|Version)))|\d{2,3}(th)?.Anniversary)(?:.(Cut|Edition|Version))?(.(Extended|Uncensored|Remastered|Unrated|Uncut|Open.?Matte|IMAX|Fan.?Edit))?|((Uncensored|Remastered|Unrated|Uncut|Open?.Matte|IMAX|Fan.?Edit|Restored|((2|3|4)in1))))))\b\)?", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private static readonly Regex EditionRegex = new Regex(@"\(?\b(?<edition>(((Recut.|Extended.|Ultimate.)?(Director.?s|Collector.?s|Theatrical|Ultimate|Extended|Despecialized|(Special|Rouge|Final|Assembly|Imperial|Diamond|Signature|Hunter|Rekall)(?=(.(Cut|Edition|Version)))|\d{2,3}(th)?.Anniversary)(?:.(Cut|Edition|Version))?(.(Extended|Uncensored|Remastered|Unrated|Uncut|Open.?Matte|IMAX|Fan.?Edit))?|((Uncensored|Remastered|Unrated|Uncut|Open?.Matte|IMAX|Fan.?Edit|Restored|((2|3|4)in1))))))\b\)?", RegexOptions.Compiled | RegexOptions.IgnoreCase, RegexDefaults.Timeout);
 
-        private static readonly Regex ReportEditionRegex = new Regex(@"^.+?" + EditionRegex, RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private static readonly Regex ReportEditionRegex = new Regex(@"^.+?" + EditionRegex, RegexOptions.Compiled | RegexOptions.IgnoreCase, RegexDefaults.Timeout);
 
         private static readonly Regex HardcodedSubsRegex = new Regex(@"\b((?<hcsub>(\w+(?<!SOFT|MULTI|HORRIBLE)SUBS?))|(?<hc>(HC|SUBBED)))\b",
-                                                        RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.IgnorePatternWhitespace);
+                                                        RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.IgnorePatternWhitespace,
+                                                        RegexDefaults.Timeout);
 
         private static readonly RegexReplace[] PreSubstitutionRegex = Array.Empty<RegexReplace>();
 
@@ -31,217 +33,239 @@ namespace NzbDrone.Core.Parser
             // Site - Performers - Title (Month DD, YYYY) [Quality]
             // Pure Taboo - Sarah Arabic, Lily LaBeau - A Costly Divorce (June 24, 2025) [1080p HEVC x265]
             new Regex(@"^(?<studiotitle>[^-]+?)(?<releasetoken>\s*-\s*.+?)\s*\(\s*(?<airmonthname>January|February|March|April|May|June|July|August|September|October|November|December)\s+(?<airday>[0-3]?\d),?\s+(?<airyear>(19|20)\d{2})\s*\)",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+                RegexOptions.IgnoreCase | RegexOptions.Compiled,
+                RegexDefaults.Timeout),
 
             // [Site] Title - Performers (yyyy-mm-dd) [Quality]
             // [BellesaFilms] The Sister - Ashley Lane, Mannie Coco (2025-09-28) [2160p]
             new Regex(@"^\[(?<studiotitle>[^\]]+)]\s+(?<releasetoken>.+?)\s*\(\s*.*?(?<airyear>\d{4})-(?<airmonth>\d{2})-(?<airday>\d{2})\)(?:\s+\[(?<quality>\d+p)])?",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+                RegexOptions.IgnoreCase | RegexOptions.Compiled,
+                RegexDefaults.Timeout),
 
             // SCENE - Site title in brackets with full year in date then episode info
             // [Blacked] - 2025-11-24 - BBC-Queen Violet Takes On Three Cocks - Violet Myers - 1080p
             new Regex(@"^\[(?<studiotitle>.+?)\][-_. ]{1,3}(?<airyear>(?:19|20)\d{2})[-_. ]+(?<airmonth>[0-1][0-9])[-_. ]+(?<airday>[0-3][0-9])(?:[-_. ]+)?(?<releasetoken>.+)",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+                RegexOptions.IgnoreCase | RegexOptions.Compiled,
+                RegexDefaults.Timeout),
 
             // SCENE - Site title in brackets or parentheses, date after title and performer
             // [Site] Beautiful Episode - Loli - 2023-07-22 - 1080p
             // [Deeper] Key Mistress - Jessi Rae - 2025-12-18 - 1080p
             // (Studio) Title - Performer - 2025-12-18 - 1080p
             new Regex("^(\\[|\\()(?<studiotitle>.+?)(\\]|\\))(?<releasetoken>.+?)(?:( - |\\s)(\\[|\\()?(?<airyear>(19|20)\\d{2})[-_.](?<airmonth>[0-1][0-9])[-_.](?<airday>[0-3][0-9])(\\]|\\))?)",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+                RegexOptions.IgnoreCase | RegexOptions.Compiled,
+                RegexDefaults.Timeout),
 
             // (?P<site>.+?)?[\s\.\-](?P<date>\d{2}[\s\.\-]\d{2}[\s\.\-]\d{2})[\s\.\-](?P<performer>\w+.+?)?[\s\.\-](?P<title>.*?(?=(?:[\s\.\-]mp4)|$))
             // SCENE with airdate (18.04.28, 2018.04.28, 18-04-28, 18 04 28, 18_04_28) and performer
             new Regex(@"^(?<studiotitle>.+?)?[-_. ]+(?<airyear>\d{2}|\d{4})[-_. ]+(?<airmonth>[0-1][0-9])[-_. ]+(?<airday>[0-3][0-9])[-_. ]+(?<performer>\w+.+?)?[-_. ](?<title>.*?(?=(?:[-_. ]mp4)|$))",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+                RegexOptions.IgnoreCase | RegexOptions.Compiled,
+                RegexDefaults.Timeout),
 
             // SCENE - Site title in brackets with full year in date then episode info
             // [Site] 19-07-2023 - Loli - Beautiful Episode 2160p {RlsGroup}
             new Regex("^\\[(?<studiotitle>.+?)\\][-_. ]+(?<airday>[0-3][0-9])(?![-_. ]+[0-3][0-9])?[-_. ]+(?<airmonth>[0-1][0-9])[-_. ]+(?<airyear>(19|20)\\d{2})",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+                RegexOptions.IgnoreCase | RegexOptions.Compiled,
+                RegexDefaults.Timeout),
 
             // SCENE - Site title in brackets, date after title and performer
             // [Site] Beautiful Episode - Loli - 2023-07-22 - 1080p
             new Regex("^\\[(?<studiotitle>.+?)\\](?<releasetoken>.+?)(?:( - |\\s)(\\[|\\()?(?<airyear>(19|20)\\d{2})[-_.](?<airmonth>[0-1][0-9])[-_.](?<airday>[0-3][0-9])(\\]|\\))?)",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+                RegexOptions.IgnoreCase | RegexOptions.Compiled,
+                RegexDefaults.Timeout),
 
             // SCENE with non-separated airdate after title (20180428)
             new Regex(@"^(?<studiotitle>.+?)?[-_. ]+(?<airyear>(19|20)\d{2})(?<airmonth>[0-1][0-9])(?<airday>[0-3][0-9])",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+                RegexOptions.IgnoreCase | RegexOptions.Compiled,
+                RegexDefaults.Timeout),
 
             // SCENE with airdate after title [studio] title (dd.mm.yyyy)
             new Regex(@"\[(?<studiotitle>.+?)\]+[-_. ]+(?<releasetoken>.+?)(?<airday>[0-3][0-9])\.(?<airmonth>[0-1][0-9])\.(?<airyear>(19|20)\d{2})\)",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+                RegexOptions.IgnoreCase | RegexOptions.Compiled,
+                RegexDefaults.Timeout),
 
             // SCENE with airdate after title studio - title (dd.mm.yyyy)
             // StudioName-Performer.Name-ID.429.[19.10.2025].1080p-XXX
             // StudioName-Performer.Name-ID.429.(19.10.2025).1080p-XXX
             new Regex(@"(?<studiotitle>.+?)?[-]+(?<releasetoken>.+?)(?:\[|\()(?<airday>[0-3][0-9])\.(?<airmonth>[0-1][0-9])\.(?<airyear>(19|20)\d{2})(?:\)|\])",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+                RegexOptions.IgnoreCase | RegexOptions.Compiled,
+                RegexDefaults.Timeout),
 
             // SCENE with airdate (18.04.28, 2018.04.28, 18-04-28, 18 04 28, 18_04_28)
             new Regex(@"^(?<studiotitle>.+?)?[-_. ]+(?<airyear>\d{2}|\d{4})[-_. ]+(?<airmonth>[0-1][0-9])[-_. ]+(?<airday>[0-3][0-9])",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+                RegexOptions.IgnoreCase | RegexOptions.Compiled,
+                RegexDefaults.Timeout),
 
             // SCENE with airdate before title (2018-10-12, 20181012) (Strict pattern to avoid false matches)
             new Regex(@"^(?<airyear>19[6-9]\d|20\d{2})[-_]?(?<airmonth>[0-1][0-9])[-_]?(?<airday>[0-3][0-9])",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+                RegexOptions.IgnoreCase | RegexOptions.Compiled,
+                RegexDefaults.Timeout),
 
             // SCENE with airdate after title [studio] title [dd.mm.yyyy
             new Regex(@"\[(?<studiotitle>.+?)\](?<releasetoken>.+?)\[(?<airday>[0-3][0-9])(?![-_\/. ]+[0-3][0-9])?[-_\/. ]+(?<airmonth>[0-1][0-9])[-_\/. ]+(?<airyear>(19|20)\d{2})",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+                RegexOptions.IgnoreCase | RegexOptions.Compiled,
+                RegexDefaults.Timeout),
 
             // SCENE with airdate after title [studio] title yyyy-mm-dd
             new Regex(@"\[(?<studiotitle>.+?)\](?<releasetoken>.+?)((?<airyear>\d{2}|\d{4})[-_.](?<airmonth>[0-1][0-9])[-_.](?<airday>[0-3][0-9]))",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+                RegexOptions.IgnoreCase | RegexOptions.Compiled,
+                RegexDefaults.Timeout),
 
             // SCENE with Episode numbers after studio E1234 title
             new Regex(@"\[(?<studiotitle>.+?)?\].?[(]+(?<episode>[eE]+\d{1,6})?[\)]",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+                RegexOptions.IgnoreCase | RegexOptions.Compiled,
+                RegexDefaults.Timeout),
 
             // Some german or french tracker formats (missing year, ...) (Only applies to german and TrueFrench releases) - see ParserFixture for examples and tests - french removed as it broke all movies w/ french titles
-            new Regex(@"^(?<title>(?![(\[]).+?)((\W|_))(" + EditionRegex + @".{1,3})?(?:(?<!(19|20)\d{2}.*?)(?<!(?:Good|The)[_ .-])(German|TrueFrench))(.+?)(?=((19|20)\d{2}|$))(?<year>(19|20)\d{2}(?!p|i|\d+|\]|\W\d+))?(\W+|_|$)(?!\\)", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+            new Regex(@"^(?<title>(?![(\[]).+?)((\W|_))(" + EditionRegex + @".{1,3})?(?:(?<!(19|20)\d{2}.*?)(?<!(?:Good|The)[_ .-])(German|TrueFrench))(.+?)(?=((19|20)\d{2}|$))(?<year>(19|20)\d{2}(?!p|i|\d+|\]|\W\d+))?(\W+|_|$)(?!\\)", RegexOptions.IgnoreCase | RegexOptions.Compiled, RegexDefaults.Timeout),
 
             // Special, Despecialized, etc. Edition Movies, e.g: Mission.Impossible.3.Special.Edition.2011
             new Regex(@"^(?<title>(?![(\[]).+?)?(?:(?:[-_\W](?<![)\[!]))*" + EditionRegex + @".{1,3}(?<year>(1(8|9)|20)\d{2}(?!p|i|\d+|\]|\W\d+)))+(\W+|_|$)(?!\\)",
-                          RegexOptions.IgnoreCase | RegexOptions.Compiled),
+                          RegexOptions.IgnoreCase | RegexOptions.Compiled,
+                          RegexDefaults.Timeout),
 
             // MOVIE format, e.g: Studio.2024.Title.1080p-VERIFIED
-            new Regex(@"^(?<studio>(?![(\[]).+?)?(?:(?:[-_\W](?<![)\[!]))*(?<year>(1(8|9)|20)\d{2}(?!p|i|(1(8|9)|20)\d{2}|\]|\W(1(8|9)|20)\d{2})))+(\W+|_|$)(?!\\)(?<title>.*)\-VERIFIED", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+            new Regex(@"^(?<studio>(?![(\[]).+?)?(?:(?:[-_\W](?<![)\[!]))*(?<year>(1(8|9)|20)\d{2}(?!p|i|(1(8|9)|20)\d{2}|\]|\W(1(8|9)|20)\d{2})))+(\W+|_|$)(?!\\)(?<title>.*)\-VERIFIED", RegexOptions.IgnoreCase | RegexOptions.Compiled, RegexDefaults.Timeout),
 
             // MOVIE format, e.g: [Studio] Title [2024]
-            new Regex(@"^(?:\[(?<studio>.+?)\][-_. ]?)(?<title>.*)(\[(?<year>(1(8|9)|20)\d{2})\])", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+            new Regex(@"^(?:\[(?<studio>.+?)\][-_. ]?)(?<title>.*)(\[(?<year>(1(8|9)|20)\d{2})\])", RegexOptions.IgnoreCase | RegexOptions.Compiled, RegexDefaults.Timeout),
 
             // MOVIE Oil Explosion 3 (Elegant Angel) XXX DVDRip NEW 2018
-            new Regex(@"^(?<title>(?![(\[]).+?)(\W+|_|$)\(.+\).+?(XXX)*(?<year>(1(8|9)|20)\d{2}(?!p|i|(1(8|9)|20)\d{2}|\]|\W(1(8|9)|20)\d{2}))", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+            new Regex(@"^(?<title>(?![(\[]).+?)(\W+|_|$)\(.+\).+?(XXX)*(?<year>(1(8|9)|20)\d{2}(?!p|i|(1(8|9)|20)\d{2}|\]|\W(1(8|9)|20)\d{2}))", RegexOptions.IgnoreCase | RegexOptions.Compiled, RegexDefaults.Timeout),
 
             // Normal movie format, e.g: Mission.Impossible.3.2011
-            new Regex(@"^(?<title>(?![(\[]).+?)?(?:(?:[-_\W](?<![)\[!]))*(?<year>(1(8|9)|20)\d{2}(?!p|i|(1(8|9)|20)\d{2}|\]|\W(1(8|9)|20)\d{2})))+(\W+|_|$)(?!\\)", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+            new Regex(@"^(?<title>(?![(\[]).+?)?(?:(?:[-_\W](?<![)\[!]))*(?<year>(1(8|9)|20)\d{2}(?!p|i|(1(8|9)|20)\d{2}|\]|\W(1(8|9)|20)\d{2})))+(\W+|_|$)(?!\\)", RegexOptions.IgnoreCase | RegexOptions.Compiled, RegexDefaults.Timeout),
 
             // PassThePopcorn Torrent names: Star.Wars[PassThePopcorn]
-            new Regex(@"^(?<title>.+?)?(?:(?:[-_\W](?<![()\[!]))*(?<year>(\[\w *\])))+(\W+|_|$)(?!\\)", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+            new Regex(@"^(?<title>.+?)?(?:(?:[-_\W](?<![()\[!]))*(?<year>(\[\w *\])))+(\W+|_|$)(?!\\)", RegexOptions.IgnoreCase | RegexOptions.Compiled, RegexDefaults.Timeout),
 
             // That did not work? Maybe some tool uses [] for years. Who would do that?
-            new Regex(@"^(?<title>(?![(\[]).+?)?(?:(?:[-_\W](?<![)!]))*(?<year>(1(8|9)|20)\d{2}(?!p|i|\d+|\W\d+)))+(\W+|_|$)(?!\\)", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+            new Regex(@"^(?<title>(?![(\[]).+?)?(?:(?:[-_\W](?<![)!]))*(?<year>(1(8|9)|20)\d{2}(?!p|i|\d+|\W\d+)))+(\W+|_|$)(?!\\)", RegexOptions.IgnoreCase | RegexOptions.Compiled, RegexDefaults.Timeout),
 
             // SCENE with Episode numbers after studio E1234 title
             new Regex(@"(?<studiotitle>.+?)?[-_. ]+(?<episode>[eE]+\d{1,6})",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+                RegexOptions.IgnoreCase | RegexOptions.Compiled,
+                RegexDefaults.Timeout),
 
             // As a last resort for movies that have ( or [ in their title.
-            new Regex(@"^(?<title>.+?)?(?:(?:[-_\W](?<![)\[!]))*(?<year>(1(8|9)|20)\d{2}(?!p|i|\d+|\]|\W\d+)))+(\W+|_|$)(?!\\)", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+            new Regex(@"^(?<title>.+?)?(?:(?:[-_\W](?<![)\[!]))*(?<year>(1(8|9)|20)\d{2}(?!p|i|\d+|\]|\W\d+)))+(\W+|_|$)(?!\\)", RegexOptions.IgnoreCase | RegexOptions.Compiled, RegexDefaults.Timeout),
 
-            new Regex(@"^(?<title>(?![(\[]).+?)?(XXX)(\W+|_|$)(?!\\)", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+            new Regex(@"^(?<title>(?![(\[]).+?)?(XXX)(\W+|_|$)(?!\\)", RegexOptions.IgnoreCase | RegexOptions.Compiled, RegexDefaults.Timeout),
 
             // StashId
-            new Regex(@"(?<stashid>.{8}-.{4}-.{4}-.{4}-.{12})", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+            new Regex(@"(?<stashid>.{8}-.{4}-.{4}-.{4}-.{12})", RegexOptions.IgnoreCase | RegexOptions.Compiled, RegexDefaults.Timeout),
 
             // JAV
-            new Regex(@"^(?<code>[A-Z]{2,5}[- ][0-9]{3,5})", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+            new Regex(@"^(?<code>[A-Z]{2,5}[- ][0-9]{3,5})", RegexOptions.IgnoreCase | RegexOptions.Compiled, RegexDefaults.Timeout),
 
             // JAV-FC2
-            new Regex(@"(?<code>FC2.*(?:PPV).*[0-9]{4,7})", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+            new Regex(@"(?<code>FC2.*(?:PPV).*[0-9]{4,7})", RegexOptions.IgnoreCase | RegexOptions.Compiled, RegexDefaults.Timeout),
 
             // JAV code after leading tracker/tag blocks
-            new Regex(@"^(?:[\s._+\-]*(?:\[[^\]]+\]|\([^)]+\)|\{[^}]+\}))+[\s._+\-]*(?<code>[A-Z]{2,5}-[0-9]{3,5})(?=[A-Z]?(?:$|[\s._+\-\[\]\(\)\{\}]))", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+            new Regex(@"^(?:[\s._+\-]*(?:\[[^\]]+\]|\([^)]+\)|\{[^}]+\}))+[\s._+\-]*(?<code>[A-Z]{2,5}-[0-9]{3,5})(?=[A-Z]?(?:$|[\s._+\-\[\]\(\)\{\}]))", RegexOptions.IgnoreCase | RegexOptions.Compiled, RegexDefaults.Timeout),
 
             // Pattern for IDs in brackets like [SKMJ-649], (ABC-123), {XYZ-456}, [SKMJ_649], [SKMJ.649]
-            new Regex(@"[\[\(\{](?<code>[A-Z]{2,5}[- _.][0-9]{3,5})[\]\)\}]", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+            new Regex(@"[\[\(\{](?<code>[A-Z]{2,5}[- _.][0-9]{3,5})[\]\)\}]", RegexOptions.IgnoreCase | RegexOptions.Compiled, RegexDefaults.Timeout),
 
             // Final check that it is a video
-            new Regex(@"^(?<title>.+?)?(480|540|576|720|1080|2160)p", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+            new Regex(@"^(?<title>.+?)?(480|540|576|720|1080|2160)p", RegexOptions.IgnoreCase | RegexOptions.Compiled, RegexDefaults.Timeout),
         };
 
         private static readonly Regex[] ReportTitleFolderRegex = new[]
         {
             // When year comes first.
-            new Regex(@"^(?:(?:[-_\W](?<![)!]))*(?<year>(19|20)\d{2}(?!p|i|\d+|\W\d+)))+(\W+|_|$)(?<title>.+?)?$")
+            new Regex(@"^(?:(?:[-_\W](?<![)!]))*(?<year>(19|20)\d{2}(?!p|i|\d+|\W\d+)))+(\W+|_|$)(?<title>.+?)?$", RegexOptions.None, RegexDefaults.Timeout)
         };
 
         private static readonly Regex[] RejectHashedReleasesRegex = new Regex[]
             {
                 // Generic match for md5 and mixed-case hashes.
-                new Regex(@"^[0-9a-zA-Z]{32}", RegexOptions.Compiled),
+                new Regex(@"^[0-9a-zA-Z]{32}", RegexOptions.Compiled, RegexDefaults.Timeout),
 
                 // Generic match for shorter lower-case hashes.
-                new Regex(@"^[a-z0-9]{24}$", RegexOptions.Compiled),
+                new Regex(@"^[a-z0-9]{24}$", RegexOptions.Compiled, RegexDefaults.Timeout),
 
                 // Format seen on some NZBGeek releases
                 // Be very strict with these coz they are very close to the valid 101 ep numbering.
-                new Regex(@"^[A-Z]{11}\d{3}$", RegexOptions.Compiled),
-                new Regex(@"^[a-z]{12}\d{3}$", RegexOptions.Compiled),
+                new Regex(@"^[A-Z]{11}\d{3}$", RegexOptions.Compiled, RegexDefaults.Timeout),
+                new Regex(@"^[a-z]{12}\d{3}$", RegexOptions.Compiled, RegexDefaults.Timeout),
 
                 // Backup filename (Unknown origins)
-                new Regex(@"^Backup_\d{5,}S\d{2}-\d{2}$", RegexOptions.Compiled),
+                new Regex(@"^Backup_\d{5,}S\d{2}-\d{2}$", RegexOptions.Compiled, RegexDefaults.Timeout),
 
                 // 123 - Started appearing December 2014
-                new Regex(@"^123$", RegexOptions.Compiled),
+                new Regex(@"^123$", RegexOptions.Compiled, RegexDefaults.Timeout),
 
                 // abc - Started appearing January 2015
-                new Regex(@"^abc$", RegexOptions.Compiled | RegexOptions.IgnoreCase),
+                new Regex(@"^abc$", RegexOptions.Compiled | RegexOptions.IgnoreCase, RegexDefaults.Timeout),
 
                 // abc - Started appearing 2020
-                new Regex(@"^abc[-_. ]xyz", RegexOptions.Compiled | RegexOptions.IgnoreCase),
+                new Regex(@"^abc[-_. ]xyz", RegexOptions.Compiled | RegexOptions.IgnoreCase, RegexDefaults.Timeout),
 
                 // b00bs - Started appearing January 2015
-                new Regex(@"^b00bs$", RegexOptions.Compiled | RegexOptions.IgnoreCase)
+                new Regex(@"^b00bs$", RegexOptions.Compiled | RegexOptions.IgnoreCase, RegexDefaults.Timeout)
             };
 
         // Regex to detect whether the title was reversed.
-        private static readonly Regex ReversedTitleRegex = new Regex(@"(?:^|[-._ ])(p027|p0801)[-._ ]", RegexOptions.Compiled);
+        private static readonly Regex ReversedTitleRegex = new Regex(@"(?:^|[-._ ])(p027|p0801)[-._ ]", RegexOptions.Compiled, RegexDefaults.Timeout);
 
         // Regex to split movie titles that contain `AKA`.
-        private static readonly Regex AlternativeTitleRegex = new Regex(@"[ ]+(?:AKA|\/)[ ]+", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        private static readonly Regex AlternativeTitleRegex = new Regex(@"[ ]+(?:AKA|\/)[ ]+", RegexOptions.IgnoreCase | RegexOptions.Compiled, RegexDefaults.Timeout);
 
         // Regex to unbracket alternative titles.
-        private static readonly Regex BracketedAlternativeTitleRegex = new Regex(@"(.*) \([ ]*AKA[ ]+(.*)\)", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        private static readonly Regex BracketedAlternativeTitleRegex = new Regex(@"(.*) \([ ]*AKA[ ]+(.*)\)", RegexOptions.IgnoreCase | RegexOptions.Compiled, RegexDefaults.Timeout);
 
-        private static readonly Regex NormalizeAlternativeTitleRegex = new Regex(@"[ ]+(?:A\.K\.A\.)[ ]+", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        private static readonly Regex NormalizeAlternativeTitleRegex = new Regex(@"[ ]+(?:A\.K\.A\.)[ ]+", RegexOptions.IgnoreCase | RegexOptions.Compiled, RegexDefaults.Timeout);
 
         private static readonly Regex NormalizeRegex = new Regex(@"((?:\b|_)(?<!^|[^a-zA-Z0-9_']\w[^a-zA-Z0-9_'])([aà](?!$|[^a-zA-Z0-9_']\w[^a-zA-Z0-9_'])|an|the|and|or|of)(?!$)(?:\b|_))|\W|_",
-                                                                RegexOptions.IgnoreCase | RegexOptions.Compiled);
+                                                                RegexOptions.IgnoreCase | RegexOptions.Compiled,
+                                                                RegexDefaults.Timeout);
 
-        private static readonly Regex ReportImdbId = new Regex(@"(?<imdbid>tt\d{7,8})", RegexOptions.IgnoreCase | RegexOptions.Compiled);
-        private static readonly Regex ReportTmdbId = new Regex(@"tmdb(id)?-(?<tmdbid>\d+)", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        private static readonly Regex ReportImdbId = new Regex(@"(?<imdbid>tt\d{7,8})", RegexOptions.IgnoreCase | RegexOptions.Compiled, RegexDefaults.Timeout);
+        private static readonly Regex ReportTmdbId = new Regex(@"tmdb(id)?-(?<tmdbid>\d+)", RegexOptions.IgnoreCase | RegexOptions.Compiled, RegexDefaults.Timeout);
 
         private static readonly RegexReplace SimpleTitleRegex = new RegexReplace(@"(?:(480|540|576|720|1080|2160)[ip]|[xh][\W_]?26[45]|DD\W?5\W1|[<>?*]|848x480|1280x720|1920x1080|3840x2160|4096x2160|(8|10)b(it)?|10-bit)\s*?(?![a-b0-9])",
                                                                 string.Empty,
                                                                 RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
         private static readonly Regex SpecialEpisodeTitleRegex = new Regex(@"(?<episodetitle>.+?)(?:\[.*(?:480p|720p|1080p|2160p|HDTV|WEB|WEBRip|WEB-?DL).*\]|[. ]XXX[. ](?:480p|720p|1080p|2160p|HDTV|WEB|WEBRip|WEB-?DL).*|(?:480p|720p|1080p|2160p|HDTV|WEB|WEBRip|WEB-?DL)|$)",
-                          RegexOptions.Compiled);
+                          RegexOptions.Compiled,
+                          RegexDefaults.Timeout);
 
         // Marks where the release tag block starts, so masking the scene title out of the simple
         // release title can't reach into the quality, codec and release group behind it.
         private static readonly Regex ReleaseTagBoundaryRegex = new Regex(@"[-_. ](?:XXX|\d{3,4}[ip]|WEB[-_. ]?DL|WEBRip|WEB|BluRay|BDRip|BRRip|DVDRip|DVD|HDTV|HDRip|SDTV|SD|HEVC|AVC|AV1|VP9|XviD|DivX|[xh][-_. ]?26[45]|AAC|AC3|DTS|MP3|mp4|mkv|avi|wmv|m4v)(?![a-z0-9])",
-                                                                         RegexOptions.IgnoreCase | RegexOptions.Compiled);
+                                                                         RegexOptions.IgnoreCase | RegexOptions.Compiled,
+                                                                         RegexDefaults.Timeout);
 
-        private static readonly Regex StashIdRegex = new Regex(@"(?<stashid>.{8}-.{4}-.{4}-.{4}-.{12})", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        private static readonly Regex StashIdRegex = new Regex(@"(?<stashid>.{8}-.{4}-.{4}-.{4}-.{12})", RegexOptions.IgnoreCase | RegexOptions.Compiled, RegexDefaults.Timeout);
 
-        private static readonly Regex SimpleReleaseTitleRegex = new Regex(@"\s*(?:[<>?*|])", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private static readonly Regex SimpleReleaseTitleRegex = new Regex(@"\s*(?:[<>?*|])", RegexOptions.Compiled | RegexOptions.IgnoreCase, RegexDefaults.Timeout);
 
         // Valid TLDs http://data.iana.org/TLD/tlds-alpha-by-domain.txt
 
         private static readonly Regex CleanQualityBracketsRegex = new Regex(@"\[[a-z0-9 ._-]+\]$",
-                                                                   RegexOptions.IgnoreCase | RegexOptions.Compiled);
+                                                                   RegexOptions.IgnoreCase | RegexOptions.Compiled,
+                                                                   RegexDefaults.Timeout);
 
         private static readonly Regex YearInTitleRegex = new Regex(@"^(?<title>.+?)(?:\W|_.)?[\(\[]?(?<year>\d{4})[\]\)]?",
-                                                                RegexOptions.IgnoreCase | RegexOptions.Compiled);
+                                                                RegexOptions.IgnoreCase | RegexOptions.Compiled,
+                                                                RegexDefaults.Timeout);
 
-        private static readonly Regex SpecialCharRegex = new Regex(@"(\&|\:|\\|\/)+", RegexOptions.Compiled);
-        private static readonly Regex PunctuationRegex = new Regex(@"[^\w\s]", RegexOptions.Compiled);
-        private static readonly Regex ArticleWordRegex = new Regex(@"^(a|an|the)\s", RegexOptions.IgnoreCase | RegexOptions.Compiled);
-        private static readonly Regex SpecialEpisodeWordRegex = new Regex(@"\b(part|special|edition|christmas)\b\s?", RegexOptions.IgnoreCase | RegexOptions.Compiled);
-        private static readonly Regex DuplicateSpacesRegex = new Regex(@"\s{2,}", RegexOptions.Compiled);
-        private static readonly Regex NamerDuplicateRegex = new Regex(@"_\d$", RegexOptions.Compiled);
+        private static readonly Regex SpecialCharRegex = new Regex(@"(\&|\:|\\|\/)+", RegexOptions.Compiled, RegexDefaults.Timeout);
+        private static readonly Regex PunctuationRegex = new Regex(@"[^\w\s]", RegexOptions.Compiled, RegexDefaults.Timeout);
+        private static readonly Regex ArticleWordRegex = new Regex(@"^(a|an|the)\s", RegexOptions.IgnoreCase | RegexOptions.Compiled, RegexDefaults.Timeout);
+        private static readonly Regex SpecialEpisodeWordRegex = new Regex(@"\b(part|special|edition|christmas)\b\s?", RegexOptions.IgnoreCase | RegexOptions.Compiled, RegexDefaults.Timeout);
+        private static readonly Regex DuplicateSpacesRegex = new Regex(@"\s{2,}", RegexOptions.Compiled, RegexDefaults.Timeout);
+        private static readonly Regex NamerDuplicateRegex = new Regex(@"_\d$", RegexOptions.Compiled, RegexDefaults.Timeout);
 
-        private static readonly Regex EmojiRegex = new Regex(@"\p{Cs}", RegexOptions.Compiled);
-        private static readonly Regex UniCodeRegex = new Regex(@"[^\u0000-\u007F]+", RegexOptions.Compiled);
+        private static readonly Regex EmojiRegex = new Regex(@"\p{Cs}", RegexOptions.Compiled, RegexDefaults.Timeout);
+        private static readonly Regex UniCodeRegex = new Regex(@"[^\u0000-\u007F]+", RegexOptions.Compiled, RegexDefaults.Timeout);
 
-        private static readonly Regex RequestInfoRegex = new Regex(@"^(?:\[.+?\])+", RegexOptions.Compiled);
+        private static readonly Regex RequestInfoRegex = new Regex(@"^(?:\[.+?\])+", RegexOptions.Compiled, RegexDefaults.Timeout);
 
         // Strips domain suffixes (Site.com -> Site) anywhere in the studio token, not just the trailing one.
-        private static readonly Regex StudioDomainSuffixRegex = new Regex(@"\.(com|net|org|tv|xxx|co|io)\b", RegexOptions.IgnoreCase | RegexOptions.Compiled, TimeSpan.FromSeconds(5));
+        private static readonly Regex StudioDomainSuffixRegex = new Regex(@"\.(com|net|org|tv|xxx|co|io)\b", RegexOptions.IgnoreCase | RegexOptions.Compiled, RegexDefaults.Timeout);
 
         private static readonly string[] Numbers = new[] { "zero", "one", "two", "three", "four", "five", "six", "seven", "eight", "nine" };
         private static Dictionary<string, string> _umlautMappings = new Dictionary<string, string>
@@ -550,7 +574,7 @@ namespace NzbDrone.Core.Parser
 
         public static string NormalizeImdbId(string imdbId)
         {
-            var imdbRegex = new Regex(@"^(\d{1,10}|(tt)\d{1,10})$");
+            var imdbRegex = new Regex(@"^(\d{1,10}|(tt)\d{1,10})$", RegexOptions.None, RegexDefaults.Timeout);
 
             if (!imdbRegex.IsMatch(imdbId))
             {
@@ -575,13 +599,13 @@ namespace NzbDrone.Core.Parser
             value = value.RemoveAccent();
 
             // Replace spaces
-            value = Regex.Replace(value, @"\s", "-", RegexOptions.Compiled);
+            value = Regex.Replace(value, @"\s", "-", RegexOptions.Compiled, RegexDefaults.Timeout);
 
             // Should invalid characters be replaced with dash or empty string?
             var replaceCharacter = invalidDashReplacement ? "-" : string.Empty;
 
             // Remove invalid chars
-            value = Regex.Replace(value, @"[^a-z0-9\s-_]", replaceCharacter, RegexOptions.Compiled);
+            value = Regex.Replace(value, @"[^a-z0-9\s-_]", replaceCharacter, RegexOptions.Compiled, RegexDefaults.Timeout);
 
             // Trim dashes or underscores from end, or user defined character set
             if (!string.IsNullOrEmpty(trimEndChars))
@@ -592,7 +616,7 @@ namespace NzbDrone.Core.Parser
             // Replace double occurrences of - or _, or user defined character set
             if (!string.IsNullOrEmpty(deduplicateChars))
             {
-                value = Regex.Replace(value, @"([" + deduplicateChars + "]){2,}", "$1", RegexOptions.Compiled);
+                value = Regex.Replace(value, @"([" + deduplicateChars + "]){2,}", "$1", RegexOptions.Compiled, RegexDefaults.Timeout);
             }
 
             return value;
@@ -716,7 +740,7 @@ namespace NzbDrone.Core.Parser
             // (\d+)         : Capturing group for the actual number
             var pattern = @"\s+(?:Volume|Vol\.?)\s+#?0*(\d+)";
             var replacement = " $1";
-            title = Regex.Replace(title, pattern, replacement);
+            title = Regex.Replace(title, pattern, replacement, RegexOptions.None, RegexDefaults.Timeout);
 
             return NormalizeTitle(title);
         }

--- a/src/NzbDrone.Core/Parser/QualityParser.cs
+++ b/src/NzbDrone.Core/Parser/QualityParser.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
 using NLog;
+using NzbDrone.Common;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Common.Instrumentation;
 using NzbDrone.Core.MediaFiles;
@@ -89,7 +90,7 @@ namespace NzbDrone.Core.Parser
         private static readonly Regex HighDefPdtvRegex = new (@"hr[-_. ]ws", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         private static readonly Regex RemuxRegex = new (@"(?:[_. \[]|\d{4}p-|\bHybrid-)(?<remux>(?:(BD|UHD)[-_. ]?)?Remux)\b|(?<remux>(?:(BD|UHD)[-_. ]?)?Remux[_. ]\d{4}p)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
-        private static readonly Regex GermanRemuxRegex = new Regex(@"((?<=\d{4}).*German.*([DM]L)?)(?=.*\b(AVC|HEVC|VC[_. -]?1|MVC|MPEG[_. -]?2))(?=.*Blu-?ray)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private static readonly Regex GermanRemuxRegex = new Regex(@"((?<=\d{4}).*German.*([DM]L)?)(?=.*\b(AVC|HEVC|VC[_. -]?1|MVC|MPEG[_. -]?2))(?=.*Blu-?ray)", RegexOptions.Compiled | RegexOptions.IgnoreCase, RegexDefaults.Timeout);
 
         public static QualityModel ParseQuality(string name)
         {

--- a/src/NzbDrone.Core/Parser/RegexReplace.cs
+++ b/src/NzbDrone.Core/Parser/RegexReplace.cs
@@ -1,4 +1,5 @@
 using System.Text.RegularExpressions;
+using NzbDrone.Common;
 
 namespace NzbDrone.Core.Parser
 {
@@ -10,13 +11,13 @@ namespace NzbDrone.Core.Parser
 
         public RegexReplace(string pattern, string replacement, RegexOptions regexOptions)
         {
-            _regex = new Regex(pattern, regexOptions);
+            _regex = new Regex(pattern, regexOptions, RegexDefaults.Timeout);
             _replacementFormat = replacement;
         }
 
         public RegexReplace(string pattern, MatchEvaluator replacement, RegexOptions regexOptions)
         {
-            _regex = new Regex(pattern, regexOptions);
+            _regex = new Regex(pattern, regexOptions, RegexDefaults.Timeout);
             _replacementFunc = replacement;
         }
 

--- a/src/NzbDrone.Core/Profiles/Releases/PerlRegexFactory.cs
+++ b/src/NzbDrone.Core/Profiles/Releases/PerlRegexFactory.cs
@@ -1,11 +1,12 @@
 using System;
 using System.Text.RegularExpressions;
+using NzbDrone.Common;
 
 namespace NzbDrone.Core.Profiles.Releases
 {
     public static class PerlRegexFactory
     {
-        private static Regex _perlRegexFormat = new Regex(@"/(?<pattern>.*)/(?<modifiers>[a-z]*)", RegexOptions.Compiled);
+        private static Regex _perlRegexFormat = new Regex(@"/(?<pattern>.*)/(?<modifiers>[a-z]*)", RegexOptions.Compiled, RegexDefaults.Timeout);
 
         public static bool TryCreateRegex(string pattern, out Regex regex)
         {
@@ -26,7 +27,7 @@ namespace NzbDrone.Core.Profiles.Releases
             var options = GetOptions(modifiers);
 
             // For now we simply expect the pattern to be .net compliant. We should probably check and reject perl-specific constructs.
-            return new Regex(pattern, options | RegexOptions.Compiled);
+            return new Regex(pattern, options | RegexOptions.Compiled, RegexDefaults.Timeout);
         }
 
         private static RegexOptions GetOptions(string modifiers)

--- a/src/NzbDrone.Core/RootFolders/RootFolderService.cs
+++ b/src/NzbDrone.Core/RootFolders/RootFolderService.cs
@@ -54,8 +54,8 @@ namespace NzbDrone.Core.RootFolders
                                                                      "@eadir",
                                                                      ".grab"
                                                                  };
-        private static readonly Regex ExcludedSubFoldersRegex = new Regex(@"(?:\\|\/|^)(?:@eadir|\.@__thumb|plex versions|\.[^\\/]+)(?:\\|\/)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
-        private static readonly Regex ExcludedFilesRegex = new Regex(@"^\._|^Thumbs\.db$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private static readonly Regex ExcludedSubFoldersRegex = new Regex(@"(?:\\|\/|^)(?:@eadir|\.@__thumb|plex versions|\.[^\\/]+)(?:\\|\/)", RegexOptions.Compiled | RegexOptions.IgnoreCase, RegexDefaults.Timeout);
+        private static readonly Regex ExcludedFilesRegex = new Regex(@"^\._|^Thumbs\.db$", RegexOptions.Compiled | RegexOptions.IgnoreCase, RegexDefaults.Timeout);
 
         public RootFolderService(IRootFolderRepository rootFolderRepository,
                                     IQualityProfileRepository profileRepository,

--- a/src/NzbDrone.Core/Update/GithubUpdatePackageProvider.cs
+++ b/src/NzbDrone.Core/Update/GithubUpdatePackageProvider.cs
@@ -5,6 +5,7 @@ using System.Runtime.InteropServices;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 using NLog;
+using NzbDrone.Common;
 using NzbDrone.Common.Cloud;
 using NzbDrone.Common.EnvironmentInfo;
 using NzbDrone.Common.Http;
@@ -191,7 +192,7 @@ namespace NzbDrone.Core.Update
 
                 // Attempt to strip "what's new", as it's repetitive in our UI
                 var body = release?.body != null
-                    ? Regex.Replace(release.body, @"^## What's Changed\s*\r?\n", "", RegexOptions.Multiline)
+                    ? Regex.Replace(release.body, @"^## What's Changed\s*\r?\n", "", RegexOptions.Multiline, RegexDefaults.Timeout)
                     : string.Empty;
 
                 // Strip out lines that are not New: or Fix:

--- a/src/NzbDrone.Core/Validation/Paths/MappedNetworkDriveValidator.cs
+++ b/src/NzbDrone.Core/Validation/Paths/MappedNetworkDriveValidator.cs
@@ -2,6 +2,7 @@
 using System.Text.RegularExpressions;
 using FluentValidation;
 using FluentValidation.Validators;
+using NzbDrone.Common;
 using NzbDrone.Common.Disk;
 using NzbDrone.Common.EnvironmentInfo;
 
@@ -12,7 +13,7 @@ namespace NzbDrone.Core.Validation.Paths
         private readonly IRuntimeInfo _runtimeInfo;
         private readonly IDiskProvider _diskProvider;
 
-        private static readonly Regex DriveRegex = new Regex(@"[a-z]\:\\", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private static readonly Regex DriveRegex = new Regex(@"[a-z]\:\\", RegexOptions.Compiled | RegexOptions.IgnoreCase, RegexDefaults.Timeout);
 
         public MappedNetworkDriveValidator(IRuntimeInfo runtimeInfo, IDiskProvider diskProvider)
         {

--- a/src/NzbDrone.Core/Validation/RuleBuilderExtensions.cs
+++ b/src/NzbDrone.Core/Validation/RuleBuilderExtensions.cs
@@ -1,13 +1,14 @@
 using System;
 using System.Text.RegularExpressions;
 using FluentValidation;
+using NzbDrone.Common;
 using NzbDrone.Common.Extensions;
 
 namespace NzbDrone.Core.Validation
 {
     public static class RuleBuilderExtensions
     {
-        private static readonly Regex HostRegex = new Regex("^[-_a-z0-9.]+$", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        private static readonly Regex HostRegex = new Regex("^[-_a-z0-9.]+$", RegexOptions.IgnoreCase | RegexOptions.Compiled, RegexDefaults.Timeout);
 
         public static IRuleBuilderOptions<T, int> ValidId<T>(this IRuleBuilder<T, int> ruleBuilder)
         {

--- a/src/NzbDrone.Mono/Disk/ProcMountProvider.cs
+++ b/src/NzbDrone.Mono/Disk/ProcMountProvider.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
 using NLog;
+using NzbDrone.Common;
 using NzbDrone.Common.Disk;
 using NzbDrone.Common.Extensions;
 
@@ -19,7 +20,7 @@ namespace NzbDrone.Mono.Disk
         private const string PROC_MOUNTS_FILENAME = @"/proc/mounts";
         private const string PROC_FILESYSTEMS_FILENAME = @"/proc/filesystems";
 
-        private static readonly Regex OctalRegex = new Regex(@"\\\d{3}", RegexOptions.Compiled);
+        private static readonly Regex OctalRegex = new Regex(@"\\\d{3}", RegexOptions.Compiled, RegexDefaults.Timeout);
         private readonly Logger _logger;
 
         private static string[] _fixedTypes = new[] { "ext3", "ext2", "ext4", "vfat", "fuseblk", "xfs", "jfs", "msdos", "ntfs", "minix", "hfs", "hfsplus", "qnx4", "ufs", "btrfs" };

--- a/src/NzbDrone.Mono/EnvironmentInfo/VersionAdapters/ReleaseFileVersionAdapter.cs
+++ b/src/NzbDrone.Mono/EnvironmentInfo/VersionAdapters/ReleaseFileVersionAdapter.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using System.Text.RegularExpressions;
+using NzbDrone.Common;
 using NzbDrone.Common.Disk;
 using NzbDrone.Common.EnvironmentInfo;
 
@@ -32,7 +33,7 @@ namespace NzbDrone.Mono.EnvironmentInfo.VersionAdapters
             foreach (var releaseFile in releaseFiles)
             {
                 var fileContent = _diskProvider.ReadAllText(releaseFile);
-                var lines = Regex.Split(fileContent, "\r\n|\r|\n");
+                var lines = Regex.Split(fileContent, "\r\n|\r|\n", RegexOptions.None, RegexDefaults.Timeout);
 
                 foreach (var line in lines)
                 {

--- a/src/NzbDrone.Mono/EnvironmentInfo/VersionAdapters/SynologyVersionAdapter.cs
+++ b/src/NzbDrone.Mono/EnvironmentInfo/VersionAdapters/SynologyVersionAdapter.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using System.Text.RegularExpressions;
+using NzbDrone.Common;
 using NzbDrone.Common.Disk;
 using NzbDrone.Common.EnvironmentInfo;
 
@@ -35,7 +36,7 @@ namespace NzbDrone.Mono.EnvironmentInfo.VersionAdapters
             var minor = "0";
 
             var fileContent = _diskProvider.ReadAllText(versionFile);
-            var lines = Regex.Split(fileContent, "\r\n|\r|\n");
+            var lines = Regex.Split(fileContent, "\r\n|\r|\n", RegexOptions.None, RegexDefaults.Timeout);
 
             foreach (var line in lines)
             {

--- a/src/Whisparr.Api.V3/Logs/UpdateLogFileController.cs
+++ b/src/Whisparr.Api.V3/Logs/UpdateLogFileController.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
+using NzbDrone.Common;
 using NzbDrone.Common.Disk;
 using NzbDrone.Common.EnvironmentInfo;
 using NzbDrone.Common.Extensions;
@@ -33,7 +34,7 @@ namespace Whisparr.Api.V3.Logs
             }
 
             return _diskProvider.GetFiles(_appFolderInfo.GetUpdateLogFolder(), false)
-                                     .Where(f => Regex.IsMatch(Path.GetFileName(f), LOGFILE_ROUTE.TrimStart('/'), RegexOptions.IgnoreCase))
+                                     .Where(f => Regex.IsMatch(Path.GetFileName(f), LOGFILE_ROUTE.TrimStart('/'), RegexOptions.IgnoreCase, RegexDefaults.Timeout))
                                      .ToList();
         }
 

--- a/src/Whisparr.Api.V3/MediaCovers/MediaCoverController.cs
+++ b/src/Whisparr.Api.V3/MediaCovers/MediaCoverController.cs
@@ -2,6 +2,7 @@ using System.IO;
 using System.Text.RegularExpressions;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.StaticFiles;
+using NzbDrone.Common;
 using NzbDrone.Common.Disk;
 using NzbDrone.Common.EnvironmentInfo;
 using NzbDrone.Common.Extensions;
@@ -12,7 +13,7 @@ namespace Whisparr.Api.V3.MediaCovers
     [V3ApiController]
     public class MediaCoverController : Controller
     {
-        private static readonly Regex RegexResizedImage = new Regex(@"-\d+\.jpg$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private static readonly Regex RegexResizedImage = new Regex(@"-\d+\.jpg$", RegexOptions.Compiled | RegexOptions.IgnoreCase, RegexDefaults.Timeout);
 
         private readonly IAppFolderInfo _appFolderInfo;
         private readonly IDiskProvider _diskProvider;

--- a/src/Whisparr.Http/Authentication/AuthenticationBuilderExtensions.cs
+++ b/src/Whisparr.Http/Authentication/AuthenticationBuilderExtensions.cs
@@ -4,6 +4,7 @@ using Diacritical;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.Extensions.DependencyInjection;
+using NzbDrone.Common;
 using NzbDrone.Core.Authentication;
 using NzbDrone.Core.Configuration;
 
@@ -11,7 +12,7 @@ namespace Whisparr.Http.Authentication
 {
     public static class AuthenticationBuilderExtensions
     {
-        private static readonly Regex CookieNameRegex = new Regex(@"[^a-z0-9]+", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private static readonly Regex CookieNameRegex = new Regex(@"[^a-z0-9]+", RegexOptions.Compiled | RegexOptions.IgnoreCase, RegexDefaults.Timeout);
 
         public static AuthenticationBuilder AddApiKey(this AuthenticationBuilder authenticationBuilder, string name, Action<ApiKeyAuthenticationOptions> options)
         {

--- a/src/Whisparr.Http/Frontend/Mappers/HtmlMapperBase.cs
+++ b/src/Whisparr.Http/Frontend/Mappers/HtmlMapperBase.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Text.RegularExpressions;
 using NLog;
+using NzbDrone.Common;
 using NzbDrone.Common.Disk;
 using NzbDrone.Common.EnvironmentInfo;
 
@@ -11,7 +12,7 @@ namespace Whisparr.Http.Frontend.Mappers
     {
         private readonly IDiskProvider _diskProvider;
         private readonly Lazy<ICacheBreakerProvider> _cacheBreakProviderFactory;
-        private static readonly Regex ReplaceRegex = new Regex(@"(?:(?<attribute>href|src)=\"")(?<path>.*?(?<extension>css|js|png|ico|ics|svg|json))(?:\"")(?:\s(?<nohash>data-no-hash))?", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private static readonly Regex ReplaceRegex = new Regex(@"(?:(?<attribute>href|src)=\"")(?<path>.*?(?<extension>css|js|png|ico|ics|svg|json))(?:\"")(?:\s(?<nohash>data-no-hash))?", RegexOptions.Compiled | RegexOptions.IgnoreCase, RegexDefaults.Timeout);
 
         private string _generatedContent;
 

--- a/src/Whisparr.Http/Frontend/Mappers/MediaCoverMapper.cs
+++ b/src/Whisparr.Http/Frontend/Mappers/MediaCoverMapper.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Text.RegularExpressions;
 using NLog;
+using NzbDrone.Common;
 using NzbDrone.Common.Disk;
 using NzbDrone.Common.EnvironmentInfo;
 using NzbDrone.Common.Extensions;
@@ -10,7 +11,7 @@ namespace Whisparr.Http.Frontend.Mappers
 {
     public class MediaCoverMapper : StaticResourceMapperBase
     {
-        private static readonly Regex RegexResizedImage = new Regex(@"-\d+\.jpg($|\?)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private static readonly Regex RegexResizedImage = new Regex(@"-\d+\.jpg($|\?)", RegexOptions.Compiled | RegexOptions.IgnoreCase, RegexDefaults.Timeout);
 
         private readonly IAppFolderInfo _appFolderInfo;
         private readonly IDiskProvider _diskProvider;


### PR DESCRIPTION
#### Database Migration

NO

#### Description

SonarQube raises S6444 on every `Regex` constructed, and every static `Regex` call made, without a `matchTimeout` argument. The codebase had exactly one regex that passed one, so this rule accounted for the bulk of the project's open security hotspots.

Without a timeout, a pathological pattern/input pair backtracks until it finishes, which for the release-title patterns in `Parser` can mean hanging the thread indefinitely. A timeout turns that into a bounded failure.

This adds `NzbDrone.Common.RegexDefaults.Timeout` and passes it at all 183 call sites across five assemblies:

- One shared constant rather than a per-file copy, so the value has a single place to change. An explicit argument at each call site is still required — the analyzer check is syntactic, so a process-wide `REGEX_DEFAULT_MATCH_TIMEOUT` would not close the hotspots and would leave new regexes unflagged.
- Five seconds is deliberately generous. Legitimate input matches in microseconds, so only genuine catastrophic backtracking can reach it, and a CPU-throttled host cannot trip it on a release title that would otherwise parse. A tight budget would catch the same ReDoS set while adding false-trip risk.
- Mechanical throughout — argument lists only, no pattern string is touched. Constructions with no options argument gained `RegexOptions.None`, since the overload is `(pattern, options, matchTimeout)` with no pattern+timeout form.

Two consequences worth a reviewer's attention:

- Exceeding the timeout throws `RegexMatchTimeoutException`. `ParseMovieTitle` catches broadly and degrades to "unable to parse", but the parser extension methods (`CleanMovieTitle`, `NormalizeTitle` and friends) have no guard, so a timeout there propagates to the calling task or request. At five seconds this should only be reachable via a genuine ReDoS, but it is a behaviour change: those call paths could previously only be slow, never throw.
- `NzbDroneSQLiteProcessor` uses the fully qualified name instead of a `using` directive, because importing `NzbDrone.Common` there makes `IServiceProvider` ambiguous against the `System` one.

Verification that the change is inert: normalising whitespace and stripping the added arguments reproduces the base revision of all 62 files byte-for-byte.

#### Todos

- [x] Tests — no new tests. The change adds no branch or behaviour to test; the existing suites are the regression check, and they pass unchanged (Core 4031 passed / 0 failed / 34 skipped, of which ParserTests is 1256; Common 521 passed / 0 failed, excluding the fixtures that require live network).
- [x] Translation Keys — none required, no user-facing strings.

#### Issues Fixed or Closed by this PR

None — this clears SonarQube security hotspots rather than a filed issue.
