### PR TITLE
Read system status from React Query (part 2 of 2)

### DIFF
--- a/REDUX_MIGRATION.md
+++ b/REDUX_MIGRATION.md
@@ -19,17 +19,37 @@ verified to resolve against the public repo.
 
 | Metric | At assessment | Now |
 | --- | --- | --- |
-| Files importing `react-redux` | 327 of 1,255 | **316** of 1,259 |
-| Lines under `frontend/src/Store/` | 15,374 across 138 files | **15,226** across 137 |
-| Redux action slices | 41 | **40** |
+| Files importing `react-redux` | 327 of 1,255 | **318** of 1,259 |
+| Lines under `frontend/src/Store/` | 15,374 across 138 files | **15,203** across 136 |
+| Redux slices registered in `Store/Actions/index.js` | 35 | **34** |
 | Remaining `*Connector` files | 66 | 66 |
-| Files touching React Query | 13 | **39** |
+| Files touching React Query | 35 | **39** |
 | zustand stores | 0 (not installed) | **installed, 3 primitives** |
+
+> **Recomputed in #464.** Three rows previously carried figures that no command
+> reproduced — `react-redux` read 316 where the same command that yields the
+> assessment column gives 320 on `eros-develop`, and the slice and React Query rows
+> used definitions that were never written down. The assessment column is unchanged;
+> it reproduces exactly at
+> [1d75cc96](https://github.com/Whisparr/Whisparr-Eros/commit/1d75cc96). To keep this
+> honest, the commands are now fixed:
+>
+> ```sh
+> # react-redux importers / total source files
+> git grep -l "from 'react-redux'" <ref> -- 'frontend/src/*.ts' 'frontend/src/*.tsx' \
+>   'frontend/src/*.js' | grep -v '\.css\.d\.ts' | wc -l
+> # slices
+> grep -cE '^import \* as' frontend/src/Store/Actions/index.js
+> # React Query
+> grep -rl -E 'useApiQuery|useApiMutation|usePagedApiQuery|@tanstack/react-query' \
+>   --include='*.ts' --include='*.tsx' frontend/src | wc -l
+> ```
 
 The headline number barely moves early on, and that is expected: Phase A added the
 foundation without converting any page, and Phase B is starting with the smallest pages
-by design. The slice count is the number to watch — each page conversion retires one
-outright.
+by design. The slice count is the number to watch — but only where a page owns its slice
+outright. `systemActions` serves six areas, so System Status came out of it without
+moving that row at all.
 
 ### The domains are started, not done
 
@@ -254,19 +274,40 @@ Four places where you cannot just copy their commit.
 
 ## 10. What to do next
 
-Phase A is done. Parse, Disk Space, Log Files and the read half of System Status are
-converted. Continuing through Phase B smallest-first, rather than jumping straight to
+Phase A is done. Parse, Disk Space, Log Files and System Status are converted.
+Continuing through Phase B smallest-first, rather than jumping straight to
 Queue — the point of the early pages is to make the PR shape routine before anything
 expensive.
 
-1. **System Status part 2** — retire the `status` slice and rewire `useAppPage`,
-   `About`, `Stats` and `FirstRun`. Small diff, but it is the boot path.
-2. **Health**, then tasks, backups and events — what is left of `systemActions`. Health
+1. **Health**, then tasks, backups and events — what is left of `systemActions`. Health
    feeds the sidebar, so it goes last and retires the slice with it.
-3. **Organize preview + Unmapped Files** — two small pages, one PR.
-4. **Then Queue**, as Sonarr did, because it forces SignalR-driven invalidation into
+2. **Organize preview + Unmapped Files** — two small pages, one PR.
+3. **Then Queue**, as Sonarr did, because it forces SignalR-driven invalidation into
    existence early rather than late. This is the first genuinely large one at 58 files, and
    the first that needs the SignalR pivot in Phase C.
+
+### A class component does not block the conversion below it
+
+System Status part 2 (#464) had to get four status values out of redux while
+`GeneralSettings` was still a `connect()`-wrapped class — and `mapStateToProps` cannot
+call a hook. The instinct is to convert the class first. That is Phase E work and a much
+larger change than the one being made.
+
+What worked instead, and generalises: **push each read down to the lowest component that
+can call a hook, and bridge only what is left.** Three of the four values were consumed by
+`HostSettings` and `UpdateSettings`, which are plain function components — those call
+`useSystemStatusData()` directly and the prop-drilling through the class disappears
+permanently, exactly as Sonarr has it. Only the fourth (`isWindowsService`, one string in
+one modal) genuinely needed the class, so the connector's default export became a small
+function component that reads the hook and passes that one prop in.
+
+Two notes on doing this:
+
+- Whisparr's ESLint enforces `filenames/match-exported`, so the new exported wrapper has
+  to take the file's name; rename the inner class rather than the export.
+- `connect()`'s default `mergeProps` is `{...ownProps, ...stateProps, ...dispatchProps}`,
+  so a prop passed in from the wrapper reaches the component untouched as long as
+  `mapStateToProps` no longer returns a key of the same name.
 
 ### The per-page PR shape, as established by Parse (#458)
 
@@ -386,6 +427,7 @@ If a JS test runner is ever added, remove that line and set
 | 2026-08-17 | #461 | **Disk Space.** 4 files, +19/−34. Partial trim of `systemActions`; slice survives for status, health, tasks, backups, logs, updates. |
 | 2026-08-17 | #462 | **Log Files.** App and update logs. First *partial component* conversion — the fetch half moves, the command half stays on redux until Phase C. |
 | 2026-08-17 | #463 | **System Status, part 1.** All 12 readers onto React Query; duplicate `useIsWindows` and `createSystemStatusSelector` deleted. Slice and boot path retained for part 2. |
+| 2026-08-17 | #464 | **System Status, part 2.** `status` slice, `FETCH_STATUS` and `SystemStatusAppState` deleted; `useAppPage` gate is now the query alone. Metrics table recomputed. |
 
 ### Open threads
 
@@ -403,6 +445,11 @@ If a JS test runner is ever added, remove that line and set
 - **`getErrorMessage(error as Error)` in `AddNewPerformer.tsx`** — the cast is harmless
   today because the value is redux-sourced, but it will silently lie once that page moves
   to React Query and the value becomes an `ApiError`. Remove the cast then.
+- **"Open Browser on Start" is Windows-only in Eros** — `HostSettings` gates it on
+  `isWindows && mode !== 'service'`, so the option is invisible on macOS and Linux.
+  Sonarr gates the same field on `isWindowsService` alone and shows it everywhere else.
+  Preserved verbatim in #464 rather than quietly adopting Sonarr's condition; if it is a
+  bug it deserves its own PR, since the setting does work off Windows.
 - **`NaN` progress bars on zero-size mounts** — `/diskspace` returns entries with
   `totalSpace: 0` for synthetic mounts (`/System/Volumes/Data/home` and similar). Disk
   Space computes `100 - (freeSpace / totalSpace) * 100`, so those rows render a `NaN`-width

--- a/frontend/src/App/State/SystemAppState.ts
+++ b/frontend/src/App/State/SystemAppState.ts
@@ -1,17 +1,14 @@
 import Health from 'typings/Health';
-import SystemStatus from 'typings/SystemStatus';
 import Task from 'typings/Task';
 import Update from 'typings/Update';
-import AppSectionState, { AppSectionItemState } from './AppSectionState';
+import AppSectionState from './AppSectionState';
 
 export type HealthAppState = AppSectionState<Health>;
-export type SystemStatusAppState = AppSectionItemState<SystemStatus>;
 export type TaskAppState = AppSectionState<Task>;
 export type UpdateAppState = AppSectionState<Update>;
 
 interface SystemAppState {
   health: HealthAppState;
-  status: SystemStatusAppState;
   tasks: TaskAppState;
   updates: UpdateAppState;
 }

--- a/frontend/src/Components/Page/ErrorPage.tsx
+++ b/frontend/src/Components/Page/ErrorPage.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Error } from 'App/State/AppSectionState';
+import { ApiError } from 'Utilities/Fetch/fetchJson';
 import getErrorMessage from 'Utilities/Object/getErrorMessage';
 import styles from './ErrorPage.css';
 
@@ -13,10 +14,10 @@ interface ErrorPageProps {
   qualityProfilesError?: Error;
   languagesError?: Error;
   uiSettingsError?: Error;
-  systemStatusError?: Error;
+  systemStatusError?: ApiError | null;
 }
 
-function ErrorPage(props: ErrorPageProps) {
+function ErrorPage(props: Readonly<ErrorPageProps>) {
   const {
     version,
     isLocalStorageSupported,
@@ -69,7 +70,7 @@ function ErrorPage(props: ErrorPageProps) {
     );
   } else if (systemStatusError) {
     errorMessage = getErrorMessage(
-      uiSettingsError,
+      systemStatusError,
       'Failed to load system status from API'
     );
   }

--- a/frontend/src/FirstRun/AuthenticationRequiredModalContent.tsx
+++ b/frontend/src/FirstRun/AuthenticationRequiredModalContent.tsx
@@ -22,8 +22,8 @@ import {
   saveGeneralSettings,
   setGeneralSettingsValue,
 } from 'Store/Actions/settingsActions';
-import { fetchStatus } from 'Store/Actions/systemActions';
 import createSettingsSectionSelector from 'Store/Selectors/createSettingsSectionSelector';
+import useSystemStatus from 'System/Status/useSystemStatus';
 import { InputChanged } from 'typings/inputs';
 import translate from 'Utilities/String/translate';
 import styles from './AuthenticationRequiredModalContent.css';
@@ -39,6 +39,7 @@ function onModalClose() {
 export default function AuthenticationRequiredModalContent() {
   const { isPopulated, error, isSaving, settings } = useSelector(selector);
   const dispatch = useDispatch();
+  const { refetch: refetchStatus } = useSystemStatus();
 
   const {
     authenticationMethod,
@@ -74,8 +75,8 @@ export default function AuthenticationRequiredModalContent() {
       return;
     }
 
-    dispatch(fetchStatus());
-  }, [isSaving, wasSaving, dispatch]);
+    refetchStatus();
+  }, [isSaving, wasSaving, refetchStatus]);
 
   const onPress = useCallback(() => {
     dispatch(saveGeneralSettings());

--- a/frontend/src/Helpers/Hooks/useAppPage.ts
+++ b/frontend/src/Helpers/Hooks/useAppPage.ts
@@ -11,7 +11,6 @@ import {
   fetchQualityProfiles,
   fetchUISettings,
 } from 'Store/Actions/settingsActions';
-import { fetchStatus } from 'Store/Actions/systemActions';
 import { fetchTags } from 'Store/Actions/tagActions';
 import useSystemStatus from 'System/Status/useSystemStatus';
 
@@ -26,7 +25,6 @@ const createErrorsSelector = () =>
     (state: AppState) => state.settings.languages.error,
     (state: AppState) => state.settings.importLists.error,
     (state: AppState) => state.settings.indexerFlags.error,
-    (state: AppState) => state.system.status.error,
     (state: AppState) => state.app.translations.error,
     (
       customFiltersError,
@@ -38,7 +36,6 @@ const createErrorsSelector = () =>
       languagesError,
       importListsError,
       indexerFlagsError,
-      systemStatusError,
       translationsError
     ) => {
       const hasError = !!(
@@ -51,7 +48,6 @@ const createErrorsSelector = () =>
         languagesError ||
         importListsError ||
         indexerFlagsError ||
-        systemStatusError ||
         translationsError
       );
 
@@ -67,7 +63,6 @@ const createErrorsSelector = () =>
           languagesError,
           importListsError,
           indexerFlagsError,
-          systemStatusError,
           translationsError,
         },
       };
@@ -78,11 +73,9 @@ const useAppPage = () => {
   const dispatch = useDispatch();
 
   // System status is read from React Query by every consumer now, so the app
-  // has to wait on that query rather than on the redux slice. Without this,
-  // components render once with an undefined status -- Page.tsx would compute
-  // `authentication !== 'none'` as true, and path handling would pick the
-  // wrong separator. The redux slice below is still populated for About,
-  // Stats and FirstRun until those convert.
+  // waits on that query. Without this, components render once with an
+  // undefined status -- Page.tsx would compute `authentication !== 'none'` as
+  // true, and path handling would pick the wrong separator.
   const { isSuccess: isSystemStatusPopulated, error: systemStatusQueryError } =
     useSystemStatus();
 
@@ -95,7 +88,6 @@ const useAppPage = () => {
       state.settings.languages.isPopulated &&
       state.settings.importLists.isPopulated &&
       state.settings.indexerFlags.isPopulated &&
-      state.system.status.isPopulated &&
       state.app.translations.isPopulated
   );
 
@@ -106,8 +98,7 @@ const useAppPage = () => {
   const errors = useMemo(() => {
     return {
       ...reduxErrors,
-      systemStatusError:
-        reduxErrors.systemStatusError ?? systemStatusQueryError,
+      systemStatusError: systemStatusQueryError,
     };
   }, [reduxErrors, systemStatusQueryError]);
 
@@ -132,7 +123,6 @@ const useAppPage = () => {
     dispatch(fetchImportLists());
     dispatch(fetchIndexerFlags());
     dispatch(fetchUISettings());
-    dispatch(fetchStatus());
     dispatch(fetchTranslations());
   }, [dispatch]);
 

--- a/frontend/src/Settings/General/GeneralSettings.js
+++ b/frontend/src/Settings/General/GeneralSettings.js
@@ -97,10 +97,7 @@ class GeneralSettings extends Component {
       settings,
       hasSettings,
       isResettingApiKey,
-      isWindows,
       isWindowsService,
-      mode,
-      packageUpdateMechanism,
       onInputChange,
       onConfirmResetApiKey,
       ...otherProps
@@ -124,8 +121,6 @@ class GeneralSettings extends Component {
               <HostSettings
                 advancedSettings={advancedSettings}
                 settings={settings}
-                isWindows={isWindows}
-                mode={mode}
                 onInputChange={onInputChange}
               />
 
@@ -155,8 +150,6 @@ class GeneralSettings extends Component {
               <UpdateSettings
                 advancedSettings={advancedSettings}
                 settings={settings}
-                isWindows={isWindows}
-                packageUpdateMechanism={packageUpdateMechanism}
                 onInputChange={onInputChange}
               />
 
@@ -200,10 +193,7 @@ GeneralSettings.propTypes = {
   settings: PropTypes.object.isRequired,
   isResettingApiKey: PropTypes.bool.isRequired,
   hasSettings: PropTypes.bool.isRequired,
-  isWindows: PropTypes.bool.isRequired,
   isWindowsService: PropTypes.bool.isRequired,
-  mode: PropTypes.string.isRequired,
-  packageUpdateMechanism: PropTypes.string.isRequired,
   onInputChange: PropTypes.func.isRequired,
   onConfirmResetApiKey: PropTypes.func.isRequired,
   onConfirmRestart: PropTypes.func.isRequired,

--- a/frontend/src/Settings/General/GeneralSettingsConnector.js
+++ b/frontend/src/Settings/General/GeneralSettingsConnector.js
@@ -13,6 +13,7 @@ import {
 import { restart } from 'Store/Actions/systemActions';
 import createCommandExecutingSelector from 'Store/Selectors/createCommandExecutingSelector';
 import createSettingsSectionSelector from 'Store/Selectors/createSettingsSectionSelector';
+import { useIsWindowsService } from 'System/Status/useSystemStatus';
 import GeneralSettings from './GeneralSettings';
 
 const SECTION = 'general';
@@ -22,19 +23,10 @@ function createMapStateToProps() {
     (state) => state.settings.advancedSettings,
     createSettingsSectionSelector(SECTION),
     createCommandExecutingSelector(commandNames.RESET_API_KEY),
-    // Inlined from the former createSystemStatusSelector. connect() cannot use
-    // the React Query hook, so this stays on redux until General settings
-    // converts in Phase E.
-    (state) => state.system.status.item,
-    (advancedSettings, sectionSettings, isResettingApiKey, systemStatus) => {
+    (advancedSettings, sectionSettings, isResettingApiKey) => {
       return {
         advancedSettings,
         isResettingApiKey,
-        isWindows: systemStatus.isWindows,
-        isWindowsService:
-          systemStatus.isWindows && systemStatus.mode === 'service',
-        mode: systemStatus.mode,
-        packageUpdateMechanism: systemStatus.packageUpdateMechanism,
         ...sectionSettings,
       };
     }
@@ -50,7 +42,7 @@ const mapDispatchToProps = {
   clearPendingChanges,
 };
 
-class GeneralSettingsConnector extends Component {
+class GeneralSettingsHandlers extends Component {
   //
   // Lifecycle
 
@@ -103,7 +95,7 @@ class GeneralSettingsConnector extends Component {
   }
 }
 
-GeneralSettingsConnector.propTypes = {
+GeneralSettingsHandlers.propTypes = {
   isResettingApiKey: PropTypes.bool.isRequired,
   setGeneralSettingsValue: PropTypes.func.isRequired,
   saveGeneralSettings: PropTypes.func.isRequired,
@@ -113,7 +105,18 @@ GeneralSettingsConnector.propTypes = {
   clearPendingChanges: PropTypes.func.isRequired,
 };
 
-export default connect(
+const ConnectedGeneralSettings = connect(
   createMapStateToProps,
   mapDispatchToProps
-)(GeneralSettingsConnector);
+)(GeneralSettingsHandlers);
+
+// GeneralSettings is still a class component and connect() cannot call hooks,
+// so neither can read system status from React Query directly. This bridges the
+// one value they need until General settings converts in Phase E; the other
+// three status props now go straight to HostSettings and UpdateSettings, which
+// are function components and read the query themselves.
+export default function GeneralSettingsConnector() {
+  const isWindowsService = useIsWindowsService();
+
+  return <ConnectedGeneralSettings isWindowsService={isWindowsService} />;
+}

--- a/frontend/src/Settings/General/HostSettings.js
+++ b/frontend/src/Settings/General/HostSettings.js
@@ -5,10 +5,12 @@ import FormGroup from 'Components/Form/FormGroup';
 import FormInputGroup from 'Components/Form/FormInputGroup';
 import FormLabel from 'Components/Form/FormLabel';
 import { inputTypes, sizes } from 'Helpers/Props';
+import { useSystemStatusData } from 'System/Status/useSystemStatus';
 import translate from 'Utilities/String/translate';
 
 function HostSettings(props) {
-  const { advancedSettings, settings, isWindows, mode, onInputChange } = props;
+  const { advancedSettings, settings, onInputChange } = props;
+  const { isWindows, mode } = useSystemStatusData();
 
   const {
     bindAddress,
@@ -173,8 +175,6 @@ function HostSettings(props) {
 HostSettings.propTypes = {
   advancedSettings: PropTypes.bool.isRequired,
   settings: PropTypes.object.isRequired,
-  isWindows: PropTypes.bool.isRequired,
-  mode: PropTypes.string.isRequired,
   onInputChange: PropTypes.func.isRequired,
 };
 

--- a/frontend/src/Settings/General/UpdateSettings.js
+++ b/frontend/src/Settings/General/UpdateSettings.js
@@ -5,14 +5,15 @@ import FormGroup from 'Components/Form/FormGroup';
 import FormInputGroup from 'Components/Form/FormInputGroup';
 import FormLabel from 'Components/Form/FormLabel';
 import { inputTypes, sizes } from 'Helpers/Props';
+import { useSystemStatusData } from 'System/Status/useSystemStatus';
 import titleCase from 'Utilities/String/titleCase';
 import translate from 'Utilities/String/translate';
 
 const branchValues = ['master', 'develop', 'nightly'];
 
 function UpdateSettings(props) {
-  const { advancedSettings, settings, packageUpdateMechanism, onInputChange } =
-    props;
+  const { advancedSettings, settings, onInputChange } = props;
+  const { packageUpdateMechanism } = useSystemStatusData();
 
   const { branch, updateAutomatically, updateMechanism, updateScriptPath } =
     settings;
@@ -114,8 +115,6 @@ function UpdateSettings(props) {
 UpdateSettings.propTypes = {
   advancedSettings: PropTypes.bool.isRequired,
   settings: PropTypes.object.isRequired,
-  isWindows: PropTypes.bool.isRequired,
-  packageUpdateMechanism: PropTypes.string.isRequired,
   onInputChange: PropTypes.func.isRequired,
 };
 

--- a/frontend/src/Store/Actions/systemActions.js
+++ b/frontend/src/Store/Actions/systemActions.js
@@ -24,13 +24,6 @@ const backupsSection = 'system.backups';
 // State
 
 export const defaultState = {
-  status: {
-    isFetching: false,
-    isPopulated: false,
-    error: null,
-    item: {},
-  },
-
   health: {
     isFetching: false,
     isPopulated: false,
@@ -164,7 +157,6 @@ export const persistState = [
 //
 // Actions Types
 
-export const FETCH_STATUS = 'system/status/fetchStatus';
 export const FETCH_HEALTH = 'system/health/fetchHealth';
 
 export const FETCH_TASK = 'system/tasks/fetchTask';
@@ -194,7 +186,6 @@ export const SHUTDOWN = 'system/shutdown';
 //
 // Action Creators
 
-export const fetchStatus = createThunk(FETCH_STATUS);
 export const fetchHealth = createThunk(FETCH_HEALTH);
 
 export const fetchTask = createThunk(FETCH_TASK);
@@ -225,7 +216,6 @@ export const shutdown = createThunk(SHUTDOWN);
 // Action Handlers
 
 export const actionHandlers = handleThunks({
-  [FETCH_STATUS]: createFetchHandler('system.status', '/system/status'),
   [FETCH_HEALTH]: createFetchHandler('system.health', '/health'),
   [FETCH_TASK]: createFetchHandler('system.tasks', '/system/task'),
   [FETCH_TASKS]: createFetchHandler('system.tasks', '/system/task'),

--- a/frontend/src/System/Status/About/About.tsx
+++ b/frontend/src/System/Status/About/About.tsx
@@ -1,19 +1,16 @@
 import React, { useEffect } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
-import AppState from 'App/State/AppState';
 import DescriptionList from 'Components/DescriptionList/DescriptionList';
 import DescriptionListItem from 'Components/DescriptionList/DescriptionListItem';
 import FieldSet from 'Components/FieldSet';
 import InlineMarkdown from 'Components/Markdown/InlineMarkdown';
-import { fetchStatus } from 'Store/Actions/systemActions';
+import useSystemStatus from 'System/Status/useSystemStatus';
 import titleCase from 'Utilities/String/titleCase';
 import translate from 'Utilities/String/translate';
 import StartTime from './StartTime';
 import styles from './About.css';
 
 function About() {
-  const dispatch = useDispatch();
-  const { item } = useSelector((state: AppState) => state.system.status);
+  const { data, refetch } = useSystemStatus();
 
   const {
     version,
@@ -29,11 +26,11 @@ function About() {
     startupPath,
     mode,
     startTime,
-  } = item;
+  } = data;
 
   useEffect(() => {
-    dispatch(fetchStatus());
-  }, [dispatch]);
+    refetch();
+  }, [refetch]);
 
   return (
     <FieldSet legend={translate('About')}>

--- a/frontend/src/System/Status/Stats/Stats.tsx
+++ b/frontend/src/System/Status/Stats/Stats.tsx
@@ -1,23 +1,20 @@
 import React, { useEffect } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
-import AppState from 'App/State/AppState';
 import DescriptionList from 'Components/DescriptionList/DescriptionList';
 import DescriptionListItem from 'Components/DescriptionList/DescriptionListItem';
 import FieldSet from 'Components/FieldSet';
-import { fetchStatus } from 'Store/Actions/systemActions';
+import useSystemStatus from 'System/Status/useSystemStatus';
 import formatNumber from 'Utilities/Number/formatNumber';
 import translate from 'Utilities/String/translate';
 import styles from './Stats.css';
 
 function Stats() {
-  const dispatch = useDispatch();
-  const { item } = useSelector((state: AppState) => state.system.status);
+  const { data, refetch } = useSystemStatus();
 
-  const { movieCount, sceneCount, studioCount, performerCount } = item;
+  const { movieCount, sceneCount, studioCount, performerCount } = data;
 
   useEffect(() => {
-    dispatch(fetchStatus());
-  }, [dispatch]);
+    refetch();
+  }, [refetch]);
 
   return (
     <FieldSet legend={translate('Stats')}>


### PR DESCRIPTION
#### Database Migration

NO

#### Description

**Part 2 of 2**, completing [#463](https://github.com/Whisparr/Whisparr-Eros/pull/463). Part 1 moved every *reader* of system status onto `useSystemStatus`; this deletes the slice they used to read from. `state.system.status`, `FETCH_STATUS`, `fetchStatus` and `SystemStatusAppState` are gone, and `useAppPage`'s boot gate is now the query alone.

##### The one that needed thought: a `connect()` class in the way

`GeneralSettingsConnector.js` was the last redux reader, and it is not convertible in place — `mapStateToProps` cannot call a hook, and `GeneralSettings` below it is a class component. Converting General settings is Phase E and a far larger change than this PR.

What it does instead is push each read down to the lowest component that can call a hook:

| Value | Where it went |
| --- | --- |
| `isWindows`, `mode` | `HostSettings` — a function component, calls `useSystemStatusData()` |
| `packageUpdateMechanism` | `UpdateSettings` — same |
| `isWindows` (on `UpdateSettings`) | deleted; it was declared in `propTypes` and never read |
| `isWindowsService` | still needs the class, so the connector's default export is now a small function component that reads the hook and passes just that one prop |

Three of the four stop being drilled through the class *permanently* — that is where [Sonarr](https://github.com/Sonarr/Sonarr/blob/v5-develop/frontend/src/Settings/General/UpdateSettings.tsx) ended up too. Only `isWindowsService` (one string in the restart-required modal) is bridged, and Phase E deletes the bridge.

Two things to know if you repeat this:

- Whisparr's ESLint enforces `filenames/match-exported`, so the new export has to take the file's name. The inner class is renamed rather than the export.
- `connect()`'s default `mergeProps` is `{...ownProps, ...stateProps, ...dispatchProps}`, so the prop passed in from the wrapper arrives untouched once `mapStateToProps` stops returning a key of the same name.

##### Two behaviour notes

`About` and `Stats` use `data` and `refetch` rather than just `data`, keeping the explicit refresh-on-mount those pages had via `dispatch(fetchStatus())`. Same as Sonarr's `About.tsx`.

`ErrorPage.systemStatusError` widens to `ApiError`, since the value now comes from the query. **That branch was also passing `uiSettingsError` into `getErrorMessage`** — a copy-paste, and because `uiSettingsError` is always falsy inside that `else if`, a failed status fetch could only ever render the generic fallback, never the API's message. Fixed on the line the type change already touched.

#### Screenshot(s) (if UI related)

<details>

No visual change. Same data, same fields, same rendering — only the source changes.

</details>

#### Todos

- [ ] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json) — n/a, no new or changed strings

**Static.** `eslint` clean across `frontend/`. `yarn build` succeeds. `tsc --noEmit` adds no errors: three exist on `eros-develop` already, all in `node_modules` (`@types/webpack-livereload-plugin` ×2, `react-router-dom`), and I verified that baseline on a clean tree rather than assuming it.

**Driven, not just booted.** This changes the boot gate and the settings page, so I ran the app against a real library and drove it over CDP.

| Check | Result |
| --- | --- |
| Boot `/` | title `Whisparr`, `#root` populated, 893 chars, 38 nav links, no error page, no spinner lock |
| `/system/status` → About | Version, Database, AppData, Uptime all populated; no `undefined` |
| `/system/status` → Stats | 16,818 scenes · 269 movies · 1,117 studios · 6,869 performers — matches `/api/v3/system/status` exactly |
| `/settings/general` → Host | renders; Bind Address / Instance Name present under advanced |
| `/settings/general` → Updates | Branch + Mechanism render, Mechanism shows **Built In**, matching `packageUpdateMechanism: builtIn` |
| Open Browser on Start | correctly hidden — `isWindows` is `false` on this host (see below) |
| Restart-required modal | changed Instance Name → saved → modal appeared with **no** Windows-service sentence, correct for `isWindowsService === false`. This is the one value the bridge carries, so it is the one worth driving. |

**And the first-run flow, because that is where a mistake would lock someone out.** The FirstRun modal now calls `refetch()` where it dispatched `fetchStatus()`. If that were wrong the modal would never close on a fresh install. So I forced the state — set `AuthenticationMethod` to `None`, restarted, and drove it:

1. Modal opens (`authentication: none`) ✅
2. Selected Forms, filled username/password/confirmation, saved
3. **Modal closed and the scene index rendered** ✅
4. `/api/v3/system/status` now reports `authentication: forms` ✅

Config was restored afterwards.

The only console error on any page is the pre-existing `autoHide` prop warning from `OverlayScroller`/`PageSidebar` — I captured the substitution arguments (`autoHide | autohide`) to confirm it is the same one as in #463 and not something this PR introduced. No propTypes warnings, which also confirms `isWindowsService` arrives as a real boolean.

##### One thing I deliberately did not change

`HostSettings` gates "Open Browser on Start" on `isWindows && mode !== 'service'`, so it is invisible on macOS and Linux. Sonarr gates the same field on `isWindowsService` alone and shows it everywhere else. I kept Eros's condition verbatim — adopting Sonarr's while doing a redux swap would smuggle a behaviour change into a mechanical PR. Recorded as an open thread; if it is a bug it deserves its own PR, since the setting does work off Windows.

#### Progress

Files importing `react-redux`: **320 → 318.**

The metrics table in `REDUX_MIGRATION.md` is recomputed in this PR. Three rows carried figures that no command reproduced — the `react-redux` row read **316** where the command that reproduces the assessment column *exactly* gives **320** on `eros-develop`. The assessment column was right; the "now" column had drifted. The commands are now written into the document so the numbers stay comparable.

Note the slice count does not move: `systemActions` still serves health, tasks, backups, updates and logs. It retires with Health, as planned.

#### Issues Fixed or Closed by this PR

None. Next up: **Health**, then tasks, backups and events — the rest of `systemActions`.
