### PR TITLE
Chore: Add zustand foundation for the React Query migration

### DIFF
--- a/REDUX_MIGRATION.md
+++ b/REDUX_MIGRATION.md
@@ -1,0 +1,302 @@
+# Getting eros-develop off Redux
+
+Status assessment and playbook for migrating the Whisparr Eros frontend from Redux to
+React Query + zustand, benchmarked against Sonarr's completed `v5-develop` migration.
+
+Sources: `Whisparr/Whisparr-Eros@eros-develop` at `1d75cc96` ·
+`Sonarr/Sonarr@v5-develop` at `7e627f69`.
+Counts are file-level `react-redux` imports across 1,255 frontend source files.
+Sonarr commit hashes are short refs on `v5-develop`.
+
+---
+
+## 1. Where we actually are
+
+| Metric | Count |
+| --- | --- |
+| Files importing `react-redux` | 327 of 1,255 |
+| Lines under `frontend/src/Store/` | 15,374 across 138 files |
+| Remaining `*Connector` files | 66 |
+| Files touching `@tanstack/react-query` | 13 |
+| zustand stores | 0 (dependency not installed) |
+
+Roughly: **4% migrated, 22% hybrid, 74% untouched.**
+
+### The domains are started, not done
+
+Movie, Scene, Performer and Studio each have a read hook, and each index page still runs
+on Redux underneath it. `useMovie`, `usePerformer` and `useStudio` are real React Query
+hooks that work — but they only cover fetching one record. The index page, filter set,
+persisted view options, selection footer, bulk edit/delete modals and refresh buttons are
+all still Redux. The clearest tell is that the new hooks themselves call `useSelector`:
+
+| File | Redux it still depends on |
+| --- | --- |
+| `Movie/Index/useMovieIndexQuery.ts` | `state.movieIndex.selectedFilterKey`, `createCustomFiltersSelector`, `movieActions.filters` |
+| `Movie/Index/useMovieIndex.ts` | 8 × `movieIndexActions` dispatches (`setMovieTableOption`, `setMoviePosterOption`, …) |
+| `Scene/Index/useSceneIndexQuery.ts` | `sceneIndexActions`, `state.sceneIndex` |
+| `Tags/useTags.ts` | `createTagsSelector` — react-query-shaped name, selector body |
+
+### The ordering problem
+
+Eros went domain-first (Movie, Scene, Performer, Studio). Sonarr went the other way —
+peripheral pages first, then shared plumbing, and only reached Series in month four.
+
+That wasn't arbitrary. A domain index page sits on top of five shared systems: persisted
+view options, row selection, custom filters, command dispatch, and paging. In Eros **none
+of those five exist off Redux yet.** So each domain gets ~80% converted and then stalls
+against the same missing floor — which is exactly the hybrid state above.
+
+**Recommendation:** pause domain work, build the foundation (phase A), then close
+Movie/Scene/Performer/Studio in one pass each. The high-value instinct was right; the
+sequencing is what's costing you.
+
+---
+
+## 2. Sonarr's proven sequence
+
+Sonarr finished this in **54 commits between Sep 2025 and Jun 2026**. Their tree has no
+`Store/` directory and no redux dependency at all.
+
+| Period | Commits | What |
+| --- | --- | --- |
+| Sep–Oct 25 | 4 | Queue, Blocklist, History, Log Files. Queue first (58 files) to force the primitives into existence. |
+| Nov 25 | 16 | System, Health, Disk Space, Tasks, Backups, Calendar, Parse, Wanted, Tags, Root Folders, Custom Filters, Interactive Search, Episodes. |
+| Dec 25 | 14 | Series (91 files), Commands (51 files), and `Convert app state to zustand stores`. |
+| Jan–Apr 26 | 11 | Settings, one section per fortnight, never batched. |
+| May–Jun 26 | 9 | Custom Formats, Import Lists, Delay Profiles, Download Clients — then `Goodbye Redux`. |
+
+### Three things worth copying exactly
+
+1. **One page per commit, never batched.** Even the tiny ones (disk space: 4 files, 19
+   insertions) shipped alone. Bisectable, reviewable, revertable.
+2. **zustand arrived late, deliberately.** `878f879c` lands in month four, after ~20 pages
+   had already proven what client state actually still needed. They did not design the
+   store layer up front.
+3. **A dedicated correctness pass near the end.** `9bed77c6` "Avoid mutation for
+   react-query data" — 37 files — cleaning up code that mutated cached objects in place, a
+   habit carried over from reducers. Budget for this; it will bite here too.
+
+---
+
+## 3. Phase A — the missing floor
+
+Blocking. ~5 PRs. Everything downstream needs these. Sonarr has all of them; Eros has
+none. Port close to verbatim — this is not the place to invent.
+
+| Build | Retires | Sonarr ref |
+| --- | --- | --- |
+| zustand + `createPersist` | `Store/Middleware/createPersistState.js`, `redux-localstorage`, `Store/Migrators/` | `Helpers/createPersist.ts` |
+| `useOptionsStore` factory — per-page columns, sort, filter key, view mode, poster/overview options | `movieIndexActions`, `sceneIndexActions`, `createSetTableOptionReducer` | `878f879c` |
+| `useSelectStore` — row selection for every index and manage modal | `App/SelectContext.tsx`, `Helpers/Hooks/useSelectState.tsx` | `App/Select/useSelectStore.ts` |
+| `usePagedApiQuery` — server-side paging with `keepPreviousData` | `createFetchServerSideCollectionHandler.js`, `Components/Table/usePaging.ts` | `Helpers/Hooks/usePagedApiQuery.ts` |
+| `clientSideFilterAndSort` — the filter/sort engine every index shares | `createClientSideCollectionSelector.js`, `create*ClientSideCollectionItemsSelector` ×4 | `Utilities/Filter/` |
+| Pending-changes stores (×3) — defer to phase E, only Settings needs them | `createSetSettingValueReducer.js`, `createSetProviderFieldValueReducer.js` | `7e702380` |
+
+### Also fix while you're in here
+
+Eros's `useApiQuery` has drifted from Sonarr's. Ours `JSON.stringify`s query params and
+bodies into the cache key and hardcodes `placeholderData: (prev) => prev` as a default.
+Sonarr passes params as a structural key and leaves placeholder behaviour to the caller.
+The stringify keys work, but they make cache invalidation by prefix impossible — which
+you will want the moment SignalR starts driving invalidations. Align it now while there
+are only 13 callers.
+
+Same for the ad-hoc `apiPut`/`apiPatch` helpers and the two `// TODO: Move to
+useApiMutation` markers in `Movie/useMovie.ts` — fold those in before the pattern gets
+copied into three more domains.
+
+---
+
+## 4. Phase B — leaf pages
+
+~12 PRs. Low risk, high clearance. Self-contained pages with few dependents; each removes
+a whole state slice. Take them roughly in Sonarr's order.
+
+| Page | Retires | Sonarr ref |
+| --- | --- | --- |
+| **Queue** — biggest leaf, 16 consumers, SignalR-driven, drives sidebar badge | `queueActions` (539 loc), `QueueAppState` | `ae201f52` (58 files) |
+| **Blocklist** — incl. per-movie blocklist tab | `blocklistActions`, `movieBlocklistActions` | `a4f21085` |
+| **History** *(hybrid)* — `useHistory` covers paged list + movie history; finish details modal | `historyActions`, `movieHistoryActions`, `HistoryDetailsConnector` ×2 | `a45b0776`, `6b479a5a` |
+| **System: Status / Health / Disk Space** — three commits; Health has the sidebar dependency | `systemActions` (400 loc, 20 consumers), `createHealthCheckSelector.js`, `createSystemStatusSelector.ts` | `49c52c2e`, `0552a811`, `871ae955` |
+| **System: Tasks / Backups / Log Files / Events** | `BackupsConnector.js`, `RestoreBackupModal*Connector.js`, `LogsTableConnector.js` | `3091f40c`, `c295e24f`, `ff5e7327` |
+| **Calendar** — 12 files; needs the options store from phase A | `calendarActions` (443 loc), `CalendarAppState` | `ccb7f07c` (28 files) |
+| **Parse** — small, isolated; Sonarr's deleted 333 lines for 55 | `parseActions.ts`, `ParseAppState` | `263f4839` |
+| **Wanted: Missing + Cutoff Unmet** — one commit; first real `usePagedApiQuery` consumer | `wantedActions` (342 loc), `WantedAppState` | `40712781` |
+| **Organize preview + Unmapped Files** — two small pages, one PR | `organizePreviewActions`, `unmappedMovieFileActions` | `10c0e18a` |
+
+---
+
+## 5. Phase C — shared plumbing
+
+~7 PRs. Wide, shallow changes: a small hook plus a long list of import rewrites. Sonarr's
+commands commit touched 51 files, custom filters 44. Ship them alone.
+
+| System | Retires | Sonarr ref |
+| --- | --- | --- |
+| **Commands** — 44 live consumers; every refresh/search button. SignalR-fed. | `commandActions` (207 loc), `createCommandSelector.ts`, `createExecutingCommandsSelector.ts`, `createCommandExecutingSelector.ts` | `dec6f4b5` (51 files) |
+| **Custom filters** — prerequisite for every index filter modal | `customFilterActions`, `CustomFiltersModalContentConnector.js`, `CustomFiltersAppState` | `7d2e01d5` (44 files) |
+| **Tags** — rewrite `useTags` for real, plus tag details and filter-builder rows | `tagActions`, `createTagsSelector.ts`, `createTagDetailsSelector.ts`, `TagFilterBuilderRowValueConnector.js` | `0809a72c` (40 files) |
+| **Root folders** — 17 consumers across Settings, Add flows, edit modals | `rootFolderActions`, `createRootFoldersSelector.ts` | `7a5157df` |
+| **Paths + file browser** *(hybrid)* — `usePaths` exists; finish `PathInput`, `FileBrowserModalContent` | `pathActions`, `PathsAppState` | `91b24290` |
+| **Provider options + captcha** — feeds every provider settings form; do before phase E | `providerOptionActions`, `captchaActions`, `oAuthActions` | `cd7adba1` |
+| **SignalR → query invalidation** — the pivot: `SignalRConnector.js` dispatches actions today; becomes a listener that invalidates query keys | `Components/SignalRConnector.js`, `Store/thunks.ts`, `redux-batched-actions` | `Components/SignalRListener.tsx` |
+| **App shell** — messages, dimensions, theme, advanced settings. zustand, not React Query. 34 files import `baseActions`. | `appActions`, `MessagesAppState`, `createDimensionsSelector.ts` | `878f879c`, `7e702380` |
+
+---
+
+## 6. Phase D — close out the domains
+
+~9 PRs. Each domain is one commit in Sonarr's model (Series was 91 files). Eros has four
+parallel domains where Sonarr had one — budget four Series-sized commits, but they share a
+shape: convert one properly, then the other three are largely mechanical.
+
+| Domain | Remaining work | Sonarr ref |
+| --- | --- | --- |
+| **Movie** *(hybrid)* — do first, set the template. 39 redux files. | Index options → `movieOptionsStore`; filters → `FILTERS`/`FILTER_BUILDER` in `useMovie`; select footer; Edit/Delete/Tags/Organize modals. Retires `movieActions`, `movieIndexActions`, `movieTitlesActions`. | `0521a6c3` (91 files) |
+| **Scene** *(hybrid)* — 24 redux files. Shares the `Movie` model, so hooks can share a generic base. | `sceneIndexActions`, `createAllScenesSelector.ts`, `DeleteSceneModalContentConnector.js` | — |
+| **Performer** *(hybrid)* — 23 redux files. Details, scenes tab, add flow, edit modal. | `performerActions` (676 loc), `performerScenesActions`, `addPerformerActions`, `EditPerformerModalContentConnector.js` | — |
+| **Studio** *(hybrid)* — 22 redux files. Same shape as Performer. | `studioActions` (510 loc), `studioMoviesActions`, `studioScenesActions`, `DeleteStudioModalConnector.js` | — |
+| **Collection** — untouched, fully connector-based. 7 of the 66 connectors live here. | `movieCollectionActions` (572 loc), `Collection*Connector.js` ×7, `createCollectionSelector.ts` | — |
+| **Movie files + credits** *(hybrid)* — `useMovieFile` covers most; credits and titles still redux | `movieFileActions`, `movieCreditsActions`, `MovieCreditPosterConnector.tsx` | `44fc1e0e` |
+| **Interactive search** — release list, override match, download client picker | `releaseActions` (365 loc), `ReleasesAppState` | `8f95849e` (41 files) |
+| **Interactive import** — folder picker, quality/language selects, row grid | `interactiveImportActions` (366 loc), `InteractiveImportAppState` | `ec44e1c5` |
+| **Add / Import Movie** *(hybrid)* — `useAddNewMovie` and `useImportMutation` exist; finish folder-select and import-list flows | `addMovieActions` | `ad57cf4b` |
+
+---
+
+## 7. Phase E — Settings
+
+~14 PRs, 87 files. The long grind. `settingsActions` has 77 live consumers, and 37 of the
+66 remaining connectors are in here. Sonarr spent six months at roughly one section per
+fortnight and never batched two together. Do the same.
+
+**Prerequisite:** the three pending-changes stores (`usePendingChangesStore`,
+`usePendingFieldsStore`, `usePendingItemsStore`), which replace the dirty-form tracking in
+`createSetSettingValueReducer` and `createSetProviderFieldValueReducer`. Land those in
+their own PR before section one.
+
+| Order | Section | Retires | Sonarr ref |
+| --- | --- | --- | --- |
+| 1 | **UI settings** — smallest, 32 files read it. Good pathfinder. | `Settings/ui.js`, `UISettingsConnector.js`, `createUISettingsSelector.ts` | `74e6ce43` |
+| 2 | Remote path mappings · Release profiles | `Settings/remotePathMappings.js`, `Settings/releaseProfiles.js` | `8fcab2d3`, `4713615b` |
+| 3 | Quality profiles · Quality definitions (4 connectors incl. reset modal) | `Settings/qualityProfiles.js`, `Settings/qualityDefinitions.js`, `Quality*Connector.js` ×4 | `21ca65a0`, `cf593b1f` |
+| 4 | Connections (Notifications) | `Settings/notifications.js`, `DeviceInput.tsx` | `6d49b41d` |
+| 5 | Naming · Media Management · Metadata | `Settings/naming.js`, `Settings/namingExamples.js`, `Settings/mediaManagement.js`, `Settings/metadata.js` | `677c588a`, `bbb4c671`, `c0a56586` |
+| 6 | Languages · General (partial `useGeneralSettings` exists) | `Settings/languages.js`, `Settings/general.js`, `GeneralSettingsConnector.js` | `5bac016f`, `6764cf1c` |
+| 7 | Indexers · Indexer Options · Indexer Flags (11 files, three commits) | `Settings/indexers.js`, `Settings/indexerOptions.js`, `Settings/indexerFlags.js`, `IndexerFilterBuilderRowValueConnector.js` | `c4c0ec25`, `7a455dd0`, `fbb70519` |
+| 8 | Auto tagging · Import list exclusions | `Settings/autoTaggings.js`, `Settings/autoTaggingSpecifications.js`, `Settings/importListExclusions.js` | `0ebda892`, `b0fac152` |
+| 9 | Import lists + options (16 files — largest subtree) | `Settings/importLists.js`, `Settings/importListOptions.js`, `ImportListFilterBuilderRowValueConnector.js` | `75d1a958`, `ba7b6b03` |
+| 10 | Custom formats (10 files, 6 connectors, import/export modals) | `Settings/customFormats.js`, `Settings/customFormatSpecifications.js`, `CustomFormat*Connector.js` ×6 | `06aa7d57` (38 files) |
+| 11 | Delay profiles · Download clients + options | `Settings/delayProfiles.js`, `Settings/downloadClients.js`, `Settings/downloadClientOptions.js`, `createEnabledDownloadClientsSelector.ts` | `ed1d92c5`, `7be32b0c`, `d04e2996` |
+
+---
+
+## 8. Phase F — teardown
+
+Sonarr's ending was two commits: a correctness sweep, then the delete.
+
+### F1 — Avoid mutation for react-query data
+
+Reducer habits produce code that mutates objects in place. Under Redux that was contained;
+under React Query a cached object is shared across every component reading that key, so
+in-place edits corrupt other views silently. Sonarr's sweep hit 37 files (`9bed77c6`). Do
+this **before** the delete, while the old code is still there to compare against.
+
+Sonarr also switched `useApiQuery`'s generic to `Readonly<T>` so the compiler catches it —
+Eros's copy has not.
+
+### F2 — Goodbye Redux
+
+Sonarr's final commit (`0460281f`) removed 1,996 lines across 51 files. The Eros equivalent:
+
+- Delete `frontend/src/Store/` — 138 files, 15,374 lines.
+- Delete surviving `App/State/*AppState.ts` slices (33 today; most disappear with their phase).
+- Drop `<Provider>` from `frontend/src/bootstrap.tsx`.
+- Remove from `package.json`: `react-redux`, `redux`, `redux-actions`,
+  `redux-batched-actions`, `redux-localstorage`, `redux-thunk`, `@types/redux-actions`.
+- Re-home the Sentry middleware — `createSentryMiddleware.js` is a redux middleware and
+  needs a non-redux home before the store goes.
+
+---
+
+## 9. Where Eros diverges from Sonarr
+
+Four places where you cannot just copy their commit.
+
+1. **Four domains, not one.** Sonarr had Series; Eros has Movie, Scene, Performer and
+   Studio, each with its own index, details, edit, delete and select-footer stack. Biggest
+   multiplier on the estimate. Decide early whether the four share a generic
+   `createDomainHooks` factory or stay copy-pasted — Scene already reuses the `Movie`
+   model, so at minimum those two should share.
+2. **Server-side paged indexes.** Sonarr's Series index is client-side filtered over one
+   `/series` fetch. Eros's Movie and Scene indexes page on the server. `useSeries`'s
+   fetch-all/build-a-Map/filter-in-memory pattern does not port directly; those need
+   `usePagedApiQuery` plus server-side filter translation. Performer and Studio indexes are
+   closer to Sonarr's model.
+3. **Collection has no Sonarr analogue** and is the least-migrated area in the tree — 7
+   connectors and a 572-line action file. Needs designing rather than porting.
+4. **Safe-for-work mode.** `SafeForWorkContext` and `SafeForWorkButtonConnector.js` are
+   Eros-specific global UI state. Belongs in the app zustand store alongside theme and
+   advanced-settings, but there is no Sonarr commit to follow.
+
+---
+
+## 10. What to do next
+
+The first four PRs:
+
+1. **Align `useApiQuery` / `useApiMutation` with Sonarr's** and remove the two
+   `TODO: Move to useApiMutation` markers in `Movie/useMovie.ts`. Small, and it stops the
+   drift compounding.
+2. **Add zustand + `createPersist` + `useOptionsStore`.** Port from Sonarr near-verbatim.
+3. **Convert one leaf page end-to-end — Parse or Disk Space.** Deliberately trivial. The
+   point is to establish the PR shape, test expectations and coverage story before anything
+   expensive.
+4. **Then Queue**, as Sonarr did, because it forces SignalR-driven invalidation into
+   existence early rather than late.
+
+### On testing — what Sonarr actually did
+
+Sonarr shipped this entire migration with **no automated frontend verification at all**:
+
+- No jest, no vitest, no testing-library, no `test` script, zero `*.test.*` files.
+- Their Selenium `NzbDrone.Automation.Test` project is six smoke tests that click a nav
+  icon and assert a div exists. It was untouched across the whole migration window — the
+  only commits touching it were a .NET 10 bump and two tooling simplifications.
+- Those Selenium tests **don't run in CI**. `build_v5.yml` filters
+  `TestCategory!=AutomationTest` on every leg. Whisparr's `build_v3.yml` has the identical
+  exclusion.
+
+Their real safety net was **TypeScript**, plus one-page-per-commit bisectability and a
+large beta population. And that is where Eros is not starting from the same place:
+
+| | Sonarr | Whisparr Eros |
+| --- | --- | --- |
+| `.js` files in `frontend/src` | 23 | **385** |
+| `.ts` / `.tsx` files | 878 | 873 |
+
+Sonarr was effectively all-TypeScript before the migration, so `strict: true` +
+`noImplicitAny` + `react-hooks/exhaustive-deps: error` caught the class of error a
+state-management rewrite produces. Eros's 385 untyped files are concentrated in exactly
+the code being migrated — all of `Store/Actions`, all 66 connectors.
+
+**So the migration is also the TypeScript conversion, and that is the test story.** Each
+converted page moves code from unchecked to checked. Two consequences worth holding to:
+
+1. Don't leave `.js` shims behind. A converted page that still imports an untyped
+   connector keeps the compiler blind on the seam that just changed.
+2. Extend the Selenium smoke tests opportunistically. `PageBase` currently has no
+   Performer, Studio, Scene or Collection nav icons — the Eros-specific pages aren't
+   covered even by the six that exist. Adding them as each page migrates is nearly free
+   and uses infrastructure already in the repo. They still won't run in CI, so treat them
+   as a local pre-merge check, not a gate.
+
+### Risk to verify on the first PR
+
+Sonar's scanner is `dotnet-sonarscanner` with only `sonar.cs.opencover.reportsPaths` set —
+there is no JS/TS coverage report. `frontend/src` is not in `sonar.exclusions`, so those
+files are analysed for issues but have no coverage data. **Confirm on the first migration
+PR whether new frontend TypeScript counts as uncovered new code against the 80% new-code
+gate.** If it does, every PR in this roadmap fails the gate and the scanner config needs a
+frontend exclusion or a coverage source before phase B starts.

--- a/frontend/src/App/Select/useSelectStore.ts
+++ b/frontend/src/App/Select/useSelectStore.ts
@@ -1,0 +1,317 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { create, useStore } from 'zustand';
+import { useShallow } from 'zustand/react/shallow';
+import getToggledRange from 'Utilities/Table/getToggledRange';
+
+export type Id = string | number;
+export type SelectStoreReturnType<T extends SelectStoreModel<Id>> = ReturnType<
+  typeof useSelectStore<T>
+>;
+
+type ItemState<T extends SelectStoreModel<Id>> = Map<T['id'], ItemStateValue>;
+
+interface ItemStateValue {
+  isSelected: boolean;
+  isDisabled?: boolean;
+}
+
+export interface SelectStoreModel<TId extends Id> {
+  id: TId;
+}
+
+export interface SelectStore<T extends SelectStoreModel<Id>> {
+  itemState: Map<T['id'], ItemStateValue>;
+  lastToggled: T['id'] | null;
+  items: T[];
+}
+
+interface ItemSelectState {
+  allSelected: boolean;
+  allUnselected: boolean;
+  anySelected: boolean;
+  selectedCount: number;
+}
+
+const initialState = <T extends SelectStoreModel<Id>>(
+  items: T[] = []
+): SelectStore<T> => ({
+  itemState: new Map<T['id'], ItemStateValue>(),
+  lastToggled: null,
+  items,
+});
+
+function toggleAll<T extends SelectStoreModel<Id>>(
+  itemState: ItemState<T>,
+  isSelected: boolean
+) {
+  const newItemState = new Map(itemState);
+
+  newItemState.forEach((value, key) => {
+    newItemState.set(key, {
+      isSelected: value.isDisabled ? value.isSelected : isSelected,
+      isDisabled: value.isDisabled,
+    });
+  });
+
+  return newItemState;
+}
+
+export default function useSelectStore<T extends SelectStoreModel<Id>>(
+  items: ReadonlyArray<SelectStoreModel<T['id']>>
+) {
+  const store = useRef(
+    create<SelectStore<T>>(() => initialState(items as T[]))
+  );
+
+  const [itemSelectState, setItemSelectState] = useState<ItemSelectState>({
+    allSelected: false,
+    allUnselected: true,
+    anySelected: false,
+    selectedCount: 0,
+  });
+
+  const reset = useCallback(() => {
+    store.current.setState(initialState(items as T[]), true);
+  }, [items]);
+
+  const selectAll = useCallback(() => {
+    store.current.setState((state) => {
+      const newItemState = toggleAll(state.itemState, true);
+
+      return {
+        lastToggled: null,
+        itemState: newItemState,
+      };
+    });
+  }, []);
+
+  const unselectAll = useCallback(() => {
+    store.current.setState((state) => {
+      const newItemState = toggleAll(state.itemState, false);
+
+      return {
+        lastToggled: null,
+        itemState: newItemState,
+      };
+    });
+  }, []);
+
+  const toggleSelected = useCallback(
+    ({
+      id,
+      isSelected,
+      shiftKey,
+    }: {
+      id: T['id'];
+      isSelected: boolean | null;
+      shiftKey: boolean;
+    }) => {
+      store.current.setState((state) => {
+        const lastToggled = state.lastToggled;
+        const nextSelectedState = new Map(state.itemState);
+        const currentItemState = nextSelectedState.get(id);
+
+        if (isSelected == null) {
+          nextSelectedState.delete(id);
+        } else if (!currentItemState?.isDisabled) {
+          nextSelectedState.set(id, {
+            isSelected,
+            isDisabled: currentItemState?.isDisabled,
+          });
+
+          if (shiftKey && lastToggled) {
+            const { lower, upper } = getToggledRange(
+              state.items,
+              id,
+              lastToggled
+            );
+
+            for (let i = lower; i < upper; i++) {
+              if (!nextSelectedState.get(state.items[i].id)?.isDisabled) {
+                nextSelectedState.set(state.items[i].id, {
+                  isSelected,
+                  isDisabled: currentItemState?.isDisabled,
+                });
+              }
+            }
+          }
+        }
+
+        return {
+          ...state,
+          lastToggled: id,
+          itemState: nextSelectedState,
+        };
+      });
+    },
+    []
+  );
+
+  const toggleDisabled = useCallback((id: T['id'], isDisabled: boolean) => {
+    store.current.setState((state) => {
+      const currentItemState = state.itemState.get(id);
+
+      if (currentItemState) {
+        const newItemState = new Map(state.itemState);
+        newItemState.set(id, {
+          ...currentItemState,
+          isDisabled,
+        });
+
+        return {
+          itemState: newItemState,
+        };
+      }
+
+      return state;
+    });
+  }, []);
+
+  const getSelectedIds = useCallback((): Array<T['id']> => {
+    const iState = store.current.getState().itemState;
+
+    return Array.from(iState.entries()).reduce<T['id'][]>(
+      (acc, [id, value]) => {
+        if (value.isSelected) {
+          acc.push(id);
+        }
+
+        return acc;
+      },
+      []
+    );
+  }, []);
+
+  const getIsSelected = useCallback((id: T['id']): boolean => {
+    const item = store.current.getState().itemState.get(id);
+
+    return item?.isSelected ?? false;
+  }, []);
+
+  const useIsSelected = (id: T['id']) => {
+    return useStore(
+      store.current,
+      useShallow((state) => {
+        const item = state.itemState.get(id);
+
+        return item?.isSelected ?? false;
+      })
+    );
+  };
+
+  const useSelectedIds = () => {
+    return useStore(
+      store.current,
+      useShallow((state) => {
+        return Array.from(state.itemState.entries()).reduce<T['id'][]>(
+          (acc, [id, value]) => {
+            if (value.isSelected) {
+              acc.push(id);
+            }
+
+            return acc;
+          },
+          []
+        );
+      })
+    );
+  };
+
+  const useHasItems = () => {
+    return useStore(
+      store.current,
+      useShallow((state) => {
+        return state.itemState.size > 0;
+      })
+    );
+  };
+
+  useEffect(() => {
+    const unsubscribe = store.current.subscribe((state) => {
+      const itemState = state.itemState;
+      const itemValues = Array.from(itemState.values());
+
+      const { allSelected, allUnselected, anySelected, selectedCount } =
+        itemValues.reduce(
+          (acc, item) => {
+            acc.allSelected =
+              acc.allSelected && !!(item.isSelected || item.isDisabled);
+            acc.allUnselected =
+              acc.allUnselected && (!item.isSelected || !!item.isDisabled);
+            acc.anySelected = acc.anySelected || item.isSelected;
+            acc.selectedCount += item.isSelected ? 1 : 0;
+
+            return acc;
+          },
+          {
+            allSelected:
+              itemState.size > 0 && itemValues.some((i) => i.isSelected),
+            allUnselected: true,
+            anySelected: false,
+            selectedCount: 0,
+          }
+        );
+
+      setItemSelectState((s) => {
+        if (
+          s.allSelected === allSelected &&
+          s.allUnselected === allUnselected &&
+          s.anySelected === anySelected &&
+          s.selectedCount === selectedCount
+        ) {
+          return s;
+        }
+
+        return {
+          allSelected,
+          allUnselected,
+          anySelected,
+          selectedCount,
+        };
+      });
+    });
+
+    return () => {
+      unsubscribe();
+    };
+  }, []);
+
+  useEffect(() => {
+    store.current.setState((state) => {
+      const nextItemState = items.reduce((acc: ItemState<T>, item) => {
+        const id = item.id;
+        const existingItem = state.itemState.get(id);
+
+        acc.set(
+          id,
+          existingItem ?? {
+            isSelected: false,
+            isDisabled: false,
+          }
+        );
+
+        return acc;
+      }, new Map<T['id'], ItemStateValue>());
+
+      return {
+        itemState: nextItemState,
+        lastToggled: null,
+        items: items as T[],
+      };
+    });
+  }, [items]);
+
+  return {
+    ...itemSelectState,
+    getIsSelected,
+    getSelectedIds,
+    reset,
+    selectAll,
+    toggleDisabled,
+    toggleSelected,
+    unselectAll,
+    useHasItems,
+    useIsSelected,
+    useSelectedIds,
+  };
+}

--- a/frontend/src/Helpers/Hooks/useOptionsStore.ts
+++ b/frontend/src/Helpers/Hooks/useOptionsStore.ts
@@ -1,0 +1,198 @@
+import { StateCreator } from 'zustand';
+import { PersistOptions } from 'zustand/middleware';
+import Column from 'Components/Table/Column';
+import { createPersist } from 'Helpers/createPersist';
+import { SortDirection } from 'Helpers/Props/sortDirections';
+
+type TSettingsWithoutColumns = object;
+
+interface TSettingsWithColumns {
+  columns: Column[];
+  selectedFilterKey: string | number;
+  sortKey: string;
+  sortDirection: SortDirection;
+}
+
+type TSettings = TSettingsWithoutColumns | TSettingsWithColumns;
+
+export interface PageableOptions {
+  pageSize: number;
+  selectedFilterKey: string | number;
+  sortKey: string;
+  sortDirection: SortDirection;
+  columns: Column[];
+}
+
+export type OptionChanged<T> = {
+  name: keyof T;
+  value: T[keyof T];
+};
+
+const mergeColumns = <T extends { columns: Column[] }>(
+  persistedState: unknown,
+  currentState: T
+) => {
+  const currentColumns = currentState.columns;
+  const persistedColumns = (persistedState as T).columns;
+  const columns: Column[] = [];
+
+  // Add persisted columns in the same order they're currently in
+  // as long as they haven't been removed.
+
+  persistedColumns.forEach((persistedColumn) => {
+    const column = currentColumns.find((i) => i.name === persistedColumn.name);
+
+    if (column) {
+      const newColumn: Partial<Column> = {};
+
+      // We can't use a spread operator or Object.assign to clone the column
+      // or any accessors are lost and can break translations.
+      for (const prop of Object.keys(column)) {
+        const attributes = Object.getOwnPropertyDescriptor(column, prop);
+
+        if (!attributes) {
+          return;
+        }
+
+        Object.defineProperty(newColumn, prop, attributes);
+      }
+
+      newColumn.isVisible = persistedColumn.isVisible;
+
+      columns.push(newColumn as Column);
+    }
+  });
+
+  // Add any columns added to the app in the initial position.
+  currentColumns.forEach((currentColumn, index) => {
+    const persistedColumnIndex = persistedColumns.findIndex(
+      (i) => i.name === currentColumn.name
+    );
+    const column = Object.assign({}, currentColumn);
+
+    if (persistedColumnIndex === -1) {
+      columns.splice(index, 0, column);
+    }
+  });
+
+  return {
+    ...(persistedState as T),
+    columns,
+  };
+};
+
+const merge = <T extends TSettings>(
+  persistedState: unknown,
+  currentState: T
+) => {
+  if ('columns' in currentState) {
+    return {
+      ...currentState,
+      ...mergeColumns(persistedState, currentState),
+    };
+  }
+
+  return {
+    ...currentState,
+    ...((persistedState as T) ?? {}),
+  };
+};
+
+export const applySort = <T extends TSettings>(
+  state: T,
+  sortKey: string,
+  sortDirection: SortDirection | undefined
+) => {
+  if (!('sortKey' in state) || !('sortDirection' in state)) {
+    return state;
+  }
+
+  let newSortDirection = sortDirection;
+
+  if (sortDirection == null) {
+    if (state.sortKey === sortKey) {
+      newSortDirection =
+        state.sortDirection === 'ascending' ? 'descending' : 'ascending';
+    } else {
+      newSortDirection = state.sortDirection;
+    }
+  }
+
+  return {
+    sortKey,
+    sortDirection: newSortDirection,
+  };
+};
+
+export const createOptionsStore = <T extends TSettings>(
+  name: string,
+  state: StateCreator<T>,
+  options: Omit<PersistOptions<T>, 'name' | 'storage'> = {}
+) => {
+  const store = createPersist<T>(name, state, {
+    merge,
+    ...options,
+  });
+
+  const useOptions = () => {
+    return store((state) => state);
+  };
+
+  const useOption = <K extends keyof T>(key: K) => {
+    return store((state) => state[key]);
+  };
+
+  const getOptions = () => {
+    return store.getState();
+  };
+
+  const getOption = <K extends keyof T>(key: K) => {
+    return store.getState()[key];
+  };
+
+  const setOptions = (options: Partial<T>) => {
+    if ('sortKey' in options || 'sortDirection' in options) {
+      throw new Error('Use setSort to set sortKey and sortDirection');
+    }
+
+    store.setState((state) => ({
+      ...state,
+      ...options,
+    }));
+  };
+
+  const setOption = <K extends keyof T>(key: K, value: T[K]) => {
+    if (key === 'sortKey' || key === 'sortDirection') {
+      throw new Error('Use setSort to set sortKey and sortDirection');
+    }
+
+    store.setState((state) => ({
+      ...state,
+      [key]: value,
+    }));
+  };
+
+  const setSort = ({
+    sortKey,
+    sortDirection,
+  }: {
+    sortKey: string;
+    sortDirection?: SortDirection;
+  }) => {
+    // @ts-expect-error - Cannot verify if T has sortKey and sortDirection
+    store.setState((state) => {
+      return applySort(state, sortKey, sortDirection);
+    });
+  };
+
+  return {
+    store,
+    useOptions,
+    useOption,
+    getOptions,
+    getOption,
+    setOptions,
+    setOption,
+    setSort,
+  };
+};

--- a/frontend/src/Helpers/createPersist.ts
+++ b/frontend/src/Helpers/createPersist.ts
@@ -1,0 +1,21 @@
+import { create, type StateCreator } from 'zustand';
+import { persist, type PersistOptions } from 'zustand/middleware';
+
+export const createPersist = <T>(
+  name: string,
+  state: StateCreator<T>,
+  options: Omit<PersistOptions<T>, 'name' | 'storage'> = {}
+) => {
+  const instanceName =
+    window.Whisparr.instanceName?.toLowerCase().replaceAll(' ', '_') ||
+    'whisparr';
+
+  const finalName = `${instanceName}_${name}`;
+
+  return create(
+    persist<T>(state, {
+      ...options,
+      name: finalName,
+    })
+  );
+};

--- a/frontend/src/Utilities/Table/getToggledRange.ts
+++ b/frontend/src/Utilities/Table/getToggledRange.ts
@@ -1,6 +1,6 @@
-import ModelBase from 'App/ModelBase';
+import { Id, SelectStoreModel } from 'App/Select/useSelectStore';
 
-function getToggledRange<T extends ModelBase>(
+function getToggledRange<T extends SelectStoreModel<Id>>(
   items: T[],
   id: number | string,
   lastToggled: number | string

--- a/package.json
+++ b/package.json
@@ -90,7 +90,8 @@
     "stacktrace-js": "2.0.2",
     "swiper": "12.2.0",
     "typescript": "5.9.3",
-    "use-debounce": "10.1.1"
+    "use-debounce": "10.1.1",
+    "zustand": "5.0.15"
   },
   "devDependencies": {
     "@babel/core": "7.29.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8401,6 +8401,11 @@ zip-stream@^6.0.1:
   resolved "https://registry.yarnpkg.com/zod/-/zod-4.3.6.tgz#89c56e0aa7d2b05107d894412227087885ab112a"
   integrity sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==
 
+zustand@5.0.15:
+  version "5.0.15"
+  resolved "https://registry.yarnpkg.com/zustand/-/zustand-5.0.15.tgz#42bddf35647cb80a818a8943a69f6618c126fcfe"
+  integrity sha512-MpSEjRiBkA9crSYeOUH32rJC7SVqAbm0Fqcqge/bUi2PPoLcBWKOsG+C8mevmpr8TwXHBVkChbbJiyvkE+i/3A==
+
 zwitch@^2.0.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/zwitch/-/zwitch-2.0.4.tgz#c827d4b0acb76fc3e685a4c6ec2902d51070e9d7"


### PR DESCRIPTION
#### Database Migration

NO

#### Description

First step of moving `eros-develop` off Redux and onto React Query, following the route Sonarr took on `v5-develop` (they finished in 54 commits between Sep 2025 and Jun 2026; their tree has no `Store/` directory and no redux dependency at all).

This PR adds only the client-state foundation. **Nothing consumes it yet** — it exists to unblock the per-page conversions, which are otherwise stuck.

The ordering matters and is worth stating, because it explains why the work started but stalled. Movie, Scene, Performer and Studio each got a React Query read hook, but every index page still runs on Redux underneath — `useMovieIndexQuery` is a React Query hook that calls `useSelector` for its filters, and `useMovieIndex` dispatches eight redux actions. A domain index page sits on top of five shared systems: persisted view options, row selection, custom filters, command dispatch and paging. None of the five existed off Redux, so each domain converts ~80% and then hits the same missing floor. Sonarr avoided this by doing peripheral pages and shared plumbing first and not reaching Series until month four.

Added:

- **`Helpers/createPersist.ts`** — zustand + persist wrapper, localStorage keys namespaced by instance name. Replaces `Store/Middleware/createPersistState.js` and `redux-localstorage`.
- **`Helpers/Hooks/useOptionsStore.ts`** — `createOptionsStore` factory for per-page view options (columns, sort, filter key, view mode), including the column-merge logic that preserves a user's column ordering and visibility when the app adds or removes columns across an upgrade. Replaces the `*IndexActions` slices and `createSetTableOptionReducer`.
- **`App/Select/useSelectStore.ts`** — row selection with shift-range and disabled items, with granular subscriptions so a row re-renders only when its own selection changes. Replaces `App/SelectContext.tsx` and `Helpers/Hooks/useSelectState.tsx`.

Also adds `REDUX_MIGRATION.md`: the assessment of where we actually are (327 of 1,255 frontend files still import `react-redux`; 15,374 lines under `Store/`; 66 connectors left) and the phased playbook for the rest, with the Sonarr reference commit for each step.

##### Provenance

These are hand-ports, not cherry-picks — the three files were never added together in Sonarr and each originating commit also rewrites Sonarr-specific code that has no counterpart here:

| File | Sonarr source |
| --- | --- |
| `createPersist.ts` | [Sonarr/Sonarr@591b569b](https://github.com/Sonarr/Sonarr/commit/591b569b) — *Add Series with ReactQuery Mutation*, Feb 2025 |
| `useOptionsStore.ts` | [Sonarr/Sonarr@ae201f52](https://github.com/Sonarr/Sonarr/commit/ae201f52) — *Use react-query for queue UI*, Sep 2025 |
| `useSelectStore.ts` | [Sonarr/Sonarr@910b85f3](https://github.com/Sonarr/Sonarr/commit/910b85f3) — *Improve 'Select All' in Library Import*, Nov 2025 |

Deviations from those originals:

- `window.Sonarr` → `window.Whisparr`.
- **Iterator helpers replaced with `Array.from(...)`** in three places in `useSelectStore` (`Map.values().reduce`/`.some`, `.entries().reduce`). Sonarr relies on the ES2025 iterator helpers; our browserslist is `defaults` with no core-js config covering them, so those would break on older browsers. This is the only behavioural divergence.
- `useOptionsStore` declarations reordered — our eslint enables `no-use-before-define`, Sonarr's does not.
- `getToggledRange` widened from `ModelBase` (`id: number`) to `SelectStoreModel<Id>` (`id: string | number`), matching Sonarr. It had no callers, so nothing else changes.

#### Screenshot(s) (if UI related)

None — no UI change. The primitives have no consumers in this PR.

#### Todos

- [ ] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json) — n/a, no new user-facing strings

On tests: there is no frontend test infrastructure in this repo (no jest/vitest/testing-library, zero `*.test.*` files), and there is none in Sonarr either — they shipped the entire migration without one. Their `NzbDrone.Automation.Test` Selenium project was untouched across the whole migration window, and it doesn't run in CI in either repo (`TestCategory!=AutomationTest` on every leg of `build_v3.yml` / `build_v5.yml`).

What Sonarr leaned on instead was TypeScript, and that's the gap worth naming: they had 23 `.js` files in `frontend/src` before starting, we have 385, concentrated in exactly the code being migrated (all of `Store/Actions`, all 66 connectors). So the migration is also the TypeScript conversion, and that's the verification story — each converted page moves code from unchecked to checked.

Verification on this PR: `tsc --noEmit` clean, `eslint` clean, `yarn build` succeeds. Being straight about the limit — nothing imports these files yet, so webpack never reached them; `tsc` is the only check that actually covered the new code.

##### One thing to watch on this PR specifically

This is the first PR adding new frontend TypeScript, so it's a useful probe for a question that affects every PR in the roadmap. The Sonar scanner sets only `sonar.cs.opencover.reportsPaths` and `frontend/src` is not in `sonar.exclusions`, so frontend files are analysed for issues but have no coverage data. If Sonar counts new frontend TypeScript as uncovered new code, every migration PR trips the 80% new-code gate and the scanner config needs a frontend exclusion or a coverage source before the conversions start.

#### Issues Fixed or Closed by this PR

None.
