### PR TITLE
Set React Query client defaults

### DIFF
--- a/REDUX_MIGRATION.md
+++ b/REDUX_MIGRATION.md
@@ -628,6 +628,7 @@ If a JS test runner is ever added, remove that line and set
 | 2026-08-18 | #469 | **Events.** First paged page. `usePage` added; the system slice is down to restart/shutdown. Three type holes fixed that only `.js` files had been hiding. |
 | 2026-08-18 | #470 | **SignalR container.** Class + `connect()` → function component, as Sonarr did in Jan 2025. Redux stays inside. |
 | 2026-08-18 | #471 | **Organize preview + Unmapped Files.** Two slices retired. First conversion where a page's table prefs move to a zustand options store rather than to React Query. |
+| 2026-08-20 | #485 | **React Query client defaults.** `staleTime: 60s` and `retry: 1` on `queryClient`, closing Whisparr/Whisparr#1132. Not a conversion — it changes behaviour for every already-converted page, which is why it rode alone. Measured before and after over four flows: 46–48 requests became 28–30. Verified push still drives updates: an external API mutation refetched `/movie/paged` unprompted on an idle page. Turned up a separate redux bug on the way — `useShowMovieMonitorToggleButton` dispatches `fetchGeneralSettings()` from a per-row mount effect, so `/config/host` fires once per table row. |
 | 2026-08-20 | #484 | **Custom filters, part 2 of 2 — reads.** `useCustomFilters`/`useCustomFiltersList` queries; all 19 `createCustomFiltersSelector` call sites swept across 8 filter domains; `customFilterActions` and `CustomFiltersAppState` deleted. `useAppPage` now gates on the query, which is what keeps a persisted filter from flashing the unfiltered list on reload. `createClientSideCollectionSelector` takes custom filters as an own prop. Also: `staleTime: Infinity` (the default 0 cost one extra GET per navigation), six vestigial `<section>.customFilters` persist paths removed, and `AppState`'s duplicate `CustomFilter` type now re-exports the canonical one. |
 | 2026-08-20 | #483 | **Custom filters, part 1 of 2 — mutations.** Save and delete onto `useApiMutation`; `FilterBuilderModalContentConnector` and `CustomFiltersModalContentConnector` retired, both modal contents to TSX. Reads stay on redux, so the mutations apply their own response to the slice rather than refetching. Two latent bugs fixed on the way: the manage modal's sort was a no-op, and its `Alert` took a prop the component does not have. |
 | 2026-08-20 | #481 | **Calendar.** `calendarActions` and `CalendarAppState` deleted; Phase B complete. Options and view to a persisted zustand store, the visible range to a second non-persisted one, `/calendar` to `useApiQuery`. Two fixes ride along, both in code the conversion rewrites: `executeCommandHelper` never returned the created command, which had left *Search for Missing* throwing and its spinner dead; and the view switch no longer resets to today (Whisparr/Whisparr#1131), matching what Sonarr's own conversion did. |
@@ -657,8 +658,9 @@ If a JS test runner is ever added, remove that line and set
   but it fires once per retired slice per user, and every conversion so far has added one.
   `Store/Migrators/migrate.js` is where a sweep would go, and it wants doing once at the
   end rather than per-PR.
-- **Whisparr/Whisparr#1132** — `App/queryClient.ts` builds the client with no defaults, so
-  `staleTime` is 0 and every observer that mounts after the first refetches. Measured on
+- ~~**Whisparr/Whisparr#1132**~~ — **Fixed, #485.** `App/queryClient.ts` built the client
+  with no defaults, so `staleTime` was 0 and every observer that mounted after the first
+  refetched. Measured on
   `eros-develop` before Calendar was touched: `/queue/details` ×2 and `/movie/stats` ×2 on
   the calendar, `/queue/details` ×3 on `/scenes`, `/system/status` ×2 everywhere. #481 adds
   `/calendar` to that list — 9 requests against the thunk's 6 over the same six-step
@@ -667,7 +669,12 @@ If a JS test runner is ever added, remove that line and set
   `new QueryClient()`, same `isMeasured` gate, same first-commit `useCalendar()` in the
   toolbar, same per-day-cell `useCalendar()` — so this is upstream's shape, not an Eros
   divergence. The fix is a client default; it changes behaviour for every converted page
-  and should not ride along in a page conversion.
+  and should not ride along in a page conversion — so it went out alone as #485,
+  `staleTime: 60s` plus `retry: 1`. A minute of staleness is safe because freshness here
+  is push-driven: `invalidateQueries` is not gated by `staleTime`, `refetchOnWindowFocus`
+  stays on, and nothing in the tree sets `refetchInterval`. Measured over four flows,
+  46–48 requests became 28–30 — navigating six index pages went 14 to 4, and paging back
+  to an already-fetched page went 8–10 to 2.
 - **Whisparr/Whisparr#1123** — `AUTH_HEADERS` and hand-rolled fetch helpers still
   duplicated in `useStudio`, `usePerformer`, `useAddNewMovie`. Not on the critical path;
   filed rather than folded into #455. `useHistory` came off it in #478 — its `apiPost`

--- a/frontend/src/App/queryClient.ts
+++ b/frontend/src/App/queryClient.ts
@@ -1,6 +1,23 @@
 import { QueryClient } from '@tanstack/react-query';
 
-export const queryClient = new QueryClient();
+// Freshness in this app is push-driven: SignalRListener invalidates a dozen query
+// families as the server changes them. React Query's default staleTime of 0 layers a
+// poll on top of that -- every component that mounts a new observer refetches data
+// nothing has touched. A minute of staleness costs nothing here because
+// refetchOnWindowFocus stays on, so returning to the tab still catches everything up.
+//
+// Queries that need something else say so locally: config-shaped data that only this
+// app mutates uses Infinity, and genuinely poll-worthy data (backups) sets its own.
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 60 * 1000,
+      // Three retries with backoff is a slow way to surface a failure from a server
+      // that is usually on the same machine.
+      retry: 1,
+    },
+  },
+});
 
 // This code is only for TypeScript
 declare global {


### PR DESCRIPTION
#### Database Migration

NO

#### Description

`App/queryClient.ts` built the client bare, so `staleTime` was 0 and data was stale the
moment it arrived. `refetchOnMount` then fired for every observer mounting after the
first, and again on every navigation that remounted one.

Freshness in this app is push-driven, not poll-driven: `SignalRListener` invalidates a
dozen query families as the server changes them, and `invalidateQueries` refetches active
observers regardless of staleness. A `staleTime` of 0 layers a poll on top of that and
refetches data nothing has touched. A minute is safe because `refetchOnWindowFocus` stays
on, so returning to the tab still catches everything up — and nothing here polls, there is
no `refetchInterval` anywhere in the tree.

`retry` drops from 3 to 1. Three attempts with exponential backoff is a slow way to
surface a failure from a server usually running on the same machine.

#### Measurements

Same four flows on this branch's parent and on the change, counting API requests.
`/config/host` excluded — it comes from a redux thunk and no React Query default moves it
(see below). Each configuration run twice; ranges are the observed spread.

| flow | before | after |
| --- | --- | --- |
| cold load `/movies` | 16 | 15 |
| navigate 6 index pages | 14 | **4** |
| page next, next, prev, prev | 8–10 | **2** |
| movie detail and back | 8 | 7–9 |
| **total** | **46–48** | **28–30** |

Paging is the clearest case: revisiting a page already fetched now costs nothing, where
before every visit refetched.

Correctness checks:

- **Push still works.** With `/movies` open and quiet (0 requests over 8s), flipping a
  movie's `monitored` flag through the API *from outside the browser* triggered
  `POST /movie/paged` within seconds, unprompted. `invalidateQueries` is not gated by
  `staleTime`, and this confirms it end to end.
- 20 pages swept — index, activity, wanted, collections, calendar, settings, system — all
  render with zero console errors.

#### Out of scope, found while measuring

`GET /config/host` fires **once per table row**: `useShowMovieMonitorToggleButton` calls
`useGeneralSettings`, which dispatches `fetchGeneralSettings()` from a mount effect, and
`StudioIndexRow`, `PerformerIndexRow` and `PerformerIndexPoster` each call it. 51 requests
over a six-page navigation. It is a redux thunk, so nothing in this PR touches it, and it
wants its own fix.

#### Todos

- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)

#### Issues Fixed or Closed by this PR

- Fixes Whisparr/Whisparr#1132
