### PR TITLE
Chore: Stop every CI job full-cloning the repo

### DIFF
--- a/.github/workflows/build_v3.yml
+++ b/.github/workflows/build_v3.yml
@@ -42,7 +42,14 @@ jobs:
       - name: Check out
         uses: actions/checkout@v7
         with:
-          fetch-depth: 0 # fetches tags; needed to read the version marker
+          # `git tag --merged HEAD` below needs the whole commit graph, so this
+          # one job cannot go shallow. tree:0 makes it a treeless partial clone:
+          # the commits and tags arrive (~5 MB), the trees and blobs behind them
+          # (~360 MB) do not. Every other job in this workflow builds or tests
+          # from a downloaded artifact and reads no history at all - leave those
+          # on the default shallow checkout.
+          fetch-depth: 0
+          filter: tree:0
 
       - name: Setup Environment Variables
         id: variables
@@ -118,8 +125,6 @@ jobs:
     steps:
       - name: Check out
         uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
 
       - name: Build
         uses: ./.github/actions/build
@@ -136,8 +141,6 @@ jobs:
     steps:
       - name: Check out
         uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
 
       - name: Volta
         uses: volta-cli/action@v5
@@ -189,8 +192,6 @@ jobs:
     steps:
       - name: Check out
         uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
 
       - name: Test
         uses: ./.github/actions/test
@@ -211,8 +212,6 @@ jobs:
     steps:
       - name: Check out
         uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
 
       - name: Test
         uses: ./.github/actions/test
@@ -250,8 +249,6 @@ jobs:
     steps:
       - name: Check out
         uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
       - name: Test
         uses: ./.github/actions/test
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -71,8 +71,12 @@ jobs:
       - name: Check out
         uses: actions/checkout@v7
         with:
+          # The changelog step walks PREV_TAG..CUR_TAG and the signed tag is cut
+          # from this checkout, so the full commit graph and every tag have to be
+          # here; tree:0 fetches that graph without the trees and blobs behind it.
+          # fetch-tags is implied by fetch-depth: 0.
           fetch-depth: 0
-          fetch-tags: true
+          filter: tree:0
 
       - name: Download release artifacts
         uses: actions/download-artifact@v8


### PR DESCRIPTION
#### Database Migration

NO

#### Description

`fetch-depth: 0` was set on 22 of the 23 checkouts in `build_v3.yml` and
`deploy.yml` — a full clone of every branch and tag on every job. Measured
against the current object graph:

| what gets fetched | size |
|---|---|
| full clone, all refs (`fetch-depth: 0`) | **359 MiB** |
| commits + tags only (`filter: tree:0`) | 4.7 MiB |
| single-commit snapshot (default checkout) | 5.3 MiB |

The tag count isn't the driver — 669 tags is tens of KB of ref advertisement.
It's the history, and it grows every run.

Only three checkouts read git. `prepare` runs `git tag --merged HEAD`, deploy's
`release` job walks `PREV_TAG..CUR_TAG` and signs a tag, and Sonar needs blame.
The first two keep full history but switch to `filter: tree:0` — tag
reachability and `git log --pretty` walk commits and never touch a tree, so
~359 MiB becomes ~10.

The other 20 jobs (backend ×10, frontend, and all three test matrices) build or
test from downloaded artifacts and run no git commands: the build/test composite
actions contain none, and `PublishRepositoryUrl` in `src/Directory.Build.props`
is inert with no SourceLink package referenced. Those drop to the default
shallow checkout.

`sonarqube.yml` is deliberately untouched — its blame runs through JGit, which
doesn't follow partial-clone promisors, so a lazy-fetch miss would take out
new-code detection and the coverage gate with it.

Verified `filter` is a valid input on `actions/checkout@v7`. Wall-clock
improvement can only be confirmed by this PR's own run.

#### Todos

- [ ] Tests — n/a, CI configuration only
- [ ] Translation Keys — n/a
