### PR TITLE
Use react-query for Log Files

### DIFF
--- a/REDUX_MIGRATION.md
+++ b/REDUX_MIGRATION.md
@@ -20,10 +20,10 @@ verified to resolve against the public repo.
 | Metric | At assessment | Now |
 | --- | --- | --- |
 | Files importing `react-redux` | 327 of 1,255 | **324** of 1,259 |
-| Lines under `frontend/src/Store/` | 15,374 across 138 files | **15,261** across 137 |
+| Lines under `frontend/src/Store/` | 15,374 across 138 files | **15,226** across 137 |
 | Redux action slices | 41 | **40** |
 | Remaining `*Connector` files | 66 | 66 |
-| Files touching React Query | 13 | **37** |
+| Files touching React Query | 13 | **39** |
 | zustand stores | 0 (not installed) | **installed, 3 primitives** |
 
 The headline number barely moves early on, and that is expected: Phase A added the
@@ -129,7 +129,7 @@ a whole state slice. Take them roughly in Sonarr's order.
 | **Blocklist** — incl. per-movie blocklist tab | `blocklistActions`, `movieBlocklistActions` | [Sonarr/Sonarr@a4f21085](https://github.com/Sonarr/Sonarr/commit/a4f21085) |
 | **History** *(hybrid)* — `useHistory` covers paged list + movie history; finish details modal | `historyActions`, `movieHistoryActions`, `HistoryDetailsConnector` ×2 | [Sonarr/Sonarr@a45b0776](https://github.com/Sonarr/Sonarr/commit/a45b0776), [Sonarr/Sonarr@6b479a5a](https://github.com/Sonarr/Sonarr/commit/6b479a5a) |
 | **System: Status / Health** — ~~Disk Space **done, #461**~~. Health has the sidebar dependency, so it goes last | `systemActions` (391 loc after #461), `createHealthCheckSelector.js`, `createSystemStatusSelector.ts` | [Sonarr/Sonarr@49c52c2e](https://github.com/Sonarr/Sonarr/commit/49c52c2e), [Sonarr/Sonarr@0552a811](https://github.com/Sonarr/Sonarr/commit/0552a811), ~~[Sonarr/Sonarr@871ae955](https://github.com/Sonarr/Sonarr/commit/871ae955)~~ |
-| **System: Tasks / Backups / Log Files / Events** | `BackupsConnector.js`, `RestoreBackupModal*Connector.js`, `LogsTableConnector.js` | [Sonarr/Sonarr@3091f40c](https://github.com/Sonarr/Sonarr/commit/3091f40c), [Sonarr/Sonarr@c295e24f](https://github.com/Sonarr/Sonarr/commit/c295e24f), [Sonarr/Sonarr@ff5e7327](https://github.com/Sonarr/Sonarr/commit/ff5e7327) |
+| **System: Tasks / Backups / Events** — ~~Log Files **done, #462**~~ | `BackupsConnector.js`, `RestoreBackupModal*Connector.js`, `LogsTableConnector.js` | [Sonarr/Sonarr@3091f40c](https://github.com/Sonarr/Sonarr/commit/3091f40c), [Sonarr/Sonarr@c295e24f](https://github.com/Sonarr/Sonarr/commit/c295e24f), [Sonarr/Sonarr@ff5e7327](https://github.com/Sonarr/Sonarr/commit/ff5e7327) |
 | **Calendar** — 12 files; needs the options store from phase A | `calendarActions` (443 loc), `CalendarAppState` | [Sonarr/Sonarr@ccb7f07c](https://github.com/Sonarr/Sonarr/commit/ccb7f07c) (28 files) |
 | ~~**Parse**~~ — **done, #458.** 14 files, +77/−337 | ~~`parseActions.ts`, `ParseAppState`~~ | [Sonarr/Sonarr@263f4839](https://github.com/Sonarr/Sonarr/commit/263f4839) |
 | **Wanted: Missing + Cutoff Unmet** — one commit; first real `usePagedApiQuery` consumer | `wantedActions` (342 loc), `WantedAppState` | [Sonarr/Sonarr@40712781](https://github.com/Sonarr/Sonarr/commit/40712781) |
@@ -258,11 +258,9 @@ Phase A is done; Parse and Disk Space are converted. Continuing through Phase B
 smallest-first, rather than jumping straight to Queue — the point of the early pages is to
 make the PR shape routine before anything expensive.
 
-1. **Log Files** — [Sonarr/Sonarr@ff5e7327](https://github.com/Sonarr/Sonarr/commit/ff5e7327),
-   4 files. Next smallest, and another partial trim of `systemActions`.
-2. **System Status**, then **Health** — the rest of the `systemActions` cluster. Health
-   goes last because it feeds the sidebar; converting it last means the slice can be
-   retired in the same PR.
+1. **System Status**, then **Health** — with tasks, backups and events, these are what
+   is left of `systemActions`. Health goes last because it feeds the sidebar; converting it
+   last means the slice can be retired in the same PR as the page that finishes it.
 3. **Organize preview + Unmapped Files** — two small pages, one PR.
 4. **Then Queue**, as Sonarr did, because it forces SignalR-driven invalidation into
    existence early rather than late. This is the first genuinely large one at 58 files, and
@@ -293,6 +291,17 @@ Worth repeating verbatim on each page:
    its phase table, the next-up list above, and a row in the §11 log. It is the progress
    tracker; keeping it current is part of the work, not a follow-up. It costs a minute
    while the numbers are in front of you and is archaeology later.
+
+**A component can convert halfway, and often should.** Log Files (#462) moved its data
+fetching to React Query but kept `useDispatch` and `createCommandExecutingSelector` for
+the delete-logs command, because commands are Phase C. Sonarr's version of that page uses
+their `Commands/useCommands` hooks, which do not exist here yet — porting it wholesale
+would have dragged the 44-consumer commands slice into a four-file PR. Convert the concern
+the PR is about and leave the rest; the file will be visited again.
+
+The consequence is that the `react-redux` import count moves more slowly than the work
+does. A page can be most of the way converted and still import `react-redux` for one
+selector. The slice line count and the phase tables are the better progress signal.
 
 ### On testing — what Sonarr actually did
 
@@ -359,6 +368,7 @@ If a JS test runner is ever added, remove that line and set
 | 2026-08-16 | #456 | Dependabot: ignore the redux family — it is being removed, not upgraded. |
 | 2026-08-17 | #458 | **Parse.** First page conversion. Slice retired; unreachable `Parse.tsx` deleted. |
 | 2026-08-17 | #461 | **Disk Space.** 4 files, +19/−34. Partial trim of `systemActions`; slice survives for status, health, tasks, backups, logs, updates. |
+| 2026-08-17 | #462 | **Log Files.** App and update logs. First *partial component* conversion — the fetch half moves, the command half stays on redux until Phase C. |
 
 ### Open threads
 

--- a/frontend/src/App/State/SystemAppState.ts
+++ b/frontend/src/App/State/SystemAppState.ts
@@ -1,5 +1,4 @@
 import Health from 'typings/Health';
-import LogFile from 'typings/LogFile';
 import SystemStatus from 'typings/SystemStatus';
 import Task from 'typings/Task';
 import Update from 'typings/Update';
@@ -8,15 +7,12 @@ import AppSectionState, { AppSectionItemState } from './AppSectionState';
 export type HealthAppState = AppSectionState<Health>;
 export type SystemStatusAppState = AppSectionItemState<SystemStatus>;
 export type TaskAppState = AppSectionState<Task>;
-export type LogFilesAppState = AppSectionState<LogFile>;
 export type UpdateAppState = AppSectionState<Update>;
 
 interface SystemAppState {
   health: HealthAppState;
-  logFiles: LogFilesAppState;
   status: SystemStatusAppState;
   tasks: TaskAppState;
-  updateLogFiles: LogFilesAppState;
   updates: UpdateAppState;
 }
 

--- a/frontend/src/Store/Actions/systemActions.js
+++ b/frontend/src/Store/Actions/systemActions.js
@@ -152,19 +152,6 @@ export const defaultState = {
     ],
   },
 
-  logFiles: {
-    isFetching: false,
-    isPopulated: false,
-    error: null,
-    items: [],
-  },
-
-  updateLogFiles: {
-    isFetching: false,
-    isPopulated: false,
-    error: null,
-    items: [],
-  },
 };
 
 export const persistState = [
@@ -201,10 +188,6 @@ export const SET_LOGS_FILTER = 'system/logs/setLogsFilter';
 export const SET_LOGS_TABLE_OPTION = 'system/logs/setLogsTableOption';
 export const CLEAR_LOGS_TABLE = 'system/logs/clearLogsTable';
 
-export const FETCH_LOG_FILES = 'system/logFiles/fetchLogFiles';
-export const FETCH_UPDATE_LOG_FILES =
-  'system/updateLogFiles/fetchUpdateLogFiles';
-
 export const RESTART = 'system/restart';
 export const SHUTDOWN = 'system/shutdown';
 
@@ -234,9 +217,6 @@ export const setLogsSort = createThunk(SET_LOGS_SORT);
 export const setLogsFilter = createThunk(SET_LOGS_FILTER);
 export const setLogsTableOption = createAction(SET_LOGS_TABLE_OPTION);
 export const clearLogsTable = createAction(CLEAR_LOGS_TABLE);
-
-export const fetchLogFiles = createThunk(FETCH_LOG_FILES);
-export const fetchUpdateLogFiles = createThunk(FETCH_UPDATE_LOG_FILES);
 
 export const restart = createThunk(RESTART);
 export const shutdown = createThunk(SHUTDOWN);
@@ -321,11 +301,6 @@ export const actionHandlers = handleThunks({
   [DELETE_BACKUP]: createRemoveItemHandler(backupsSection, '/system/backup'),
 
   [FETCH_UPDATES]: createFetchHandler('system.updates', '/update'),
-  [FETCH_LOG_FILES]: createFetchHandler('system.logFiles', '/log/file'),
-  [FETCH_UPDATE_LOG_FILES]: createFetchHandler(
-    'system.updateLogFiles',
-    '/log/file/update'
-  ),
 
   ...createServerSideCollectionHandlers('system.logs', '/log', fetchLogs, {
     [serverSideCollectionHandlers.FETCH]: FETCH_LOGS,

--- a/frontend/src/System/Logs/App/AppLogFiles.tsx
+++ b/frontend/src/System/Logs/App/AppLogFiles.tsx
@@ -1,46 +1,39 @@
-import React, { useCallback, useEffect } from 'react';
+import React, { useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import AppState from 'App/State/AppState';
 import * as commandNames from 'Commands/commandNames';
 import { executeCommand } from 'Store/Actions/commandActions';
-import { fetchLogFiles } from 'Store/Actions/systemActions';
 import createCommandExecutingSelector from 'Store/Selectors/createCommandExecutingSelector';
 import LogFiles from '../LogFiles';
+import useLogFiles from '../useLogFiles';
 
 function AppLogFiles() {
   const dispatch = useDispatch();
-  const { isFetching, items } = useSelector(
-    (state: AppState) => state.system.logFiles
-  );
+  const { data = [], isFetching, refetch } = useLogFiles();
 
   const isDeleteFilesExecuting = useSelector(
     createCommandExecutingSelector(commandNames.DELETE_LOG_FILES)
   );
 
   const handleRefreshPress = useCallback(() => {
-    dispatch(fetchLogFiles());
-  }, [dispatch]);
+    refetch();
+  }, [refetch]);
 
   const handleDeleteFilesPress = useCallback(() => {
     dispatch(
       executeCommand({
         name: commandNames.DELETE_LOG_FILES,
         commandFinished: () => {
-          dispatch(fetchLogFiles());
+          refetch();
         },
       })
     );
-  }, [dispatch]);
-
-  useEffect(() => {
-    dispatch(fetchLogFiles());
-  }, [dispatch]);
+  }, [dispatch, refetch]);
 
   return (
     <LogFiles
       isDeleteFilesExecuting={isDeleteFilesExecuting}
       isFetching={isFetching}
-      items={items}
+      items={data}
       type="app"
       onRefreshPress={handleRefreshPress}
       onDeleteFilesPress={handleDeleteFilesPress}

--- a/frontend/src/System/Logs/LogFiles.tsx
+++ b/frontend/src/System/Logs/LogFiles.tsx
@@ -42,7 +42,7 @@ type LogFileType = 'app' | 'update';
 
 interface LogFilesProps {
   isFetching: boolean;
-  items: LogFile[];
+  items: readonly LogFile[];
   isDeleteFilesExecuting: boolean;
   type: LogFileType;
   onRefreshPress: () => void;

--- a/frontend/src/System/Logs/Update/UpdateLogFiles.tsx
+++ b/frontend/src/System/Logs/Update/UpdateLogFiles.tsx
@@ -1,46 +1,39 @@
-import React, { useCallback, useEffect } from 'react';
+import React, { useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import AppState from 'App/State/AppState';
 import * as commandNames from 'Commands/commandNames';
 import { executeCommand } from 'Store/Actions/commandActions';
-import { fetchUpdateLogFiles } from 'Store/Actions/systemActions';
 import createCommandExecutingSelector from 'Store/Selectors/createCommandExecutingSelector';
 import LogFiles from '../LogFiles';
+import { useUpdateLogFiles } from '../useLogFiles';
 
 function UpdateLogFiles() {
   const dispatch = useDispatch();
-  const { isFetching, items } = useSelector(
-    (state: AppState) => state.system.updateLogFiles
-  );
+  const { data = [], isFetching, refetch } = useUpdateLogFiles();
 
   const isDeleteFilesExecuting = useSelector(
     createCommandExecutingSelector(commandNames.DELETE_UPDATE_LOG_FILES)
   );
 
   const handleRefreshPress = useCallback(() => {
-    dispatch(fetchUpdateLogFiles());
-  }, [dispatch]);
+    refetch();
+  }, [refetch]);
 
   const handleDeleteFilesPress = useCallback(() => {
     dispatch(
       executeCommand({
         name: commandNames.DELETE_UPDATE_LOG_FILES,
         commandFinished: () => {
-          dispatch(fetchUpdateLogFiles());
+          refetch();
         },
       })
     );
-  }, [dispatch]);
-
-  useEffect(() => {
-    dispatch(fetchUpdateLogFiles());
-  }, [dispatch]);
+  }, [dispatch, refetch]);
 
   return (
     <LogFiles
       isDeleteFilesExecuting={isDeleteFilesExecuting}
       isFetching={isFetching}
-      items={items}
+      items={data}
       type="update"
       onRefreshPress={handleRefreshPress}
       onDeleteFilesPress={handleDeleteFilesPress}

--- a/frontend/src/System/Logs/useLogFiles.ts
+++ b/frontend/src/System/Logs/useLogFiles.ts
@@ -1,0 +1,14 @@
+import useApiQuery from 'Helpers/Hooks/useApiQuery';
+import LogFile from 'typings/LogFile';
+
+export default function useLogFiles() {
+  return useApiQuery<LogFile[]>({
+    path: '/log/file',
+  });
+}
+
+export function useUpdateLogFiles() {
+  return useApiQuery<LogFile[]>({
+    path: '/log/file/update',
+  });
+}


### PR DESCRIPTION
#### Database Migration

NO

#### Description

Third page conversion, following [Sonarr/Sonarr@ff5e7327](https://github.com/Sonarr/Sonarr/commit/ff5e7327). Covers both the app and update log file lists. Two commits: the conversion, then the roadmap update.

Trims `logFiles` and `updateLogFiles` out of `systemActions` — default state, both action types, both thunks and both fetch handlers — and drops `LogFilesAppState` from `SystemAppState`.

`systemActions` is now **365 lines, down from 401** across this and #461. Status, health, tasks, backups, updates and the logs table still live there, so the slice stays until the last of those converts.

##### New this time: a component converting halfway

Sonarr's version of these two components uses their `Commands/useCommands` hooks for the delete-logs command. Those don't exist here yet — commands are Phase C, with 44 consumers — so porting Sonarr's file wholesale would have dragged the commands slice into a four-file PR.

Instead the fetch half moves to React Query and the command half stays on redux:

```ts
const { data = [], isFetching, refetch } = useLogFiles();

const isDeleteFilesExecuting = useSelector(
  createCommandExecutingSelector(commandNames.DELETE_LOG_FILES)
);
```

`handleRefreshPress` is now `refetch()` rather than a dispatch, and the `commandFinished` callback calls `refetch()` too, so deleting logs still refreshes the list.

I've written this up in §10 of the roadmap as guidance rather than leaving it as a one-off, since it will recur: **convert the concern the PR is about and leave the rest.** The file gets visited again.

##### `Readonly<T>` earned its keep

`tsc` immediately rejected passing the query result into `LogFiles`:

```
error TS4104: The type 'readonly LogFile[]' is 'readonly' and cannot be
assigned to the mutable type 'LogFile[]'
```

First time the generic added in #455 has caught something on a page conversion. `LogFiles` only reads `items`, so widening the prop to `readonly LogFile[]` was all that was needed — I checked for `sort`/`reverse`/`push`/`splice` before widening rather than assuming.

#### Screenshot(s) (if UI related)

<details>

No visual change. Same endpoints, same table, same empty state; only the fetch mechanism differs.

</details>

#### Todos

- [ ] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json) — n/a, no new or changed strings

**Static:** `tsc --noEmit` clean, `eslint` clean across all of `frontend/`, `yarn build` succeeds. Grepped for every removed symbol (`fetchLogFiles`, `fetchUpdateLogFiles`, `LogFilesAppState`, `state.system.logFiles`, `state.system.updateLogFiles`) — none remain.

**Live:**

| Endpoint | Result |
| --- | --- |
| `GET /api/v3/log/file` | 200, 29 entries carrying `contentsUrl`, `downloadUrl`, `filename`, `id`, `lastWriteTime` |
| `GET /api/v3/log/file/update` | 200, empty list — exercises the empty-state path |

**Not click-tested:** the delete-logs command path. The refresh-after-delete now goes through `refetch()` instead of a dispatch, which is the one behavioural difference worth a look if you're exercising this one.

#### Progress

Files importing `react-redux`: **324, unchanged** — both components still import it for the command selector. `Store/` is down to 15,226 lines. React Query files 37 → 39.

That flat import count is expected from here on and is called out in the roadmap: a page can be most of the way converted and still import `react-redux` for one selector. The slice line count and the phase tables are the better signal.

#### Issues Fixed or Closed by this PR

None.
