### PR TITLE
Use react-query for Updates

### DIFF
--- a/REDUX_MIGRATION.md
+++ b/REDUX_MIGRATION.md
@@ -20,7 +20,7 @@ verified to resolve against the public repo.
 | Metric | At assessment | Now |
 | --- | --- | --- |
 | Files importing `react-redux` | 327 of 1,255 | **316** of 1,259 |
-| Lines under `frontend/src/Store/` | 15,374 across 138 files | **15,049** across 135 |
+| Lines under `frontend/src/Store/` | 15,374 across 138 files | **15,035** across 135 |
 | Redux slices registered in `Store/Actions/index.js` | 35 | **34** |
 | Remaining `*Connector` files | 66 | **62** |
 | Files touching React Query | 35 | **39** |
@@ -295,6 +295,12 @@ Five places where you cannot just copy their commit.
 
    Common domains have neither problem. `/health` is a flat list on a plain key, so the
    handler is Sonarr's line verbatim.
+6. **Updates come from GitHub, not a first-party update server.** Sonarr runs its own, so
+   its `Update.changes` is always the structured `{new, fixed}`. Eros reads GitHub
+   releases, so `changes` is `Changes | string | null` and there is an extra `body` for
+   release-note markdown, rendered through `MarkdownRenderer`. The fetch is safe to take
+   from Sonarr; **the parsing and rendering are not** — #468 converted the query and
+   deliberately changed nothing below it.
 
 ---
 
@@ -305,9 +311,9 @@ Continuing through Phase B smallest-first, rather than jumping straight to
 Queue — the point of the early pages is to make the PR shape routine before anything
 expensive.
 
-1. **Events and updates** — the rest of `systemActions`, one page per PR. Events is the
-   big one: it is a server-side paged table, so it needs `usePagedApiQuery` rather than a
-   plain list hook. The slice retires with the last of them.
+1. **Events** — all that is left of `systemActions`, and the slice retires with it. The
+   big one: a server-side paged table, so it needs `usePagedApiQuery` rather than a plain
+   list hook, and its two connectors are still `.js`.
 2. **The SignalR container** — `SignalRConnector.js` → `SignalRListener.tsx`, class to
    function component, as its own PR. Ungated (see §9.5), and worth doing before the
    larger domains so that Queue and Collection land in a converted file rather than
@@ -460,6 +466,7 @@ If a JS test runner is ever added, remove that line and set
 | 2026-08-18 | #465 | **Health.** First conversion to move a SignalR handler onto React Query rather than shim it. Two dead selectors deleted. |
 | 2026-08-18 | #466 | **Tasks.** `handleSystemTask` now invalidates instead of refetching commands, which let the per-row `setTimeout` refresh go. |
 | 2026-08-18 | #467 | **Backups.** First conversion with mutations rather than reads alone, and the first to retire connectors — 66 to 62. Four files to TSX. |
+| 2026-08-18 | #468 | **Updates.** Fetch only; the GitHub release-note parsing is Eros-specific and was left untouched. |
 
 ### Open threads
 

--- a/frontend/src/App/AppUpdatedModalContent.tsx
+++ b/frontend/src/App/AppUpdatedModalContent.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 import Button from 'Components/Link/Button';
 import LoadingIndicator from 'Components/Loading/LoadingIndicator';
 import InlineMarkdown from 'Components/Markdown/InlineMarkdown';
@@ -10,14 +10,18 @@ import ModalFooter from 'Components/Modal/ModalFooter';
 import ModalHeader from 'Components/Modal/ModalHeader';
 import usePrevious from 'Helpers/Hooks/usePrevious';
 import { kinds } from 'Helpers/Props';
-import { fetchUpdates } from 'Store/Actions/systemActions';
 import UpdateChanges from 'System/Updates/UpdateChanges';
+import useUpdates from 'System/Updates/useUpdates';
 import Update from 'typings/Update';
 import translate from 'Utilities/String/translate';
 import AppState from './State/AppState';
 import styles from './AppUpdatedModalContent.css';
 
-function mergeUpdates(items: Update[], version: string, prevVersion?: string) {
+function mergeUpdates(
+  items: readonly Update[],
+  version: string,
+  prevVersion?: string
+) {
   let installedIndex = items.findIndex((u) => u.version === version);
   let installedPreviouslyIndex = items.findIndex(
     (u) => u.version === prevVersion
@@ -74,11 +78,8 @@ interface AppUpdatedModalContentProps {
 }
 
 function AppUpdatedModalContent(props: AppUpdatedModalContentProps) {
-  const dispatch = useDispatch();
   const { version, prevVersion } = useSelector((state: AppState) => state.app);
-  const { isPopulated, error, items } = useSelector(
-    (state: AppState) => state.system.updates
-  );
+  const { data: items, isFetched: isPopulated, error, refetch } = useUpdates();
   const previousVersion = usePrevious(version);
 
   const { onModalClose } = props;
@@ -90,14 +91,10 @@ function AppUpdatedModalContent(props: AppUpdatedModalContentProps) {
   }, []);
 
   useEffect(() => {
-    dispatch(fetchUpdates());
-  }, [dispatch]);
-
-  useEffect(() => {
     if (version !== previousVersion) {
-      dispatch(fetchUpdates());
+      refetch();
     }
-  }, [version, previousVersion, dispatch]);
+  }, [version, previousVersion, refetch]);
 
   return (
     <ModalContent onModalClose={onModalClose}>

--- a/frontend/src/App/State/SystemAppState.ts
+++ b/frontend/src/App/State/SystemAppState.ts
@@ -1,10 +1,12 @@
-import Update from 'typings/Update';
 import AppSectionState from './AppSectionState';
 
-export type UpdateAppState = AppSectionState<Update>;
+// `logs` is all that is left of the system slice. It is read only by the Events
+// connectors, which are still .js, so there is no typed model for it yet; it
+// retires with the Events page.
+export type LogsAppState = AppSectionState<unknown>;
 
 interface SystemAppState {
-  updates: UpdateAppState;
+  logs: LogsAppState;
 }
 
 export default SystemAppState;

--- a/frontend/src/Store/Actions/systemActions.js
+++ b/frontend/src/Store/Actions/systemActions.js
@@ -6,7 +6,6 @@ import createAjaxRequest from 'Utilities/createAjaxRequest';
 import serverSideCollectionHandlers from 'Utilities/serverSideCollectionHandlers';
 import translate from 'Utilities/String/translate';
 import { pingServer } from './appActions';
-import createFetchHandler from './Creators/createFetchHandler';
 import createHandleActions from './Creators/createHandleActions';
 import createServerSideCollectionHandlers from './Creators/createServerSideCollectionHandlers';
 import createClearReducer from './Creators/Reducers/createClearReducer';
@@ -21,13 +20,6 @@ export const section = 'system';
 // State
 
 export const defaultState = {
-  updates: {
-    isFetching: false,
-    isPopulated: false,
-    error: null,
-    items: [],
-  },
-
   logs: {
     isFetching: false,
     isPopulated: false,
@@ -131,8 +123,6 @@ export const persistState = [
 
 
 
-export const FETCH_UPDATES = 'system/updates/fetchUpdates';
-
 export const FETCH_LOGS = 'system/logs/fetchLogs';
 export const GOTO_FIRST_LOGS_PAGE = 'system/logs/gotoLogsFirstPage';
 export const GOTO_PREVIOUS_LOGS_PAGE = 'system/logs/gotoLogsPreviousPage';
@@ -152,8 +142,6 @@ export const SHUTDOWN = 'system/shutdown';
 
 
 
-export const fetchUpdates = createThunk(FETCH_UPDATES);
-
 export const fetchLogs = createThunk(FETCH_LOGS);
 export const gotoLogsFirstPage = createThunk(GOTO_FIRST_LOGS_PAGE);
 export const gotoLogsPreviousPage = createThunk(GOTO_PREVIOUS_LOGS_PAGE);
@@ -172,8 +160,6 @@ export const shutdown = createThunk(SHUTDOWN);
 // Action Handlers
 
 export const actionHandlers = handleThunks({
-
-  [FETCH_UPDATES]: createFetchHandler('system.updates', '/update'),
 
   ...createServerSideCollectionHandlers('system.logs', '/log', fetchLogs, {
     [serverSideCollectionHandlers.FETCH]: FETCH_LOGS,

--- a/frontend/src/System/Updates/Updates.tsx
+++ b/frontend/src/System/Updates/Updates.tsx
@@ -15,7 +15,6 @@ import PageContentBody from 'Components/Page/PageContentBody';
 import { icons, kinds } from 'Helpers/Props';
 import { executeCommand } from 'Store/Actions/commandActions';
 import { fetchGeneralSettings } from 'Store/Actions/settingsActions';
-import { fetchUpdates } from 'Store/Actions/systemActions';
 import createCommandExecutingSelector from 'Store/Selectors/createCommandExecutingSelector';
 import createUISettingsSelector from 'Store/Selectors/createUISettingsSelector';
 import { useSystemStatusData } from 'System/Status/useSystemStatus';
@@ -24,26 +23,21 @@ import formatDate from 'Utilities/Date/formatDate';
 import formatDateTime from 'Utilities/Date/formatDateTime';
 import translate from 'Utilities/String/translate';
 import UpdateChanges from './UpdateChanges';
+import useUpdates from './useUpdates';
 import styles from './Updates.css';
 
 const VERSION_REGEX = /\d+\.\d+\.\d+\.\d+/i;
 
-function createUpdatesSelector() {
+// Updates come from React Query; general settings are still redux until they
+// convert in phase E, and they supply the update mechanism.
+function createGeneralSettingsSelector() {
   return createSelector(
-    (state: AppState) => state.system.updates,
     (state: AppState) => state.settings.general,
-    (updates, generalSettings) => {
-      const { error: updatesError, items } = updates;
-
-      const isFetching = updates.isFetching || generalSettings.isFetching;
-      const isPopulated = updates.isPopulated && generalSettings.isPopulated;
-
+    (generalSettings) => {
       return {
-        isFetching,
-        isPopulated,
-        updatesError,
+        isFetchingGeneralSettings: generalSettings.isFetching,
+        isGeneralSettingsPopulated: generalSettings.isPopulated,
         generalSettingsError: generalSettings.error,
-        items,
         updateMechanism: generalSettings.item.updateMechanism,
       };
     }
@@ -61,13 +55,21 @@ function Updates() {
   );
 
   const {
-    isFetching,
-    isPopulated,
-    updatesError,
+    data: items,
+    isFetching: isFetchingUpdates,
+    isFetched: isUpdatesFetched,
+    error: updatesError,
+  } = useUpdates();
+
+  const {
+    isFetchingGeneralSettings,
+    isGeneralSettingsPopulated,
     generalSettingsError,
-    items,
     updateMechanism,
-  } = useSelector(createUpdatesSelector());
+  } = useSelector(createGeneralSettingsSelector());
+
+  const isFetching = isFetchingUpdates || isFetchingGeneralSettings;
+  const isPopulated = isUpdatesFetched && isGeneralSettingsPopulated;
 
   const dispatch = useDispatch();
   const [isMajorUpdateModalOpen, setIsMajorUpdateModalOpen] = useState(false);
@@ -128,7 +130,6 @@ function Updates() {
   }, [setIsMajorUpdateModalOpen]);
 
   useEffect(() => {
-    dispatch(fetchUpdates());
     dispatch(fetchGeneralSettings());
   }, [dispatch]);
 

--- a/frontend/src/System/Updates/useUpdates.ts
+++ b/frontend/src/System/Updates/useUpdates.ts
@@ -1,0 +1,15 @@
+import useApiQuery from 'Helpers/Hooks/useApiQuery';
+import Update from 'typings/Update';
+
+const useUpdates = () => {
+  const result = useApiQuery<Update[]>({
+    path: '/update',
+  });
+
+  return {
+    ...result,
+    data: result.data ?? [],
+  };
+};
+
+export default useUpdates;


### PR DESCRIPTION
#### Database Migration

NO

#### Description

Update list onto React Query. `useUpdates` is Sonarr's hook; **nothing below the fetch is touched**, which is the point of the PR.

Sonarr runs its own update server, so their `Update.changes` is always the structured `{new, fixed}`. Eros reads GitHub releases, so `changes` is `Changes | string | null` with an extra `body` for release-note markdown, and `mergeUpdates` handles both shapes. That parsing and rendering is Eros-specific and was left exactly as-is — only the data source changes.

General settings stay on redux and still supply `updateMechanism`, so the combined selector becomes a general-settings-only one and the page composes `isFetching`/`isPopulated` from the two sources.

`mergeUpdates` now takes `readonly Update[]`. It only reads — `findIndex`, `slice`, `length` — so this is the `Readonly<T>` from #455 catching a real mutable-array signature rather than needing a cast.

`SystemAppState` is down to `logs`, which no TypeScript file reads. Typed loosely with a note; it retires with Events.

#### Screenshot(s) (if UI related)

<details>

No visual change.

</details>

#### Todos

- [ ] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json) — n/a

`eslint` and `yarn build` clean; `tsc` adds no errors over the three pre-existing `node_modules` ones.

Both render paths driven against a running instance, since the release-note handling is the fragile part:

- **Populated** — real GitHub-sourced releases rendered correctly: version rows, commit lines (`(#416)`, `(#413)`) and author handles (`@h2nkm5vydg-oss`, `@plz12345`), plus the "Currently Installed" label.
- **Error** — GitHub started returning `504 GatewayTimeout` partway through testing, which conveniently exercised the other branch: the page renders `FailedToFetchUpdates` with no crash and an empty `#root` never appears. That error now comes from the query rather than the slice, so it was worth seeing.

No console errors on either path beyond the pre-existing `autoHide` warning.

#### Progress

`react-redux` importers 316 → 316 — both consumers still use it for `state.app` and general settings. `Store/` 15,049 → 15,035; `systemActions.js` 227 → 213.

Events is all that remains of the slice.

#### Issues Fixed or Closed by this PR

None.
