### PR TITLE
Fix: Exclude binary test fixtures from analysis too

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -210,6 +210,14 @@ jobs:
             #    sonar.sourceEncoding is NOT the fix; they are not text in any
             #    encoding.
             "/d:sonar.exclusions=src/NzbDrone.Core/Localization/Core/**,**/node_modules/**,_output/**,_temp/**,_tests/**,**/*.ico,**/*.png,**/*.mp4,**/*.zip,**/*.tar.gz",
+            # sonar.exclusions governs MAIN files only. The .NET scanner
+            # classifies every *.Test project as test code, so the media
+            # fixtures under src/NzbDrone.Core.Test/Files (H264_sample.mp4,
+            # TestArchive.zip, TestArchive.tar.gz) were untouched by the list
+            # above and kept warning after #442. They need the test-scoped
+            # equivalent. Binaries only -- do not add source patterns here, it
+            # would drop real test code from analysis.
+            "/d:sonar.test.exclusions=**/*.ico,**/*.png,**/*.mp4,**/*.zip,**/*.tar.gz",
             "/d:sonar.cs.opencover.reportsPaths=coverage/**/coverage.opencover.xml"
           )
           if ($env:EVENT_NAME -eq 'pull_request_target') {


### PR DESCRIPTION
#### Database Migration

NO

#### Description

Follow-up to #442, which cleared only six of the ten `Invalid character encountered in file ...` warnings behind the "problems with file encoding" banner.

`sonar.exclusions` governs **main** files only. The .NET scanner classifies every `*.Test` project as test code, so the media fixtures under `src/NzbDrone.Core.Test/Files` were never in scope for it. The scanner log shows this directly — every project reports `Excluded sources: ...` and there is no `Excluded tests:` line at all, because `sonar.test.exclusions` was unset.

The split lines up exactly with which warnings survived #442:

| File | Project | After #442 |
|---|---|---|
| `Whisparr.ico`, `red_puzzle.ico`, `green_puzzle.ico`, `Logo/64.png`, `Logo/1024.png` | main | silenced ✅ |
| `H264_sample.mp4`, `TestArchive.zip`, `TestArchive.tar.gz` | `NzbDrone.Core.Test` | still warning ❌ |

Adding the test-scoped equivalent covers the remaining three.

**Binary patterns only.** Source patterns must not go in this property — it would drop real test code out of the analysis.

#### Deliberately left warning

`ParserFixture.cs:54` contains a genuine U+FFFD replacement character (bytes `ef bf bd`) inside a `TestCase` string, inherited from upstream Radarr:

```
[TestCase("Mission Movie: Rogue Movie (2015)�[XviD - Ita Ac3 - SoftSub Ita]...")]
```

The file is valid UTF-8; Sonar flags U+FFFD specifically because its presence means a character was already lost in a past conversion. It is the one warning of the ten that reports a real problem rather than Sonar misreading a binary, and editing a Parser fixture to silence a banner is the wrong trade. The test still exercises the parser correctly.

So the banner will persist after this merge, with one warning instead of four. That is the intended end state.

#### Notes for review

- Unrelated but worth recording: the New Code window is being switched to "Number of days: 30" in project settings. `previous_version` with no version ever recorded falls back to the project's first analysis, which is why the summary read "New code: since 5 months ago" and why `eros-develop` showed ~14% new-code coverage while PR #438 showed 93.3% over its own diff. The `/v:` added in #442 is still correct for release tracking and the Activity graph; it just cannot retroactively create a boundary, and would not have taken effect until `v3.3.9` was tagged.
- Same self-validation caveat as #439/#440/#442: `pull_request_target` runs the base branch's workflow file, so this PR's own check exercises the current `eros-develop`, not this diff.

#### Todos

- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)

#### Issues Fixed or Closed by this PR

<!-- none -->
