### PR TITLE
Chore: Add paged query and client-side filter/sort primitives

### DIFF
--- a/frontend/src/Activity/History/History.tsx
+++ b/frontend/src/Activity/History/History.tsx
@@ -15,7 +15,7 @@ import Table from 'Components/Table/Table';
 import TableBody from 'Components/Table/TableBody';
 import TableOptionsModalWrapper from 'Components/Table/TableOptions/TableOptionsModalWrapper';
 import TablePager from 'Components/Table/TablePager';
-import { PropertyFilter } from 'Filters/Filter';
+import { Filter, PropertyFilter } from 'Filters/Filter';
 import { align, icons, kinds } from 'Helpers/Props';
 import {
   setHistoryFilter,
@@ -60,9 +60,11 @@ function History(props: Partial<HistoryHandlerProps>) {
   const customFilters = useSelector(createCustomFiltersSelector('history'));
   const dispatch = useDispatch();
 
+  // TODO: Remove these casts once the duplicate Filter types in
+  // App/State/AppState are collapsed into Filters/Filter.
   const resolvedFilters = findSelectedFilters(
     selectedFilterKey,
-    filters,
+    filters as Filter[],
     customFilters
   ) as PropertyFilter[];
 

--- a/frontend/src/Helpers/Hooks/usePagedApiQuery.ts
+++ b/frontend/src/Helpers/Hooks/usePagedApiQuery.ts
@@ -1,0 +1,104 @@
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
+import { useMemo } from 'react';
+import { PropertyFilter } from 'Filters/Filter';
+import { SortDirection } from 'Helpers/Props/sortDirections';
+import fetchJson from 'Utilities/Fetch/fetchJson';
+import getQueryPath from 'Utilities/Fetch/getQueryPath';
+import getQueryString from 'Utilities/Fetch/getQueryString';
+import { QueryOptions } from './useApiQuery';
+
+interface PagedQueryOptions<T> extends QueryOptions<PagedQueryResponse<T>> {
+  page: number;
+  pageSize: number;
+  sortKey?: string;
+  sortDirection?: SortDirection;
+  filters?: PropertyFilter[];
+}
+
+export interface PagedQueryResponse<T> {
+  page: number;
+  pageSize: number;
+  sortKey: string;
+  sortDirection: string;
+  totalRecords: number;
+  totalPages: number;
+  records: T[];
+}
+
+const DEFAULT_RECORDS: never[] = [];
+
+const usePagedApiQuery = <T>(options: PagedQueryOptions<T>) => {
+  const { requestOptions, queryKey } = useMemo(() => {
+    const {
+      path,
+      page,
+      pageSize,
+      sortKey,
+      sortDirection,
+      filters,
+      queryParams,
+      queryOptions,
+      ...otherOptions
+    } = options;
+
+    return {
+      queryKey: [
+        path,
+        queryParams,
+        page,
+        pageSize,
+        sortKey,
+        sortDirection,
+        filters,
+      ],
+      requestOptions: {
+        ...otherOptions,
+        path:
+          getQueryPath(path) +
+          getQueryString({
+            ...queryParams,
+            page,
+            pageSize,
+            sortKey,
+            sortDirection,
+            filters,
+          }),
+        headers: {
+          ...options.headers,
+          'X-Api-Key': window.Whisparr.apiKey,
+          'X-Whisparr-Client': 'Whisparr',
+        },
+      },
+    };
+  }, [options]);
+
+  const { data, ...query } = useQuery({
+    ...options.queryOptions,
+    queryKey,
+    queryFn: async ({ signal }) => {
+      const response = await fetchJson<PagedQueryResponse<T>, unknown>({
+        ...requestOptions,
+        signal,
+      });
+
+      return {
+        ...response,
+        totalPages: Math.max(
+          Math.ceil(response.totalRecords / options.pageSize),
+          1
+        ),
+      };
+    },
+    placeholderData: keepPreviousData,
+  });
+
+  return {
+    ...query,
+    queryKey,
+    records: data?.records ?? DEFAULT_RECORDS,
+    totalRecords: data?.totalRecords ?? 0,
+    totalPages: data?.totalPages ?? 0,
+  };
+};
+
+export default usePagedApiQuery;

--- a/frontend/src/Helpers/Props/getFilterTypePredicate.ts
+++ b/frontend/src/Helpers/Props/getFilterTypePredicate.ts
@@ -1,0 +1,115 @@
+import { FilterType } from './filterTypes';
+
+type FilterPredicate<T> = (itemValue: T, filterValue: T) => boolean;
+
+function getFilterTypePredicate<T>(filterType: FilterType): FilterPredicate<T> {
+  if (filterType === 'contains') {
+    return function (itemValue, filterValue) {
+      if (Array.isArray(itemValue)) {
+        return itemValue.some((v) => v === filterValue);
+      }
+
+      if (typeof itemValue === 'string' && typeof filterValue === 'string') {
+        return itemValue.toLowerCase().includes(filterValue.toLowerCase());
+      }
+
+      return false;
+    };
+  }
+
+  if (filterType === 'equal') {
+    return function (itemValue, filterValue) {
+      return itemValue === filterValue;
+    };
+  }
+
+  if (filterType === 'greaterThan') {
+    return function (itemValue, filterValue) {
+      return itemValue > filterValue;
+    };
+  }
+
+  if (filterType === 'greaterThanOrEqual') {
+    return function (itemValue, filterValue) {
+      return itemValue >= filterValue;
+    };
+  }
+
+  if (filterType === 'lessThan') {
+    return function (itemValue, filterValue) {
+      return itemValue < filterValue;
+    };
+  }
+
+  if (filterType === 'lessThanOrEqual') {
+    return function (itemValue, filterValue) {
+      return itemValue <= filterValue;
+    };
+  }
+
+  if (filterType === 'notContains') {
+    return function (itemValue, filterValue) {
+      if (Array.isArray(itemValue)) {
+        return !itemValue.some((v) => v === filterValue);
+      }
+
+      if (typeof itemValue === 'string' && typeof filterValue === 'string') {
+        return !itemValue.toLowerCase().includes(filterValue.toLowerCase());
+      }
+
+      return false;
+    };
+  }
+
+  if (filterType === 'notEqual') {
+    return function (itemValue, filterValue) {
+      return itemValue !== filterValue;
+    };
+  }
+
+  if (filterType === 'startsWith') {
+    return function (itemValue, filterValue) {
+      if (typeof itemValue === 'string' && typeof filterValue === 'string') {
+        return itemValue.toLowerCase().startsWith(filterValue.toLowerCase());
+      }
+
+      return false;
+    };
+  }
+
+  if (filterType === 'notStartsWith') {
+    return function (itemValue, filterValue) {
+      if (typeof itemValue === 'string' && typeof filterValue === 'string') {
+        return !itemValue.toLowerCase().startsWith(filterValue.toLowerCase());
+      }
+
+      return false;
+    };
+  }
+
+  if (filterType === 'endsWith') {
+    return function (itemValue, filterValue) {
+      if (typeof itemValue === 'string' && typeof filterValue === 'string') {
+        return itemValue.toLowerCase().endsWith(filterValue.toLowerCase());
+      }
+
+      return false;
+    };
+  }
+
+  if (filterType === 'notEndsWith') {
+    return function (itemValue, filterValue) {
+      if (typeof itemValue === 'string' && typeof filterValue === 'string') {
+        return !itemValue.toLowerCase().endsWith(filterValue.toLowerCase());
+      }
+
+      return false;
+    };
+  }
+
+  return () => {
+    return false;
+  };
+}
+
+export default getFilterTypePredicate;

--- a/frontend/src/Utilities/Filter/clientSideFilterAndSort.ts
+++ b/frontend/src/Utilities/Filter/clientSideFilterAndSort.ts
@@ -1,0 +1,167 @@
+import _ from 'lodash';
+import ModelBase from 'App/ModelBase';
+import { CustomFilter, Filter } from 'Filters/Filter';
+import { filterTypes, sortDirections } from 'Helpers/Props';
+import { FilterType } from 'Helpers/Props/filterTypes';
+import getFilterTypePredicate from 'Helpers/Props/getFilterTypePredicate';
+import { SortDirection } from 'Helpers/Props/sortDirections';
+import findSelectedFilters from 'Utilities/Filter/findSelectedFilters';
+
+interface ClientSideFilterAndSortOptions<T extends ModelBase, TFilter, TSort> {
+  selectedFilterKey?: string | number;
+  filters?: Filter[];
+  filterPredicates?: Record<
+    keyof TFilter,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (item: T, value: any, type: FilterType) => boolean
+  >;
+  customFilters?: CustomFilter[];
+  sortKey: string;
+  sortDirection: SortDirection;
+  secondarySortKey?: string;
+  secondarySortDirection?: SortDirection;
+  sortPredicates?: Record<
+    keyof TSort,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (item: T, direction: SortDirection) => any
+  >;
+}
+
+const getSortClause = <T, TSort = null>(
+  sortKey: string,
+  sortDirection: SortDirection,
+  sortPredicates?: Record<
+    keyof TSort,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (item: T, direction: SortDirection) => any
+  >
+) => {
+  if (sortPredicates && sortPredicates.hasOwnProperty(sortKey)) {
+    return function (item: T) {
+      return sortPredicates[sortKey as keyof TSort](item, sortDirection);
+    };
+  }
+
+  return function (item: T) {
+    return item[sortKey as keyof T];
+  };
+};
+
+const filter = <T extends ModelBase, TFilter = null, TSort = null>(
+  data: ReadonlyArray<T>,
+  options: ClientSideFilterAndSortOptions<T, TFilter, TSort>
+) => {
+  const { selectedFilterKey, filters, customFilters, filterPredicates } =
+    options;
+
+  if (!selectedFilterKey) {
+    return data;
+  }
+
+  const selectedFilters = findSelectedFilters(
+    selectedFilterKey,
+    filters,
+    customFilters
+  );
+
+  return data.filter((item: T) => {
+    let i = 0;
+    let accepted = true;
+
+    while (accepted && i < selectedFilters.length) {
+      const { key, value, type = filterTypes.EQUAL } = selectedFilters[i];
+
+      if (filterPredicates && filterPredicates.hasOwnProperty(key)) {
+        const predicate = filterPredicates[key as keyof TFilter];
+
+        if (Array.isArray(value)) {
+          if (
+            type === filterTypes.NOT_CONTAINS ||
+            type === filterTypes.NOT_EQUAL
+          ) {
+            accepted = value.every((v) => predicate(item, v, type));
+          } else {
+            accepted = value.some((v) => predicate(item, v, type));
+          }
+        } else {
+          accepted = predicate(item, value, type);
+        }
+      } else if (item.hasOwnProperty(key)) {
+        const predicate = getFilterTypePredicate(type);
+
+        if (Array.isArray(value)) {
+          if (
+            type === filterTypes.NOT_CONTAINS ||
+            type === filterTypes.NOT_EQUAL
+          ) {
+            accepted = value.every((v) => predicate(item[key as keyof T], v));
+          } else {
+            accepted = value.some((v) => predicate(item[key as keyof T], v));
+          }
+        } else {
+          accepted = predicate(item[key as keyof T], value);
+        }
+      } else {
+        // Default to false if the filter can't be tested
+        accepted = false;
+      }
+
+      i++;
+    }
+
+    return accepted;
+  });
+};
+
+const sort = <T extends ModelBase, TFilter = null, TSort = null>(
+  data: ReadonlyArray<T>,
+  options: ClientSideFilterAndSortOptions<T, TFilter, TSort>
+) => {
+  const {
+    sortKey,
+    sortDirection,
+    sortPredicates,
+    secondarySortKey,
+    secondarySortDirection,
+  } = options;
+
+  const clauses = [];
+  const orders: ('asc' | 'desc')[] = [];
+
+  clauses.push(getSortClause(sortKey, sortDirection, sortPredicates));
+  orders.push(sortDirection === sortDirections.ASCENDING ? 'asc' : 'desc');
+
+  if (
+    secondarySortKey &&
+    secondarySortDirection &&
+    (sortKey !== secondarySortKey || sortDirection !== secondarySortDirection)
+  ) {
+    clauses.push(
+      getSortClause(secondarySortKey, secondarySortDirection, sortPredicates)
+    );
+    orders.push(
+      secondarySortDirection === sortDirections.ASCENDING ? 'asc' : 'desc'
+    );
+  }
+
+  return _.orderBy(data, clauses, orders);
+};
+
+const clientSideFilterAndSort = <
+  T extends ModelBase,
+  TFilter = null,
+  TSort = null,
+>(
+  data: ReadonlyArray<T>,
+  options: ClientSideFilterAndSortOptions<T, TFilter, TSort>
+) => {
+  const filteredData = filter(data, options);
+  const sortedData = sort(filteredData, options);
+
+  return {
+    data: sortedData,
+    totalItems: data.length,
+  };
+};
+
+export default clientSideFilterAndSort;

--- a/frontend/src/Utilities/Filter/findSelectedFilters.ts
+++ b/frontend/src/Utilities/Filter/findSelectedFilters.ts
@@ -1,13 +1,17 @@
+import { CustomFilter, Filter } from 'Filters/Filter';
+
 export default function findSelectedFilters(
-  selectedFilterKey,
-  filters = [],
-  customFilters = []
+  selectedFilterKey: string | number,
+  filters: Filter[] = [],
+  customFilters: CustomFilter[] = []
 ) {
   if (!selectedFilterKey) {
     return [];
   }
 
-  let selectedFilter = filters.find((f) => f.key === selectedFilterKey);
+  let selectedFilter: Filter | CustomFilter | undefined = filters.find(
+    (f) => f.key === selectedFilterKey
+  );
 
   if (!selectedFilter) {
     selectedFilter = customFilters.find((f) => f.id === selectedFilterKey);


### PR DESCRIPTION
#### Database Migration

NO

#### Description

Second piece of the React Query migration foundation, after the zustand stores in #452. Branched off `eros-develop` rather than off that branch — these are separate files with no overlap, so the two can merge in either order.

As with #452, **nothing consumes these yet.** They exist to unblock the per-page conversions.

Added:

- **`Helpers/Hooks/usePagedApiQuery.ts`** — server-side paging with `keepPreviousData`, deriving `totalPages` from `totalRecords`. Replaces the hand-rolled paging in `createFetchServerSideCollectionHandler.js` and `Components/Table/usePaging.ts`.
- **`Utilities/Filter/clientSideFilterAndSort.ts`** — the filter/sort engine every index page shares. Replaces `createClientSideCollectionSelector.js` and the four `create*ClientSideCollectionItemsSelector` selectors.

Two supporting changes they depend on:

- **`Helpers/Props/getFilterTypePredicate.ts`** — the function form of the existing `filterTypePredicates` map, which the per-domain `FILTER_PREDICATES` will also need in the domain conversions. Functionally equivalent to the map, but guards on `typeof` instead of assuming strings, and uses `String#includes` rather than the `String#contains` polyfill in `polyfills.js`. **The existing map is untouched** — redux still uses it, and it still works.
- **`Utilities/Filter/findSelectedFilters`** converted `.js` → `.ts` (tracked as a rename; the function body is unchanged, only annotations added). Without this, `clientSideFilterAndSort` imports an untyped module and the whole filter chain degrades to `any`, which defeats the purpose of the conversion. Sonarr has this file as `.ts` for the same reason.

Sourced from Sonarr `v5-develop`. The only deviation is `window.Sonarr` → `window.Whisparr` in `usePagedApiQuery`.

##### One pre-existing issue this surfaced

Typing `findSelectedFilters` revealed that we carry two `Filter` definitions:

| | `App/State/AppState.ts` | `Filters/Filter.ts` |
| --- | --- | --- |
| `type` | `string` | `FilterType` |
| `value` | `boolean \| string \| number \| string[] \| number[]` | `string \| string[] \| number[] \| boolean[] \| DateFilterValue` |

21 files import the filter types from `AppState`, and `useStudioIndexQuery.ts` already imports `Filter`/`PropertyFilter` from one and `CustomFilter` from the other. `History.tsx` was already casting the *return* value of `findSelectedFilters`; once the parameters were typed, the *argument* needed one too.

I've taken a cast plus a `TODO` at that single call site rather than unifying the types. Narrowing `type: string` → `FilterType` across 21 files is a real change with its own fallout, and it belongs with the custom filters conversion, not smuggled into a foundation PR. Flagging it as a deliberate choice rather than an oversight.

#### Screenshot(s) (if UI related)

None — no UI change.

I verified that claim rather than asserting it, since the `History.tsx` edit is a type assertion and type assertions are exactly what the compiler does *not* check. Building `eros-develop` twice gives byte-identical output, so the build is deterministic and a diff is meaningful. Diffing base against this branch, one bundle file differs, and every difference in it is non-executing:

- module id `73266` → `34940` (the file path changed `.js` → `.ts`)
- the sourcemap base64, which encodes that module filename
- `__source: { lineNumber }` values shifted by 2 — JSX dev-build debug metadata, from the two comment lines

The two things that matter are byte-for-byte identical: the emitted `findSelectedFilters` body, and the call site, which on both branches emits `(…)(selectedFilterKey, filters, customFilters)`. The cast and the type-only import erase completely.

#### Todos

- [ ] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json) — n/a, no new user-facing strings

On tests: same position as #452. There is no frontend test infrastructure in this repo, and none in Sonarr either — they shipped their whole migration without one, and their Selenium project does not run in CI in either repo. TypeScript is the safety net, which is why the `.js` → `.ts` conversion above is part of the work rather than incidental to it.

Verification: `tsc --noEmit` clean, `eslint` clean, `yarn build` succeeds. Unlike #452, the build genuinely exercises this change — `findSelectedFilters` is imported by `History.tsx` and three redux files, so it is reachable from the entry point.

Note the quality gate will report 0% coverage on new code here, for the reason explained in #453. If #453 merges first this should come back green.

#### Issues Fixed or Closed by this PR

None.
