### PR TITLE
Use react-query for Tasks

### DIFF
--- a/REDUX_MIGRATION.md
+++ b/REDUX_MIGRATION.md
@@ -19,8 +19,8 @@ verified to resolve against the public repo.
 
 | Metric | At assessment | Now |
 | --- | --- | --- |
-| Files importing `react-redux` | 327 of 1,255 | **318** of 1,259 |
-| Lines under `frontend/src/Store/` | 15,374 across 138 files | **15,167** across 135 |
+| Files importing `react-redux` | 327 of 1,255 | **317** of 1,259 |
+| Lines under `frontend/src/Store/` | 15,374 across 138 files | **15,154** across 135 |
 | Redux slices registered in `Store/Actions/index.js` | 35 | **34** |
 | Remaining `*Connector` files | 66 | 66 |
 | Files touching React Query | 35 | **39** |
@@ -305,8 +305,9 @@ Continuing through Phase B smallest-first, rather than jumping straight to
 Queue — the point of the early pages is to make the PR shape routine before anything
 expensive.
 
-1. **Tasks, backups and events** — the rest of `systemActions`. The slice retires with the
-   last of them, not with Health; it holds five sections, and Health was one.
+1. **Backups, events and updates** — the rest of `systemActions`, one page per PR. Events
+   is the big one: it is a server-side paged table, so it needs `usePagedApiQuery` rather
+   than a plain list hook. The slice retires with the last of them.
 2. **The SignalR container** — `SignalRConnector.js` → `SignalRListener.tsx`, class to
    function component, as its own PR. Ungated (see §9.5), and worth doing before the
    larger domains so that Queue and Collection land in a converted file rather than
@@ -457,6 +458,7 @@ If a JS test runner is ever added, remove that line and set
 | 2026-08-17 | #463 | **System Status, part 1.** All 12 readers onto React Query; duplicate `useIsWindows` and `createSystemStatusSelector` deleted. Slice and boot path retained for part 2. |
 | 2026-08-17 | #464 | **System Status, part 2.** `status` slice, `FETCH_STATUS` and `SystemStatusAppState` deleted; `useAppPage` gate is now the query alone. Metrics table recomputed. |
 | 2026-08-18 | #465 | **Health.** First conversion to move a SignalR handler onto React Query rather than shim it. Two dead selectors deleted. |
+| 2026-08-18 | #466 | **Tasks.** `handleSystemTask` now invalidates instead of refetching commands, which let the per-row `setTimeout` refresh go. |
 
 ### Open threads
 

--- a/frontend/src/App/State/SystemAppState.ts
+++ b/frontend/src/App/State/SystemAppState.ts
@@ -1,12 +1,9 @@
-import Task from 'typings/Task';
 import Update from 'typings/Update';
 import AppSectionState from './AppSectionState';
 
-export type TaskAppState = AppSectionState<Task>;
 export type UpdateAppState = AppSectionState<Update>;
 
 interface SystemAppState {
-  tasks: TaskAppState;
   updates: UpdateAppState;
 }
 

--- a/frontend/src/Components/SignalRConnector.js
+++ b/frontend/src/Components/SignalRConnector.js
@@ -546,7 +546,7 @@ class SignalRConnector extends Component {
   };
 
   handleSystemTask = () => {
-    this.props.dispatchFetchCommands();
+    queryClient.invalidateQueries({ queryKey: ['/system/task'] });
   };
 
   handleRootfolder = () => {

--- a/frontend/src/Store/Actions/systemActions.js
+++ b/frontend/src/Store/Actions/systemActions.js
@@ -24,13 +24,6 @@ const backupsSection = 'system.backups';
 // State
 
 export const defaultState = {
-  tasks: {
-    isFetching: false,
-    isPopulated: false,
-    error: null,
-    items: [],
-  },
-
   backups: {
     isFetching: false,
     isPopulated: false,
@@ -151,8 +144,6 @@ export const persistState = [
 // Actions Types
 
 
-export const FETCH_TASK = 'system/tasks/fetchTask';
-export const FETCH_TASKS = 'system/tasks/fetchTasks';
 
 export const FETCH_BACKUPS = 'system/backups/fetchBackups';
 export const RESTORE_BACKUP = 'system/backups/restoreBackup';
@@ -179,8 +170,6 @@ export const SHUTDOWN = 'system/shutdown';
 // Action Creators
 
 
-export const fetchTask = createThunk(FETCH_TASK);
-export const fetchTasks = createThunk(FETCH_TASKS);
 
 export const fetchBackups = createThunk(FETCH_BACKUPS);
 export const restoreBackup = createThunk(RESTORE_BACKUP);
@@ -207,8 +196,6 @@ export const shutdown = createThunk(SHUTDOWN);
 // Action Handlers
 
 export const actionHandlers = handleThunks({
-  [FETCH_TASK]: createFetchHandler('system.tasks', '/system/task'),
-  [FETCH_TASKS]: createFetchHandler('system.tasks', '/system/task'),
 
   [FETCH_BACKUPS]: createFetchHandler(backupsSection, '/system/backup'),
 

--- a/frontend/src/System/Tasks/Scheduled/ScheduledTaskRow.tsx
+++ b/frontend/src/System/Tasks/Scheduled/ScheduledTaskRow.tsx
@@ -4,10 +4,8 @@ import { useDispatch, useSelector } from 'react-redux';
 import SpinnerIconButton from 'Components/Link/SpinnerIconButton';
 import TableRowCell from 'Components/Table/Cells/TableRowCell';
 import TableRow from 'Components/Table/TableRow';
-import usePrevious from 'Helpers/Hooks/usePrevious';
 import { icons } from 'Helpers/Props';
 import { executeCommand } from 'Store/Actions/commandActions';
-import { fetchTask } from 'Store/Actions/systemActions';
 import createCommandSelector from 'Store/Selectors/createCommandSelector';
 import createUISettingsSelector from 'Store/Selectors/createUISettingsSelector';
 import { isCommandExecuting } from 'Utilities/Command';
@@ -29,7 +27,6 @@ interface ScheduledTaskRowProps {
 
 function ScheduledTaskRow(props: ScheduledTaskRowProps) {
   const {
-    id,
     taskName,
     name,
     interval,
@@ -49,7 +46,6 @@ function ScheduledTaskRow(props: ScheduledTaskRowProps) {
 
   const isQueued = !!(command && command.status === 'queued');
   const isExecuting = isCommandExecuting(command);
-  const wasExecuting = usePrevious(isExecuting);
   const isDisabled = interval === 0;
   const executeNow = !isDisabled && moment().isAfter(nextExecution);
   const hasNextExecutionTime = !isDisabled && !executeNow;
@@ -94,14 +90,6 @@ function ScheduledTaskRow(props: ScheduledTaskRowProps) {
       })
     );
   }, [taskName, dispatch]);
-
-  useEffect(() => {
-    if (!isExecuting && wasExecuting) {
-      setTimeout(() => {
-        dispatch(fetchTask({ id }));
-      }, 1000);
-    }
-  }, [id, isExecuting, wasExecuting, dispatch]);
 
   useEffect(() => {
     const interval = setInterval(() => setTime(Date.now()), 1000);

--- a/frontend/src/System/Tasks/Scheduled/ScheduledTasks.tsx
+++ b/frontend/src/System/Tasks/Scheduled/ScheduledTasks.tsx
@@ -1,13 +1,11 @@
-import React, { useEffect } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
-import AppState from 'App/State/AppState';
+import React from 'react';
 import FieldSet from 'Components/FieldSet';
 import LoadingIndicator from 'Components/Loading/LoadingIndicator';
 import Column from 'Components/Table/Column';
 import Table from 'Components/Table/Table';
 import TableBody from 'Components/Table/TableBody';
-import { fetchTasks } from 'Store/Actions/systemActions';
 import translate from 'Utilities/String/translate';
+import useTasks from '../useTasks';
 import ScheduledTaskRow from './ScheduledTaskRow';
 
 const columns: Column[] = [
@@ -44,23 +42,16 @@ const columns: Column[] = [
 ];
 
 function ScheduledTasks() {
-  const dispatch = useDispatch();
-  const { isFetching, isPopulated, items } = useSelector(
-    (state: AppState) => state.system.tasks
-  );
-
-  useEffect(() => {
-    dispatch(fetchTasks());
-  }, [dispatch]);
+  const { data, isFetched, isLoading } = useTasks();
 
   return (
     <FieldSet legend={translate('Scheduled')}>
-      {isFetching && !isPopulated && <LoadingIndicator />}
+      {isLoading && <LoadingIndicator />}
 
-      {isPopulated && (
+      {isFetched && (
         <Table columns={columns}>
           <TableBody>
-            {items.map((item) => {
+            {data.map((item) => {
               return <ScheduledTaskRow key={item.id} {...item} />;
             })}
           </TableBody>

--- a/frontend/src/System/Tasks/useTasks.ts
+++ b/frontend/src/System/Tasks/useTasks.ts
@@ -1,0 +1,15 @@
+import useApiQuery from 'Helpers/Hooks/useApiQuery';
+import Task from 'typings/Task';
+
+const useTasks = () => {
+  const result = useApiQuery<Task[]>({
+    path: '/system/task',
+  });
+
+  return {
+    ...result,
+    data: result.data ?? [],
+  };
+};
+
+export default useTasks;


### PR DESCRIPTION
#### Database Migration

NO

#### Description

Scheduled tasks onto React Query; `tasks` section dropped from the system slice. `useTasks` is Sonarr's hook unchanged.

`handleSystemTask` was dispatching `fetchCommands`, so a `system/task` broadcast refreshed commands and never the task list. It now invalidates `['/system/task']`. Not a Whisparr bug — Sonarr's pre-migration connector had the identical line, and they changed it to the same thing during their migration.

That made the per-row refresh redundant, so it's gone: `ScheduledTaskRow` was waiting for a command to stop executing, sleeping 1s, then refetching that one task. The broadcast covers every row with no arbitrary delay.

#### Screenshot(s) (if UI related)

<details>

No visual change.

</details>

#### Todos

- [ ] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json) — n/a

`eslint` and `yarn build` clean; `tsc` adds no errors over the three pre-existing `node_modules` ones.

Verified on a running instance, since removing the row refresh is only safe if the broadcast really covers it. Executing a task with no UI interaction moved the query's `dataUpdatedAt` and the row's `lastExecution` (16:55:30 → 16:56:12), with `performance.getEntriesByType("navigation").length === 1` confirming no reload. Checked on two commands after a first probe showed no refresh — that run used a command that didn't emit the broadcast, and re-testing the same command later did.

#### Progress

`react-redux` importers 318 → 317. `Store/` 15,167 → 15,154 lines. Backups, events and updates remain in `systemActions`.

#### Issues Fixed or Closed by this PR

None.
