### PR TITLE
Fix: Give Sonar a version boundary, and stop it reading binaries as source

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -9,6 +9,11 @@ on:
       - eros-develop
   workflow_dispatch:
 
+env:
+  # Keep in sync with build_v3.yml's VERSION_FALLBACK. Only used during the seed
+  # window before any vX.Y.Z tag is reachable.
+  VERSION_FALLBACK: 3.3.4
+
 jobs:
   # Approval gate for fork PRs.
   #
@@ -147,9 +152,40 @@ jobs:
       # `yarn install` running fork-controlled lifecycle scripts in this job,
       # which holds SONAR_TOKEN. Sonar applies its own JS/TS rules to the ~108k
       # frontend ncloc regardless; that analysis needs no node toolchain here.
+      # SonarCloud's New Code period is "previous_version", but nothing ever
+      # passed sonar.projectVersion, so no version boundary has ever existed and
+      # the branch's new-code window has been accumulating since the project was
+      # created ("New code: since 5 months ago"). That is why eros-develop
+      # reports ~14% new-code coverage while an individual PR reports 93% -- PR
+      # analysis scopes new code to the PR diff and is unaffected.
+      #
+      # Base version only, deliberately: build_v3.yml's full version carries a
+      # `-develop.<run_number>` suffix, and feeding that to Sonar would move the
+      # boundary on every single push, shrinking new code to one commit. Using
+      # the bare vX.Y.Z means new code == "since the last release tag", which is
+      # what the metric is supposed to express.
+      - name: Resolve project version
+        id: version
+        shell: bash
+        run: |
+          # Same reachability-scoped lookup build_v3.yml uses, same strict regex
+          # (rejects the CI-minted -develop.N tags and the legacy 4-part
+          # vX.Y.Z.B tags inherited from upstream).
+          BASE_TAG=$(git tag --merged HEAD --sort=-v:refname 2>/dev/null \
+            | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n1 || true)
+          if [ -n "$BASE_TAG" ]; then
+            BASE="${BASE_TAG#v}"
+            echo "Analysing as version ${BASE} (from tag ${BASE_TAG})"
+          else
+            BASE="${VERSION_FALLBACK}"
+            echo "Analysing as version ${BASE} (VERSION_FALLBACK; no vX.Y.Z tag reachable)"
+          fi
+          echo "version=${BASE}" >> "$GITHUB_OUTPUT"
+
       - name: Build and analyze
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_VERSION: ${{ steps.version.outputs.version }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_BRANCH: ${{ github.event.pull_request.head.ref }}
           PR_BASE: ${{ github.event.pull_request.base.ref }}
@@ -160,10 +196,20 @@ jobs:
             "/k:Whisparr_Whisparr-Eros",
             "/o:whisparr-eros",
             "/d:sonar.token=$env:SONAR_TOKEN",
-            # 45 near-identical translation files, ~49.6k ncloc -- 17% of the
-            # project, and a large share of the duplication figure. Excluding
-            # them makes both ncloc and duplicated_lines_density mean something.
-            "/d:sonar.exclusions=src/NzbDrone.Core/Localization/Core/**,**/node_modules/**,_output/**,_temp/**,_tests/**",
+            # Establishes the New Code boundary -- see "Resolve project version".
+            "/v:$env:SONAR_VERSION",
+            # Two groups of exclusions:
+            #  - Localization/Core is 45 near-identical translation files,
+            #    ~49.6k ncloc (17% of the project) and a large share of the
+            #    duplication figure; counting them made neither number mean
+            #    anything.
+            #  - The binaries are icons, logos and test media fixtures. Sonar
+            #    reads them as UTF-8 text and emits "Invalid character
+            #    encountered in file ..." for each, which is what raises the
+            #    "problems with file encoding" banner on the project summary.
+            #    sonar.sourceEncoding is NOT the fix; they are not text in any
+            #    encoding.
+            "/d:sonar.exclusions=src/NzbDrone.Core/Localization/Core/**,**/node_modules/**,_output/**,_temp/**,_tests/**,**/*.ico,**/*.png,**/*.mp4,**/*.zip,**/*.tar.gz",
             "/d:sonar.cs.opencover.reportsPaths=coverage/**/coverage.opencover.xml"
           )
           if ($env:EVENT_NAME -eq 'pull_request_target') {


### PR DESCRIPTION
#### Database Migration

NO

#### Description

Two small corrections to the scanner arguments, both visible on the project summary after the first post-coverage merge (#438).

**1. Give Sonar a version boundary.**

New Code is set to `previous_version`, but nothing ever passed `sonar.projectVersion`. With no version boundary the branch's new-code window has been accumulating since the project was created — the summary literally reads *"New code: since 5 months ago"*. That is why the two figures disagree so wildly:

| Scope | new_lines | new_coverage |
|---|---|---|
| PR #438 | 154 | **93.3%** ✅ |
| `eros-develop` branch | 11,853 | 13.9% |

PR analysis scopes new code to the PR diff and was never affected — the 80% rule has been measuring correctly at PR level since coverage started working. Only the branch figure was misleading, and it was measuring "coverage of everything ever added", not "coverage of recent work".

The version passed is the **base `vX.Y.Z` only**, resolved with the same reachability-scoped lookup and strict regex `build_v3.yml` uses (currently `3.3.8`; the regex rejects both the CI-minted `-develop.N` tags and the legacy 4-part `vX.Y.Z.B` tags inherited from upstream). `build_v3.yml`'s full version carries a `-develop.<run_number>` suffix — feeding *that* to Sonar would move the boundary on every push and shrink new code to a single commit. Base version means new code is "since the last release tag", which is what the metric should express and matches the tag-based release model.

**2. Stop Sonar reading binaries as source.**

The "problems with file encoding" banner comes from ten `Invalid character encountered in file ...` warnings. Nine are Sonar reading binaries as UTF-8:

```
Whisparr.ico  red_puzzle.ico  green_puzzle.ico  Logo/64.png  Logo/1024.png
TestArchive.zip  TestArchive.tar.gz  H264_sample.mp4
```

Now excluded. Note `sonar.sourceEncoding` — which the warning text suggests — is *not* the fix; these are not text in any encoding.

The tenth warning is left alone deliberately. `ParserFixture.cs:54` contains a genuine U+FFFD replacement character (bytes `ef bf bd`) inside a `TestCase` string, inherited from upstream Radarr. The file is valid UTF-8; Sonar flags U+FFFD specifically because its presence means a character was already lost in some past conversion. The test still exercises the parser correctly, and editing a Parser fixture to silence a cosmetic warning is the wrong trade.

#### Notes for review

- **When the window actually narrows is uncertain.** `previous_version` needs two distinct versions in the analysis history. This may take effect at the next analysis (if Sonar treats the version first appearing as a boundary) or not until `v3.3.9` is tagged. Either way it is an improvement and self-corrects; if you want the branch number fixed *immediately*, switching New Code to "Number of days: 30" in the project settings does that with no code change.
- `VERSION_FALLBACK` is duplicated from `build_v3.yml` and commented as needing to stay in sync. Only used in the seed window before any `vX.Y.Z` tag is reachable, which no longer applies.
- Same self-validation caveat as #439 and #440: `pull_request_target` runs the base branch's workflow file, so this PR's own check exercises the current `eros-develop`, not this diff.

#### Todos

- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)

#### Issues Fixed or Closed by this PR

<!-- none -->
