### PR TITLE
Chore: Readonly query data and move movie mutations onto useApiMutation

### DIFF
--- a/frontend/src/Components/Page/Header/MovieSearchInput.tsx
+++ b/frontend/src/Components/Page/Header/MovieSearchInput.tsx
@@ -69,7 +69,7 @@ interface Section {
   suggestions: MovieSuggestion[] | AddNewMovieSuggestion[];
 }
 
-function moviesToSuggestions(movies: Movie[]): MovieSuggestion[] {
+function moviesToSuggestions(movies: readonly Movie[]): MovieSuggestion[] {
   return movies.map((m, i) => ({
     key: m.id,
     title: m.title,

--- a/frontend/src/Helpers/Hooks/useApiQuery.ts
+++ b/frontend/src/Helpers/Hooks/useApiQuery.ts
@@ -10,7 +10,10 @@ import getQueryString, { QueryParams } from 'Utilities/Fetch/getQueryString';
 export interface QueryOptions<T> extends FetchJsonOptions<unknown> {
   queryParams?: QueryParams;
   queryOptions?:
-    | Omit<UndefinedInitialDataOptions<T, ApiError>, 'queryKey' | 'queryFn'>
+    | Omit<
+        UndefinedInitialDataOptions<Readonly<T>, ApiError>,
+        'queryKey' | 'queryFn'
+      >
     | undefined;
 }
 
@@ -49,7 +52,7 @@ const useApiQuery = <T>(options: QueryOptions<T>) => {
       ...options.queryOptions,
       queryKey,
       queryFn: async ({ signal }) =>
-        fetchJson<T, unknown>({ ...requestOptions, signal }),
+        fetchJson<Readonly<T>, unknown>({ ...requestOptions, signal }),
     }),
   };
 };

--- a/frontend/src/Movie/Details/Credits/MovieCreditPosters.tsx
+++ b/frontend/src/Movie/Details/Credits/MovieCreditPosters.tsx
@@ -32,7 +32,7 @@ function calculateRowHeight(posterHeight: number, isSmallScreen: boolean) {
 }
 
 interface Props {
-  items: MovieCredit[];
+  items: readonly MovieCredit[];
   itemComponent: React.ElementType;
   isSmallScreen: boolean;
 }

--- a/frontend/src/Movie/Details/MovieDetails.tsx
+++ b/frontend/src/Movie/Details/MovieDetails.tsx
@@ -211,7 +211,7 @@ function MovieDetails(props: Readonly<Partial<Props>>) {
 
   function handleMonitoredPress() {
     if (!movie) return;
-    toggleMonitored({ movie, monitored: !monitored });
+    toggleMonitored({ id: movie.id, monitored: !monitored });
   }
 
   return (

--- a/frontend/src/Movie/Edit/EditMovieModalContent.tsx
+++ b/frontend/src/Movie/Edit/EditMovieModalContent.tsx
@@ -50,16 +50,19 @@ function EditMovieModalContent({
   const [isRootFolderModalOpen, setIsRootFolderModalOpen] = useState(false);
   const [isConfirmMoveModalOpen, setIsConfirmMoveModalOpen] = useState(false);
 
-  const saveMovie = useSaveMovie();
+  // moveFiles is a query param, so it is fixed per mutation instance rather
+  // than passed at mutate() time. The component has exactly two save paths.
+  const saveMovie = useSaveMovie(false);
+  const saveMovieAndMoveFiles = useSaveMovie(true);
 
-  const isSaving = saveMovie.isPending;
+  const isSaving = saveMovie.isPending || saveMovieAndMoveFiles.isPending;
   // Map ApiError to the { status, responseJSON } shape expected by
   // selectSettings and SpinnerErrorButton.
   const saveError = useMemo(() => {
-    const err = saveMovie.error;
+    const err = saveMovie.error ?? saveMovieAndMoveFiles.error;
     if (!err) return undefined;
     return { status: err.statusCode, responseJSON: err.statusBody };
-  }, [saveMovie.error]);
+  }, [saveMovie.error, saveMovieAndMoveFiles.error]);
 
   // Compute which fields have pending (unsaved) changes so selectSettings
   // can mark them accordingly.
@@ -182,12 +185,19 @@ function EditMovieModalContent({
 
   const doSave = useCallback(
     (moveFiles: boolean) => {
-      saveMovie.mutate({
-        movie: { ...movie, monitored, qualityProfileId, path, tags },
-        moveFiles,
-      });
+      const mutation = moveFiles ? saveMovieAndMoveFiles : saveMovie;
+
+      mutation.mutate({ ...movie, monitored, qualityProfileId, path, tags });
     },
-    [saveMovie, movie, monitored, qualityProfileId, path, tags]
+    [
+      saveMovie,
+      saveMovieAndMoveFiles,
+      movie,
+      monitored,
+      qualityProfileId,
+      path,
+      tags,
+    ]
   );
 
   const handleSavePress = useCallback(() => {
@@ -205,10 +215,10 @@ function EditMovieModalContent({
   }, [doSave]);
 
   useEffect(() => {
-    if (saveMovie.isSuccess) {
+    if (saveMovie.isSuccess || saveMovieAndMoveFiles.isSuccess) {
       onModalClose();
     }
-  }, [saveMovie.isSuccess, onModalClose]);
+  }, [saveMovie.isSuccess, saveMovieAndMoveFiles.isSuccess, onModalClose]);
 
   return (
     <ModalContent onModalClose={onModalClose}>

--- a/frontend/src/Movie/useMovie.ts
+++ b/frontend/src/Movie/useMovie.ts
@@ -1,33 +1,7 @@
-import { useMutation } from '@tanstack/react-query';
 import { queryClient } from 'App/queryClient';
+import useApiMutation from 'Helpers/Hooks/useApiMutation';
 import useApiQuery from 'Helpers/Hooks/useApiQuery';
-import getQueryPath from 'Utilities/Fetch/getQueryPath';
-import fetchJson, { ApiError } from '../Utilities/Fetch/fetchJson';
 import Movie, { MoviePatchResource } from './Movie';
-
-// Shared auth headers for all API calls
-const AUTH_HEADERS = {
-  'X-Api-Key': globalThis.Whisparr.apiKey,
-  'X-Whisparr-Client': 'Whisparr',
-};
-
-function apiPut<T, TBody>(path: string, body: TBody) {
-  return fetchJson<T, TBody>({
-    path: getQueryPath(path),
-    method: 'PUT',
-    body,
-    headers: AUTH_HEADERS,
-  });
-}
-
-function apiPatch<T, TBody>(path: string, body: TBody) {
-  return fetchJson<T, TBody>({
-    path: getQueryPath(path),
-    method: 'PATCH',
-    body,
-    headers: AUTH_HEADERS,
-  });
-}
 
 // Fetch a single movie by titleSlug or movieId
 export function useMovie(titleSlug: string | number | undefined) {
@@ -47,41 +21,34 @@ export function useMoviesByForeignIds(foreignIds: string[] | undefined) {
   });
 }
 
-// TODO: Move to useApiMutation
 export function useToggleMovieMonitored() {
-  return useMutation({
-    mutationFn: ({ movie, monitored }: { movie: Movie; monitored: boolean }) =>
-      apiPatch<Movie, MoviePatchResource>(`/movie/${movie.id}`, {
-        id: movie.id,
-        monitored,
-      }),
-    onSuccess: (data) => {
-      queryClient.setQueryData([`/movie/${data.titleSlug}`], data);
+  return useApiMutation<Movie, MoviePatchResource>({
+    method: 'PATCH',
+    path: ({ id }) => `/movie/${id}`,
+    mutationOptions: {
+      onSuccess: (data) => {
+        queryClient.setQueryData([`/movie/${data.titleSlug}`], data);
+      },
     },
   });
 }
 
-// TODO: Move to useApiMutation
-export function useSaveMovie() {
-  return useMutation<Movie, ApiError, { movie: Movie; moveFiles?: boolean }>({
-    mutationFn: ({
-      movie,
-      moveFiles = false,
-    }: {
-      movie: Movie;
-      moveFiles?: boolean;
-    }) => {
-      const url = moveFiles
-        ? `/movie/${movie.id}?moveFiles=true`
-        : `/movie/${movie.id}`;
-      return apiPut<Movie, Movie>(url, movie);
-    },
-    onSuccess: (data) => {
-      queryClient.setQueryData([`/movie/${data.titleSlug}`], data);
-      queryClient.invalidateQueries({ queryKey: ['/movie/paged'] });
-    },
-    onError: (error) => {
-      console.error('useSaveMovie error', error);
+export function useSaveMovie(moveFiles = false) {
+  return useApiMutation<Movie, Movie>({
+    method: 'PUT',
+    path: ({ id }) => `/movie/${id}`,
+    // Passed only when moving. getQueryString emits `moveFiles=false` for a
+    // literal false, where the previous hand-rolled URL omitted the param
+    // entirely.
+    queryParams: moveFiles ? { moveFiles: true } : undefined,
+    mutationOptions: {
+      onSuccess: (data) => {
+        queryClient.setQueryData([`/movie/${data.titleSlug}`], data);
+        queryClient.invalidateQueries({ queryKey: ['/movie/paged'] });
+      },
+      onError: (error) => {
+        console.error('useSaveMovie error', error);
+      },
     },
   });
 }

--- a/frontend/src/MovieFile/Editor/MovieFileEditorTableContent.tsx
+++ b/frontend/src/MovieFile/Editor/MovieFileEditorTableContent.tsx
@@ -11,7 +11,7 @@ import styles from './MovieFileEditorTableContent.css';
 export interface MovieFileEditorTableContentProps {
   movieId?: number;
   isDeleting: boolean;
-  items: MovieFile[];
+  items: readonly MovieFile[];
   columns: Column[];
   sortKey: string;
   sortDirection: SortDirection;

--- a/frontend/src/MovieFile/Extras/ExtraFileTableContent.tsx
+++ b/frontend/src/MovieFile/Extras/ExtraFileTableContent.tsx
@@ -32,7 +32,7 @@ const columns = [
 
 interface ExtraFileTableContentProps {
   movieId?: number;
-  items: ExtraFileRowProps[];
+  items: readonly ExtraFileRowProps[];
 }
 
 function ExtraFileTableContent({ items }: ExtraFileTableContentProps) {

--- a/frontend/src/Performer/Details/SceneRow.tsx
+++ b/frontend/src/Performer/Details/SceneRow.tsx
@@ -71,7 +71,7 @@ export default function SceneRow(props: SceneRowProps) {
 
   const { mutate: toggleMonitored } = useToggleMovieMonitored();
   function onMonitorToggle(): void {
-    toggleMonitored({ movie, monitored: !movie.monitored });
+    toggleMonitored({ id: movie.id, monitored: !movie.monitored });
   }
 
   const url = externalLink();

--- a/frontend/src/Studio/Details/SceneRow.tsx
+++ b/frontend/src/Studio/Details/SceneRow.tsx
@@ -64,7 +64,7 @@ const onDetailsModalClose = (): void => {
 
   const { mutate: toggleMonitored } = useToggleMovieMonitored();
   function onMonitorToggle(): void {
-    toggleMonitored({ movie, monitored: !movie.monitored });
+    toggleMonitored({ id: movie.id, monitored: !movie.monitored });
   }
 
   return (

--- a/frontend/src/Studio/Details/useStudioDetails.ts
+++ b/frontend/src/Studio/Details/useStudioDetails.ts
@@ -391,7 +391,7 @@ export function ensureImageType(
  * @returns {StudioWorksData} Organized works data with year groupings and UI state
  */
 export function buildStudioWorksData(
-  allWorks: Movie[],
+  allWorks: readonly Movie[],
   expandedState: Record<number, boolean>
 ): StudioWorksData {
   const years = Array.from(

--- a/frontend/src/UnmappedFiles/UnmappedFilesTable.tsx
+++ b/frontend/src/UnmappedFiles/UnmappedFilesTable.tsx
@@ -36,7 +36,7 @@ export interface UnmappedFilesTableProps {
   isDeleting: boolean;
   deleteError?: object;
   error?: object;
-  items: UnmappedFile[];
+  items: readonly UnmappedFile[];
   columns: Array<{ name: string; isVisible: boolean }>;
   onTableOptionChange: (payload: unknown) => void;
   fetchUnmappedFiles: () => void;
@@ -115,8 +115,10 @@ class UnmappedFilesTable extends Component<
   getSortedItems() {
     const { items } = this.props;
     const { sortKey, sortDirection } = this.state;
+    // Copy in both branches: query data is readonly, and the caller passes the
+    // result to VirtualTable, which takes a mutable array.
     if (!sortKey) {
-      return items;
+      return [...items];
     }
     return [...items].sort((a, b) => {
       let valA: string | number = '';

--- a/frontend/src/Utilities/Table/getToggledRange.ts
+++ b/frontend/src/Utilities/Table/getToggledRange.ts
@@ -1,7 +1,7 @@
 import { Id, SelectStoreModel } from 'App/Select/useSelectStore';
 
 function getToggledRange<T extends SelectStoreModel<Id>>(
-  items: T[],
+  items: readonly T[],
   id: number | string,
   lastToggled: number | string
 ) {

--- a/frontend/src/Utilities/Table/toggleSelected.ts
+++ b/frontend/src/Utilities/Table/toggleSelected.ts
@@ -5,7 +5,7 @@ import getToggledRange from './getToggledRange';
 
 function toggleSelected<T extends ModelBase>(
   selectState: SelectState,
-  items: T[],
+  items: readonly T[],
   id: number | string,
   selected: boolean | null,
   shiftKey: boolean


### PR DESCRIPTION
#### Database Migration

NO

#### Description

Final piece of the React Query foundation, after Whisparr/Whisparr#452 (zustand stores) and Whisparr/Whisparr#454 (paged query and filter/sort). Two independent commits.

##### 1. `Readonly<T>` on query results — `439056a5b3`

`useApiQuery` returned a mutable `T`, so nothing stopped a component sorting or splicing a cached array in place. Under Redux that was contained; under React Query a cached object is shared by every component reading that key, so an in-place edit silently corrupts other views.

Sonarr hit this and fixed it late, in [Sonarr/Sonarr@9bed77c6](https://github.com/Sonarr/Sonarr/commit/9bed77c6) *"Avoid mutation for react-query data"*, at a cost of 37 files. Doing it now, while there are ~34 `useApiQuery` call sites rather than hundreds, cost 8 — and it protects every page converted from here on.

**No live mutation bug was found.** All six initial errors were signature mismatches — readonly data passed into a parameter or prop typed as a mutable array — so the fixes are widenings:

- `moviesToSuggestions`, `buildStudioWorksData` — parameters
- `MovieFileEditorTableContent`, `MovieCreditPosters`, `ExtraFileTableContent`, `UnmappedFilesTable` — `items` props
- `toggleSelected`, `getToggledRange` — `items` params; both only read

`UnmappedFilesTable.getSortedItems` now copies in both branches. It already copied before sorting, but returned the readonly array unchanged when unsorted, and its caller passes the result to `VirtualTable`, which takes a mutable array. Copying there keeps the widening out of `VirtualTable`, which every table in the app shares — that would have been a much wider blast radius for no benefit.

Note `Readonly<T>` is shallow: it stops array mutation (`sort`, `push`, `splice`) but not deep property assignment on the items. Sonarr has the same limitation.

##### 2. Movie mutations onto `useApiMutation` — `cc3012a7d8`

Removes the last hand-rolled fetch helpers in `useMovie` — a module-level `AUTH_HEADERS` plus `apiPut` and `apiPatch` — and resolves both `// TODO: Move to useApiMutation` markers. `useApiMutation` covers these without extension; it already supports `PATCH` and a function-valued `path`, neither of which Sonarr's version has.

**Request shapes are unchanged.** `getQueryPath` is plain string concatenation, so all three URLs are byte-identical to the hand-built ones:

```
toggle  /movie/{id}
save    /movie/{id}
move    /movie/{id}?moveFiles=true
```

Two caller-facing consequences:

- **`useToggleMovieMonitored` now takes `MoviePatchResource`** rather than `{ movie, monitored }`, because `useApiMutation` sends the mutate argument as the body and the whole `Movie` was being discarded. Three callers updated: the Studio and Performer detail `SceneRow`s, and `MovieDetails`.
- **`moveFiles` is a query param**, so it is fixed per mutation instance rather than passed at `mutate()` time. `useSaveMovie` takes it as a hook argument, matching Sonarr's `useSaveSeries`, and `EditMovieModalContent` holds two instances for its two static save paths. It is passed only when true — `getQueryString` emits `moveFiles=false` for a literal `false`, where the previous hand-rolled URL omitted the param entirely.

I considered extending `useApiMutation` to accept a function-valued `queryParams`, mirroring how `path` already works, but it does not pay off: the body would also need transforming, since `TData` would become `{ movie, moveFiles }` while the body should be just the movie. Two extensions to a shared primitive to serve one call site.

#### Screenshot(s) (if UI related)

No visual change — this is the data layer.

#### Todos

- [x] Tests — see below
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json) — n/a, no new user-facing strings

**Static:** `tsc --noEmit` clean, `eslint` clean across all of `frontend/`, `yarn build` succeeds.

**Manual, against a real library.** Because this changes live behaviour rather than adding files, it was run locally against a copy of a real 16,922-movie library, with indexers, download clients, notifications and import lists stripped from the copy first.

Verified by clicking, all passing:

- toggle monitored on movie details
- toggle monitored on scene details
- toggle monitored on performer scene rows
- toggle monitored on studio scene rows

Verified at the API level, exercising the exact requests the new code emits:

| Request | Result |
| --- | --- |
| `PATCH /movie/{id}` body `{id, monitored:false}` | 200, state flipped, response carries `titleSlug` for the cache write |
| `PUT /movie/{id}` | 202 |
| `PUT /movie/{id}?moveFiles=true` | 202 |

**Not click-tested:** the Edit Movie → Save flows. The API-level checks above cover the requests, but the two-mutation-instance restructure in `EditMovieModalContent` — combining `isPending`, `error` and the close-on-success `useEffect` across both instances — has not been exercised through the UI. That is the part of this PR I would review most closely.

#### Issues Fixed or Closed by this PR

None. Related: Whisparr/Whisparr-Eros#845, filed for the same hand-rolled `AUTH_HEADERS` pattern still present in `useStudio`, `usePerformer`, `useHistory` and `useAddNewMovie` — deliberately left out of this PR to keep its scope contained.

Also worth recording, not addressed here: toggling a movie's monitored state still has two live implementations. This react-query hook serves movie/scene details and the studio and performer scene rows, while the Collection overview connectors still dispatch the redux `toggleMovieMonitored` thunk, and the two do not share cache invalidation. Collection is the least-migrated area and has no Sonarr analogue to follow. Movie and Scene index rows display monitored state but expose no toggle.
