### PR TITLE
Chore: Stop Dependabot proposing redux upgrades

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,6 +30,9 @@ updates:
           - "eslint-*"
           - "@eslint/*"
           - "@typescript-eslint/*"
+      # Every member of this group is currently ignored (see below), so it
+      # produces no PRs today. Kept so grouping still applies if the redux
+      # migration is ever abandoned and the ignore entries are dropped.
       redux:
         patterns:
           - "redux"
@@ -62,6 +65,24 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: "swiper"
         update-types: ["version-update:semver-major"]
+      # The redux family is being removed, not upgraded. The frontend is
+      # migrating to React Query and zustand, after which every one of these
+      # is deleted from package.json. Bumping them in the meantime is churn
+      # against code with a scheduled demolition date -- react-redux 9.3.0,
+      # which #395 kept proposing, exists mainly to mark `connect` deprecated,
+      # and we still have 66 connectors to delete rather than migrate.
+      #
+      # No update-types filter: ignore every update, not just majors. Drop
+      # these entries only if the migration is abandoned.
+      #
+      # reselect is included because it is only used by redux selectors, and
+      # @types/redux-actions needs naming explicitly -- it matches none of the
+      # redux group's patterns, so it would otherwise land in prod-minor.
+      - dependency-name: "redux"
+      - dependency-name: "redux-*"
+      - dependency-name: "react-redux"
+      - dependency-name: "reselect"
+      - dependency-name: "@types/redux-actions"
   - package-ecosystem: "nuget"
     directory: "/src"
     schedule:


### PR DESCRIPTION
#### Database Migration

NO

#### Description

Adds the redux family to the npm `ignore` list so Dependabot stops proposing upgrades to packages that are on their way out.

The frontend is migrating from Redux to React Query and zustand. When that lands, every one of these is deleted from `package.json`, so bumping them in the meantime is churn against code with a scheduled demolition date.

#395 is the case in point. It keeps coming back proposing `react-redux` 7.2.4 → 9.3.0 — a release whose headline change is officially marking the `connect` API as deprecated. There are still 66 `*Connector` files in the tree, and the plan is to delete them, not migrate them off `connect`.

Ignored:

```yaml
- dependency-name: "redux"
- dependency-name: "redux-*"
- dependency-name: "react-redux"
- dependency-name: "reselect"
- dependency-name: "@types/redux-actions"
```

Deliberately no `update-types` filter, unlike the existing entries above it — those defer majors, this ignores every update, because no version of these is wanted.

Two entries are worth explaining:

- **`reselect`** is only used by redux selectors. I checked every importer: all of them are `*Connector.js` files or `Store/Selectors`, so it goes when they do.
- **`@types/redux-actions`** has to be named explicitly. It matches none of the `redux` group's patterns (`redux`, `redux-*`, `react-redux`, `reselect`), so without its own entry it would land in the `prod-minor` group and keep appearing there.

`redux-*` covers `redux-actions`, `redux-batched-actions`, `redux-localstorage` and `redux-thunk`.

The `redux` group itself is kept, with a comment noting every member is now ignored. It produces no PRs today, but if the migration were ever abandoned and these entries dropped, the grouping should still apply rather than having to be reconstructed.

#### Screenshot(s) (if UI related)

None — Dependabot configuration only.

#### Todos

- [x] Tests — n/a, configuration
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json) — n/a

Validated for tab characters and correct placement of the new entries within the npm ecosystem's `ignore` block, ahead of the `nuget` section.

Note this takes effect on Dependabot's next run against `eros-develop`. #395 should be closed once this merges — Dependabot normally closes PRs for newly ignored dependencies itself, but worth confirming rather than assuming.

#### Issues Fixed or Closed by this PR

None.
