### PR TITLE
Fix: Escape the replacement character in ParserFixture

### DIFF
--- a/src/NzbDrone.Core.Test/ParserTests/ParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/ParserFixture.cs
@@ -51,7 +51,7 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("Der.Movie.James.German.Bluray.FuckYou.Pso.Why.cant.you.follow.scene.rules.1998", "Der Movie James")]
         [TestCase("Movie.German.DL.AC3.Dubbed..BluRay.x264-PsO", "Movie")]
         [TestCase("Valana la Movie TRUEFRENCH BluRay 720p 2016 kjhlj", "Valana la Movie")]
-        [TestCase("Mission Movie: Rogue Movie (2015)�[XviD - Ita Ac3 - SoftSub Ita]azione, spionaggio, thriller *Prima Visione* Team mulnic Tom Cruise", "Mission Movie: Rogue Movie")]
+        [TestCase("Mission Movie: Rogue Movie (2015)\uFFFD[XviD - Ita Ac3 - SoftSub Ita]azione, spionaggio, thriller *Prima Visione* Team mulnic Tom Cruise", "Mission Movie: Rogue Movie")]
         [TestCase("Movie.Movie.2000.FRENCH..BluRay.-AiRLiNE", "Movie Movie")]
         [TestCase("My Movie 1999 German Bluray", "My Movie")]
         [TestCase("Leaving Movie by Movie (1897) [DVD].mp4", "Leaving Movie by Movie")]


### PR DESCRIPTION
#### Database Migration

NO

#### Description

The SonarQube scanner logs exactly one warning, and it is what raises the "problems with file encoding" banner on the project summary:

```
WARN: Invalid character encountered in file .../ParserTests/ParserFixture.cs at line 54
for encoding UTF-8. Please fix file content or configure the encoding to be used using
property 'sonar.sourceEncoding'.
```

This was the only one left after #442 and #443 excluded the binary fixtures, and it is a different problem despite the identical banner.

`ParserFixture.cs` is valid UTF-8 and the scanner reads it correctly. The bytes it objects to are `EF BF BD`, which *are* valid UTF-8 — they encode U+FFFD REPLACEMENT CHARACTER, sitting inside a release title test case (`...Rogue Movie (2015)<U+FFFD>[XviD - Ita Ac3...`). Sonar flags U+FFFD not as a decode failure but as evidence that the content was mangled by a bad decode at some earlier point.

That is also why the property the warning suggests cannot help, the same as for the binary fixtures: nothing is being decoded wrongly now, the corruption is already baked into the file. The character is not recoverable from history either — it was already U+FFFD when e011614570 genericised the test names, before this fork.

It is the only occurrence in the entire repository.

The fix writes the same character as its ASCII escape sequence. The compiled test input is byte-identical, so the case still exercises the parser on exactly the string it did before: no assertion is weakened and no test is removed. The remaining non-ASCII in the file (a Cyrillic title, French accents) is deliberate test data, is valid UTF-8, and was never flagged.

#### Todos

- [x] Tests — existing coverage, unchanged. ParserTests passes 1256/1256, the same count as before, confirming the case is still present and still asserting the same result.
- [x] Translation Keys — none required.

#### Issues Fixed or Closed by this PR

None — this clears the last SonarQube encoding warning, following on from #442 and #443.
