### PR TITLE
Fix Queue custom filters being silently ignored

### DIFF
--- a/frontend/src/Activity/Queue/useQueue.ts
+++ b/frontend/src/Activity/Queue/useQueue.ts
@@ -1,10 +1,12 @@
 import { keepPreviousData, useQueryClient } from '@tanstack/react-query';
 import { useMemo } from 'react';
-import { Filter, FilterBuilderProp } from 'Filters/Filter';
+import { useSelector } from 'react-redux';
+import { CustomFilter, Filter, FilterBuilderProp } from 'Filters/Filter';
 import useApiMutation from 'Helpers/Hooks/useApiMutation';
 import usePage from 'Helpers/Hooks/usePage';
 import usePagedApiQuery from 'Helpers/Hooks/usePagedApiQuery';
 import { filterBuilderTypes, filterBuilderValueTypes } from 'Helpers/Props';
+import { createCustomFiltersSelector } from 'Store/Selectors/createClientSideCollectionSelector';
 import Queue from 'typings/Queue';
 import getQueryString from 'Utilities/Fetch/getQueryString';
 import findSelectedFilters from 'Utilities/Filter/findSelectedFilters';
@@ -97,9 +99,16 @@ const useQueue = () => {
     includeUnknownMovieItems,
   } = useQueueOptions();
 
+  // Custom filters are still redux-backed; they convert in Phase C. Leaving
+  // them out of the lookup silently drops the filter -- the key is stored, the
+  // query is not filtered.
+  const customFilters = useSelector(
+    createCustomFiltersSelector('queue')
+  ) as CustomFilter[];
+
   const filters = useMemo(() => {
-    return findSelectedFilters(selectedFilterKey, FILTERS, []);
-  }, [selectedFilterKey]);
+    return findSelectedFilters(selectedFilterKey, FILTERS, customFilters);
+  }, [selectedFilterKey, customFilters]);
 
   const { refetch, ...query } = usePagedApiQuery<Queue>({
     path: '/queue',


### PR DESCRIPTION
#### Database Migration

NO

#### Description

Regression from #474. `useQueue` resolved the selected filter key against the built-in
filters only, passing `[]` for custom filters, so selecting one on the Queue page stored
the key, logged `Matching filter not found`, and left the query unfiltered. Worse, the
resolved filter list was `[]` before *and* after, so the React Query key never changed and
no request was issued — the page kept showing the previous results with the filter
apparently applied.

Restores what `createFetchServerSideCollectionHandler` did pre-conversion, and what
Blocklist, History and Calendar still do: read the custom filters from the redux slice.
The slice itself converts in Phase C.

Verified on a live instance with a `queue` custom filter (`protocol equal torrent`):

| | before | after |
|---|---|---|
| select custom filter | no request, `Matching filter not found` | `GET /queue?…&protocol=torrent` |
| back to All | no request | `GET /queue?…` (no `protocol`) |
| console | 1 error | none |

#### Todos

- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)

#### Issues Fixed or Closed by this PR

None filed.
