### PR TITLE
feat: add posters view to performer and studio detail pages

### DIFF
--- a/frontend/src/Movie/Details/WorkPosterCard.css
+++ b/frontend/src/Movie/Details/WorkPosterCard.css
@@ -1,0 +1,38 @@
+.content {
+  transition: all 200ms ease-in;
+
+  &:hover {
+    z-index: 2;
+    box-shadow: 0 0 12px var(--black);
+    transition: all 200ms ease-in;
+  }
+}
+
+.link {
+  composes: link from 'Components/Link/Link.css';
+
+  position: relative;
+  display: block;
+  background-color: var(--defaultColor);
+}
+
+.poster {
+  object-fit: cover;
+}
+
+.title {
+  @add-mixin truncate;
+
+  overflow: hidden;
+  width: 100%;
+  text-align: center;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: $smallFontSize;
+}
+
+.year {
+  width: 100%;
+  text-align: center;
+  font-size: $smallFontSize;
+}

--- a/frontend/src/Movie/Details/WorkPosterCard.css.d.ts
+++ b/frontend/src/Movie/Details/WorkPosterCard.css.d.ts
@@ -1,0 +1,16 @@
+declare namespace WorkPosterCardCssNamespace {
+  export interface IWorkPosterCardCss {
+    content: string;
+    link: string;
+    poster: string;
+    title: string;
+    year: string;
+  }
+}
+
+declare const WorkPosterCardCssModule: WorkPosterCardCssNamespace.IWorkPosterCardCss & {
+  /** WARNING: Only available when `css-loader` is used without `style-loader` or `mini-css-extract-plugin` */
+  locals: WorkPosterCardCssNamespace.IWorkPosterCardCss;
+};
+
+export = WorkPosterCardCssModule;

--- a/frontend/src/Movie/Details/WorkPosterCard.tsx
+++ b/frontend/src/Movie/Details/WorkPosterCard.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import Link from 'Components/Link/Link';
+import Movie from 'Movie/Movie';
+import ScenePoster from 'Scene/ScenePoster';
+import styles from './WorkPosterCard.css';
+
+interface WorkPosterCardProps {
+  work: Movie;
+  posterWidth: number;
+  posterHeight: number;
+  safeForWorkMode: boolean;
+}
+
+function WorkPosterCard(props: WorkPosterCardProps) {
+  const { work, posterWidth, posterHeight, safeForWorkMode } = props;
+  const { title, titleSlug, year, images } = work;
+
+  const link = `/movie/${titleSlug}`;
+
+  const elementStyle = {
+    width: `${posterWidth}px`,
+    height: `${posterHeight}px`,
+  };
+
+  return (
+    <div className={styles.content}>
+      <Link className={styles.link} style={elementStyle} to={link}>
+        <ScenePoster
+          className={styles.poster}
+          safeForWorkMode={safeForWorkMode}
+          style={elementStyle}
+          images={images}
+          size={180}
+          lazy={true}
+          overflow={true}
+        />
+      </Link>
+
+      <div className={styles.title} title={title}>
+        {title}
+      </div>
+
+      <div className={styles.year}>{year ? year : null}</div>
+    </div>
+  );
+}
+
+export default WorkPosterCard;

--- a/frontend/src/Performer/Details/PerformerDetails.tsx
+++ b/frontend/src/Performer/Details/PerformerDetails.tsx
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import React, { useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { useParams } from 'react-router-dom';
 import Flag from 'react-world-flags';
@@ -26,6 +26,7 @@ import {
 } from 'Helpers/Props/sortDirections';
 import MovieHeadshot from 'Movie/MovieHeadshot';
 import DeletePerformerModal from 'Performer/Delete/DeletePerformerModal';
+import PerformerIndexViewMenu from 'Performer/Index/Menus/PerformerIndexViewMenu';
 import PerformerGenderIcon from 'Performer/PerformerGenderIcon';
 import { getPerformerStatusDetails } from 'Performer/PerformerStatus';
 import QualityProfileName from 'Settings/Profiles/Quality/QualityProfileName';
@@ -37,6 +38,7 @@ import firstCharToUpper from 'Utilities/String/firstCharToUpper';
 import translate from 'Utilities/String/translate';
 import EditPerformerModal from '../Edit/EditPerformerModal';
 import PerformerDetailsLinks from './PerformerDetailsLinks';
+import PerformerDetailsPosters from './PerformerDetailsPosters';
 import PerformerDetailsYear from './PerformerDetailsYear';
 import PerformerTags from './PerformerTags';
 import {
@@ -82,6 +84,12 @@ function PerformerDetails() {
   const [isEditMovieModalOpen, setIsEditMovieModalOpen] = useState(false);
   const [isDeleteMovieModalOpen, setIsDeleteMovieModalOpen] = useState(false);
   const [allExpandedYears, setAllExpandedYears] = useState<boolean>(false);
+  const [view, setView] = useState<'table' | 'posters'>('table');
+
+  const [scrollContainer, setScrollContainer] = useState<Element | null>(null);
+  const contentBodyRef = useCallback((el: HTMLDivElement | null) => {
+    setScrollContainer(el);
+  }, []);
 
   // Initialize expandedYears so current year is expanded by default
   const [expandedYears, setExpandedYears] = useState<Record<number, boolean>>(
@@ -230,6 +238,9 @@ function PerformerDetails() {
   function handleDeleteMoviePress() {
     setIsDeleteMovieModalOpen(true);
   }
+  function handleViewSelect(value: string) {
+    setView(value === 'posters' ? 'posters' : 'table');
+  }
   function handleRefreshPress() {
     onRefreshPress();
   }
@@ -278,14 +289,24 @@ function PerformerDetails() {
           onPress={handleDeleteMoviePress}
         />
         <PageToolbarSection alignContent="right">
-          <PageToolbarButton
-            label="Expand All"
-            iconName={expandIcon}
-            onPress={handleExpandAllPress}
+          <PerformerIndexViewMenu
+            view={view}
+            isDisabled={movies.length === 0}
+            onViewSelect={handleViewSelect}
           />
+          {view === 'table' ? (
+            <PageToolbarButton
+              label="Expand All"
+              iconName={expandIcon}
+              onPress={handleExpandAllPress}
+            />
+          ) : null}
         </PageToolbarSection>
       </PageToolbar>
-      <PageContentBody innerClassName={styles.innerContentBody}>
+      <PageContentBody
+        ref={contentBodyRef}
+        innerClassName={styles.innerContentBody}
+      >
         <div className={styles.header}>
           <div
             className={styles.backdrop}
@@ -529,23 +550,32 @@ function PerformerDetails() {
           {/* Studios section (delayed render for each studio) */}
           {movies.length > 0 && (
             <FieldSet legend={translate('Works')}>
-              {moviesByYear.map(({ year, movies: yearMovies }) => (
-                <PerformerDetailsYear
-                  key={year}
-                  year={year}
-                  performerId={performer.id}
-                  columns={columns}
-                  movies={yearMovies}
-                  sortKey={sortKey}
-                  sortDirection={sortDirection}
-                  isExpanded={!!expandedYears[year]}
-                  isSmallScreen={false} // or use your actual logic for small screen
+              {view === 'posters' ? (
+                <PerformerDetailsPosters
+                  works={movies}
+                  scrollElement={scrollContainer}
                   safeForWorkMode={safeForWorkMode}
-                  onSortPress={handleSortPress}
-                  onExpandPress={handleExpandYearPress}
-                  onYearRefreshPress={onYearRefreshPress}
+                  isSmallScreen={false}
                 />
-              ))}
+              ) : (
+                moviesByYear.map(({ year, movies: yearMovies }) => (
+                  <PerformerDetailsYear
+                    key={year}
+                    year={year}
+                    performerId={performer.id}
+                    columns={columns}
+                    movies={yearMovies}
+                    sortKey={sortKey}
+                    sortDirection={sortDirection}
+                    isExpanded={!!expandedYears[year]}
+                    isSmallScreen={false} // or use your actual logic for small screen
+                    safeForWorkMode={safeForWorkMode}
+                    onSortPress={handleSortPress}
+                    onExpandPress={handleExpandYearPress}
+                    onYearRefreshPress={onYearRefreshPress}
+                  />
+                ))
+              )}
             </FieldSet>
           )}
         </div>

--- a/frontend/src/Performer/Details/PerformerDetailsPosters.css
+++ b/frontend/src/Performer/Details/PerformerDetailsPosters.css
@@ -1,0 +1,3 @@
+.cell {
+  box-sizing: border-box;
+}

--- a/frontend/src/Performer/Details/PerformerDetailsPosters.css.d.ts
+++ b/frontend/src/Performer/Details/PerformerDetailsPosters.css.d.ts
@@ -1,0 +1,12 @@
+declare namespace PerformerDetailsPostersCssNamespace {
+  export interface IPerformerDetailsPostersCss {
+    cell: string;
+  }
+}
+
+declare const PerformerDetailsPostersCssModule: PerformerDetailsPostersCssNamespace.IPerformerDetailsPostersCss & {
+  /** WARNING: Only available when `css-loader` is used without `style-loader` or `mini-css-extract-plugin` */
+  locals: PerformerDetailsPostersCssNamespace.IPerformerDetailsPostersCss;
+};
+
+export = PerformerDetailsPostersCssModule;

--- a/frontend/src/Performer/Details/PerformerDetailsPosters.tsx
+++ b/frontend/src/Performer/Details/PerformerDetailsPosters.tsx
@@ -1,0 +1,171 @@
+import React, { useCallback, useMemo } from 'react';
+import {
+  AutoSizer,
+  Grid,
+  type GridCellProps,
+  WindowScroller,
+} from 'react-virtualized';
+import WorkPosterCard from 'Movie/Details/WorkPosterCard';
+import Movie from 'Movie/Movie';
+import dimensions from 'Styles/Variables/dimensions';
+import styles from './PerformerDetailsPosters.css';
+
+const columnPadding = Number.parseInt(dimensions.movieIndexColumnPadding, 10);
+const columnPaddingSmallScreen = Number.parseInt(
+  dimensions.movieIndexColumnPaddingSmallScreen,
+  10
+);
+
+// Matches the 'medium' poster size used by SceneIndexPosters
+const ADDITIONAL_COLUMN_COUNT = 2;
+
+const TITLE_HEIGHT = 19;
+const YEAR_HEIGHT = 17;
+
+interface PerformerDetailsPostersProps {
+  works: readonly Movie[];
+  scrollElement: Element | null;
+  safeForWorkMode: boolean;
+  isSmallScreen: boolean;
+}
+
+interface PostersGridProps {
+  items: Movie[];
+  width: number;
+  height: number;
+  scrollTop: number;
+  isScrolling: boolean;
+  safeForWorkMode: boolean;
+  isSmallScreen: boolean;
+  onChildScroll: (params: { scrollTop: number }) => void;
+}
+
+function getColumnWidth(width: number, isSmallScreen: boolean): number {
+  const maximumColumnWidth = isSmallScreen ? 300 : 310;
+  const columns = Math.floor(width / maximumColumnWidth);
+  const remainder = width % maximumColumnWidth;
+
+  return remainder === 0
+    ? maximumColumnWidth
+    : Math.floor(width / (columns + ADDITIONAL_COLUMN_COUNT));
+}
+
+function PostersGrid(props: PostersGridProps) {
+  const {
+    items,
+    width,
+    height,
+    scrollTop,
+    isScrolling,
+    safeForWorkMode,
+    isSmallScreen,
+    onChildScroll,
+  } = props;
+
+  const columnWidth = getColumnWidth(width, isSmallScreen);
+  const columnCount = Math.max(Math.floor(width / columnWidth), 1);
+  const padding = isSmallScreen ? columnPaddingSmallScreen : columnPadding;
+  const posterWidth = columnWidth - padding * 2;
+  const posterHeight = Math.ceil((170 / 300) * posterWidth);
+  const rowHeight = posterHeight + TITLE_HEIGHT + YEAR_HEIGHT + padding * 2;
+
+  const cellRenderer = useCallback(
+    ({ columnIndex, rowIndex, key, style }: GridCellProps) => {
+      const index = rowIndex * columnCount + columnIndex;
+      const work = items[index];
+
+      if (!work) {
+        return null;
+      }
+
+      return (
+        <div key={key} className={styles.cell} style={{ ...style, padding }}>
+          <WorkPosterCard
+            work={work}
+            posterWidth={posterWidth}
+            posterHeight={posterHeight}
+            safeForWorkMode={safeForWorkMode}
+          />
+        </div>
+      );
+    },
+    [items, columnCount, padding, posterWidth, posterHeight, safeForWorkMode]
+  );
+
+  return (
+    <Grid
+      autoHeight={true}
+      height={height}
+      width={width}
+      columnCount={columnCount}
+      columnWidth={columnWidth}
+      rowCount={Math.ceil(items.length / columnCount)}
+      rowHeight={rowHeight}
+      overscanRowCount={2}
+      cellRenderer={cellRenderer}
+      scrollTop={scrollTop}
+      isScrolling={isScrolling}
+      onScroll={onChildScroll}
+    />
+  );
+}
+
+function PerformerDetailsPosters(props: PerformerDetailsPostersProps) {
+  const { works, scrollElement, safeForWorkMode, isSmallScreen } = props;
+
+  const items = useMemo(() => {
+    return [...works].sort((a, b) => {
+      const aDate = a.releaseDate ? Date.parse(a.releaseDate) : 0;
+      const bDate = b.releaseDate ? Date.parse(b.releaseDate) : 0;
+
+      if (aDate !== bDate) {
+        return bDate - aDate;
+      }
+
+      return a.title.localeCompare(b.title);
+    });
+  }, [works]);
+
+  return (
+    <WindowScroller scrollElement={scrollElement ?? undefined}>
+      {({ height, isScrolling, onChildScroll, scrollTop, registerChild }) => {
+        if (!height) {
+          return null;
+        }
+
+        return (
+          <div
+            ref={(element) => {
+              (registerChild as unknown as (el: Element | null) => void)(
+                element
+              );
+            }}
+          >
+            <AutoSizer disableHeight={true}>
+              {({ width }) => {
+                if (!width) {
+                  return null;
+                }
+
+                return (
+                  <PostersGrid
+                    items={items}
+                    width={width}
+                    height={height}
+                    scrollTop={scrollTop}
+                    isScrolling={isScrolling}
+                    safeForWorkMode={safeForWorkMode}
+                    isSmallScreen={isSmallScreen}
+                    onChildScroll={onChildScroll}
+                  />
+                );
+              }}
+            </AutoSizer>
+          </div>
+        );
+      }}
+    </WindowScroller>
+  );
+}
+
+export default PerformerDetailsPosters;

--- a/frontend/src/Studio/Details/StudioDetails.tsx
+++ b/frontend/src/Studio/Details/StudioDetails.tsx
@@ -37,11 +37,13 @@ import QualityProfileName from 'Settings/Profiles/Quality/QualityProfileName';
 import { setStudioScenesExpanded } from 'Store/Actions/studioScenesActions';
 import DeleteStudioModal from 'Studio/Delete/DeleteStudioModal';
 import EditStudioModal from 'Studio/Edit/EditStudioModal';
+import StudioIndexViewMenu from 'Studio/Index/Menus/StudioIndexViewMenu';
 import { type Image } from 'Studio/Studio';
 import StudioLogo from 'Studio/StudioLogo';
 import formatBytes from 'Utilities/Number/formatBytes';
 import translate from 'Utilities/String/translate';
 import StudioDetailsLinks from './StudioDetailsLinks';
+import StudioDetailsPosters from './StudioDetailsPosters';
 import StudioDetailsYear from './StudioDetailsYear';
 import StudioTags from './StudioTags';
 import {
@@ -67,6 +69,11 @@ function StudioDetails() {
   const [scrollContainer, setScrollContainer] = useState<Element | null>(null);
   const contentBodyRef = useCallback((el: HTMLDivElement | null) => {
     setScrollContainer(el);
+  }, []);
+
+  const [view, setView] = useState<'table' | 'posters'>('table');
+  const handleViewSelect = useCallback((value: string) => {
+    setView(value === 'posters' ? 'posters' : 'table');
   }, []);
 
   const listRef = useRef<List>(null);
@@ -279,11 +286,18 @@ function StudioDetails() {
         </PageToolbarSection>
 
         <PageToolbarSection alignContent="right">
-          <PageToolbarButton
-            label={allExpanded ? 'Collapse All' : 'Expand All'}
-            iconName={expandIcon}
-            onPress={handleExpandAllPress}
+          <StudioIndexViewMenu
+            view={view}
+            isDisabled={!isPopulated}
+            onViewSelect={handleViewSelect}
           />
+          {view === 'table' ? (
+            <PageToolbarButton
+              label={allExpanded ? 'Collapse All' : 'Expand All'}
+              iconName={expandIcon}
+              onPress={handleExpandAllPress}
+            />
+          ) : null}
         </PageToolbarSection>
       </PageToolbar>
 
@@ -505,56 +519,72 @@ function StudioDetails() {
 
           {isWorksFetching && !isPopulated ? <LoadingIndicator /> : null}
 
-          {/* WORKS BY YEAR */}
-          {isPopulated && (studio.hasMovies || studio.hasScenes) && (
-            <FieldSet legend={translate('Works')}>
-              <WindowScroller scrollElement={scrollContainer ?? undefined}>
-                {({
-                  height,
-                  isScrolling,
-                  onChildScroll,
-                  scrollTop,
-                  registerChild,
-                }) => {
-                  if (!height) {
-                    return null;
-                  }
+          {/* WORKS POSTER GRID */}
+          {isPopulated &&
+            (studio.hasMovies || studio.hasScenes) &&
+            view === 'posters' && (
+              <FieldSet legend={translate('Works')}>
+                <StudioDetailsPosters
+                  works={allWorks}
+                  scrollElement={scrollContainer}
+                  safeForWorkMode={safeForWorkMode}
+                  isSmallScreen={false}
+                />
+              </FieldSet>
+            )}
 
-                  return (
-                    <div
-                      ref={(element) => {
-                        (
-                          registerChild as unknown as (
-                            el: Element | null
-                          ) => void
-                        )(element);
-                      }}
-                    >
-                      <AutoSizer disableHeight={true}>
-                        {({ width }) => (
-                          <List
-                            ref={listRef}
-                            autoHeight={true}
-                            height={height}
-                            width={width}
-                            rowCount={worksByYear.length}
-                            rowHeight={cacheRef.current.rowHeight}
-                            estimatedRowSize={80}
-                            deferredMeasurementCache={cacheRef.current}
-                            overscanRowCount={6}
-                            scrollTop={scrollTop}
-                            isScrolling={isScrolling}
-                            rowRenderer={rowRenderer}
-                            onScroll={onChildScroll}
-                          />
-                        )}
-                      </AutoSizer>
-                    </div>
-                  );
-                }}
-              </WindowScroller>
-            </FieldSet>
-          )}
+          {/* WORKS BY YEAR */}
+          {isPopulated &&
+            (studio.hasMovies || studio.hasScenes) &&
+            view === 'table' && (
+              <FieldSet legend={translate('Works')}>
+                <WindowScroller scrollElement={scrollContainer ?? undefined}>
+                  {({
+                    height,
+                    isScrolling,
+                    onChildScroll,
+                    scrollTop,
+                    registerChild,
+                  }) => {
+                    if (!height) {
+                      return null;
+                    }
+
+                    return (
+                      <div
+                        ref={(element) => {
+                          (
+                            registerChild as unknown as (
+                              el: Element | null
+                            ) => void
+                          )(element);
+                        }}
+                      >
+                        <AutoSizer disableHeight={true}>
+                          {({ width }) => (
+                            <List
+                              ref={listRef}
+                              autoHeight={true}
+                              height={height}
+                              width={width}
+                              rowCount={worksByYear.length}
+                              rowHeight={cacheRef.current.rowHeight}
+                              estimatedRowSize={80}
+                              deferredMeasurementCache={cacheRef.current}
+                              overscanRowCount={6}
+                              scrollTop={scrollTop}
+                              isScrolling={isScrolling}
+                              rowRenderer={rowRenderer}
+                              onScroll={onChildScroll}
+                            />
+                          )}
+                        </AutoSizer>
+                      </div>
+                    );
+                  }}
+                </WindowScroller>
+              </FieldSet>
+            )}
         </div>
 
         {/* MODALS */}

--- a/frontend/src/Studio/Details/StudioDetailsPosters.css
+++ b/frontend/src/Studio/Details/StudioDetailsPosters.css
@@ -1,0 +1,3 @@
+.cell {
+  box-sizing: border-box;
+}

--- a/frontend/src/Studio/Details/StudioDetailsPosters.css.d.ts
+++ b/frontend/src/Studio/Details/StudioDetailsPosters.css.d.ts
@@ -1,0 +1,12 @@
+declare namespace StudioDetailsPostersCssNamespace {
+  export interface IStudioDetailsPostersCss {
+    cell: string;
+  }
+}
+
+declare const StudioDetailsPostersCssModule: StudioDetailsPostersCssNamespace.IStudioDetailsPostersCss & {
+  /** WARNING: Only available when `css-loader` is used without `style-loader` or `mini-css-extract-plugin` */
+  locals: StudioDetailsPostersCssNamespace.IStudioDetailsPostersCss;
+};
+
+export = StudioDetailsPostersCssModule;

--- a/frontend/src/Studio/Details/StudioDetailsPosters.tsx
+++ b/frontend/src/Studio/Details/StudioDetailsPosters.tsx
@@ -1,0 +1,171 @@
+import React, { useCallback, useMemo } from 'react';
+import {
+  AutoSizer,
+  Grid,
+  type GridCellProps,
+  WindowScroller,
+} from 'react-virtualized';
+import WorkPosterCard from 'Movie/Details/WorkPosterCard';
+import Movie from 'Movie/Movie';
+import dimensions from 'Styles/Variables/dimensions';
+import styles from './StudioDetailsPosters.css';
+
+const columnPadding = Number.parseInt(dimensions.movieIndexColumnPadding, 10);
+const columnPaddingSmallScreen = Number.parseInt(
+  dimensions.movieIndexColumnPaddingSmallScreen,
+  10
+);
+
+// Matches the 'medium' poster size used by SceneIndexPosters
+const ADDITIONAL_COLUMN_COUNT = 2;
+
+const TITLE_HEIGHT = 19;
+const YEAR_HEIGHT = 17;
+
+interface StudioDetailsPostersProps {
+  works: readonly Movie[];
+  scrollElement: Element | null;
+  safeForWorkMode: boolean;
+  isSmallScreen: boolean;
+}
+
+interface PostersGridProps {
+  items: Movie[];
+  width: number;
+  height: number;
+  scrollTop: number;
+  isScrolling: boolean;
+  safeForWorkMode: boolean;
+  isSmallScreen: boolean;
+  onChildScroll: (params: { scrollTop: number }) => void;
+}
+
+function getColumnWidth(width: number, isSmallScreen: boolean): number {
+  const maximumColumnWidth = isSmallScreen ? 300 : 310;
+  const columns = Math.floor(width / maximumColumnWidth);
+  const remainder = width % maximumColumnWidth;
+
+  return remainder === 0
+    ? maximumColumnWidth
+    : Math.floor(width / (columns + ADDITIONAL_COLUMN_COUNT));
+}
+
+function PostersGrid(props: PostersGridProps) {
+  const {
+    items,
+    width,
+    height,
+    scrollTop,
+    isScrolling,
+    safeForWorkMode,
+    isSmallScreen,
+    onChildScroll,
+  } = props;
+
+  const columnWidth = getColumnWidth(width, isSmallScreen);
+  const columnCount = Math.max(Math.floor(width / columnWidth), 1);
+  const padding = isSmallScreen ? columnPaddingSmallScreen : columnPadding;
+  const posterWidth = columnWidth - padding * 2;
+  const posterHeight = Math.ceil((170 / 300) * posterWidth);
+  const rowHeight = posterHeight + TITLE_HEIGHT + YEAR_HEIGHT + padding * 2;
+
+  const cellRenderer = useCallback(
+    ({ columnIndex, rowIndex, key, style }: GridCellProps) => {
+      const index = rowIndex * columnCount + columnIndex;
+      const work = items[index];
+
+      if (!work) {
+        return null;
+      }
+
+      return (
+        <div key={key} className={styles.cell} style={{ ...style, padding }}>
+          <WorkPosterCard
+            work={work}
+            posterWidth={posterWidth}
+            posterHeight={posterHeight}
+            safeForWorkMode={safeForWorkMode}
+          />
+        </div>
+      );
+    },
+    [items, columnCount, padding, posterWidth, posterHeight, safeForWorkMode]
+  );
+
+  return (
+    <Grid
+      autoHeight={true}
+      height={height}
+      width={width}
+      columnCount={columnCount}
+      columnWidth={columnWidth}
+      rowCount={Math.ceil(items.length / columnCount)}
+      rowHeight={rowHeight}
+      overscanRowCount={2}
+      cellRenderer={cellRenderer}
+      scrollTop={scrollTop}
+      isScrolling={isScrolling}
+      onScroll={onChildScroll}
+    />
+  );
+}
+
+function StudioDetailsPosters(props: StudioDetailsPostersProps) {
+  const { works, scrollElement, safeForWorkMode, isSmallScreen } = props;
+
+  const items = useMemo(() => {
+    return [...works].sort((a, b) => {
+      const aDate = a.releaseDate ? Date.parse(a.releaseDate) : 0;
+      const bDate = b.releaseDate ? Date.parse(b.releaseDate) : 0;
+
+      if (aDate !== bDate) {
+        return bDate - aDate;
+      }
+
+      return a.title.localeCompare(b.title);
+    });
+  }, [works]);
+
+  return (
+    <WindowScroller scrollElement={scrollElement ?? undefined}>
+      {({ height, isScrolling, onChildScroll, scrollTop, registerChild }) => {
+        if (!height) {
+          return null;
+        }
+
+        return (
+          <div
+            ref={(element) => {
+              (registerChild as unknown as (el: Element | null) => void)(
+                element
+              );
+            }}
+          >
+            <AutoSizer disableHeight={true}>
+              {({ width }) => {
+                if (!width) {
+                  return null;
+                }
+
+                return (
+                  <PostersGrid
+                    items={items}
+                    width={width}
+                    height={height}
+                    scrollTop={scrollTop}
+                    isScrolling={isScrolling}
+                    safeForWorkMode={safeForWorkMode}
+                    isSmallScreen={isSmallScreen}
+                    onChildScroll={onChildScroll}
+                  />
+                );
+              }}
+            </AutoSizer>
+          </div>
+        );
+      }}
+    </WindowScroller>
+  );
+}
+
+export default StudioDetailsPosters;


### PR DESCRIPTION
#### Database Migration

NO

#### Description

Adds an opt-in **Posters view** to the Performer and Studio detail pages. When selected, the Works section renders a flat, virtualized grid of poster cards (screenshot image, title, year) linking to each work's detail page. Table view remains the default and is unchanged.

- Reuses the existing Table/Posters ViewMenu from the index pages.
- Uses react-virtualized Grid + WindowScroller (already used in StudioDetails) for virtualization, safe for performers/studios with thousands of works.
- Honors safeForWorkMode via the existing ScenePoster/MovieImage path.
- No new dependencies, no DB migration, no backend changes, no new translation keys (reuses existing Table/Posters).

#### Screenshot(s) (if UI related)

<details>
<summary>Performer detail page, Posters view</summary>
<img width="1680" height="1050" alt="image_0" src="https://github.com/user-attachments/assets/a4e6d9bf-94ab-4830-96a5-79f0b756e8f9" />


</details>

<details>
<summary>Studio detail page, Posters view</summary>
<img width="1680" height="1050" alt="image_1" src="https://github.com/user-attachments/assets/35679a3b-b3f7-4840-91ef-c185c9d5eb10" />

</details>

#### Todos

- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)

#### Issues Fixed or Closed by this PR

N/A (no issue opened upstream for this feature)