### PR TITLE
Move advanced settings onto zustand

### DIFF
--- a/REDUX_MIGRATION.md
+++ b/REDUX_MIGRATION.md
@@ -187,7 +187,7 @@ commands commit touched 51 files, custom filters 44. Ship them alone.
 | ~~**Paths + file browser**~~ *(hybrid)* — `usePaths` existed; `PathInput` and `FileBrowserModalContent` finished. **Done, #489.** | ~~`pathActions`~~, ~~`PathsAppState`~~, ~~`createPathsSelector.ts`~~ | [Sonarr/Sonarr@91b24290](https://github.com/Sonarr/Sonarr/commit/91b24290), [Sonarr/Sonarr@9a0e23a9](https://github.com/Sonarr/Sonarr/commit/9a0e23a9) |
 | ~~**Provider options + captcha**~~ — feeds every provider settings form. **Done, #490.** | ~~`providerOptionActions`~~, ~~`captchaActions`~~, ~~`oAuthActions`~~, ~~`ProviderOptionsAppState`~~, ~~`CaptchaAppState`~~, ~~`OAuthAppState`~~ | [Sonarr/Sonarr@cd7adba1](https://github.com/Sonarr/Sonarr/commit/cd7adba1), [Sonarr/Sonarr@3c77c4b9](https://github.com/Sonarr/Sonarr/commit/3c77c4b9), [Sonarr/Sonarr@8a68c860](https://github.com/Sonarr/Sonarr/commit/8a68c860) |
 | **SignalR → query invalidation** — mostly landed already; the row was written against a `SignalRConnector.js` that no longer exists. **Wanted handlers fixed in #491**; the 9 remaining dispatches are blocked downstream, see below. | nothing on its own — the last dispatches leave with the app shell, Collection and Settings | [Sonarr/Sonarr@SignalRListener](https://github.com/Sonarr/Sonarr/blob/v5-develop/frontend/src/Components/SignalRListener.tsx) |
-| **App shell** — messages, dimensions, connection state, version, sidebar, translations. Three PRs; **#492 and #493 done**, advanced settings left. | ~~`createDimensionsSelector.ts`~~, ~~`MessagesAppState`~~, ~~`appActions`~~, ~~the `app` slice~~ | [Sonarr/Sonarr@878f879c](https://github.com/Sonarr/Sonarr/commit/878f879c), [Sonarr/Sonarr@7e702380](https://github.com/Sonarr/Sonarr/commit/7e702380) |
+| ~~**App shell**~~ — messages, dimensions, connection state, version, sidebar, translations, advanced settings. Three PRs. **Done, #492, #493 and #494.** | ~~`createDimensionsSelector.ts`~~, ~~`MessagesAppState`~~, ~~`appActions`~~, ~~the `app` slice~~, ~~`settings.advancedSettings`~~ | [Sonarr/Sonarr@878f879c](https://github.com/Sonarr/Sonarr/commit/878f879c), [Sonarr/Sonarr@7e702380](https://github.com/Sonarr/Sonarr/commit/7e702380) |
 
 ---
 
@@ -358,9 +358,31 @@ the whole app rather than one page.
      sidebar visibility onto `App/appStore`; messages onto `App/messagesStore`.
    - ~~**Translations.**~~ **Done, #493.** `App/useTranslations`, the boot gate in
      `useAppPage`, and with them `appActions` and the `app` slice.
-   - **Advanced settings.** `state.settings.advancedSettings` onto its own store, as Sonarr
-     did in [7e702380](https://github.com/Sonarr/Sonarr/commit/7e702380). Carves cleanly out
-     of `settingsActions` ahead of Phase E.
+   - ~~**Advanced settings.**~~ **Done, #494.** `Settings/advancedSettingsStore`, carved out
+     of `settingsActions` ahead of Phase E. **Phase C is complete.**
+
+### Advanced settings had eleven connectors, not three consumers
+
+§5 filed this as a boolean with a toggle. The boolean is read by eleven `connect()`
+components — five under Custom Formats and Download Clients, plus General, Metadata,
+Notifications, Quality Definitions and UI — none of which can call a hook, and by five TSX
+files through `useShowAdvancedSettings`.
+
+Two things kept it small anyway. `useShowAdvancedSettings` already existed as the single
+read for the TSX side, so re-pointing that one file at the store left all five importers
+untouched. And rather than eleven bespoke wrappers as in #492, the flag is injected by one
+`withAdvancedSettings` HOC, matching `withScrollPosition` — every wrapped component keeps
+the prop contract it already had, so the components themselves are unchanged and the diff
+stays in the connectors.
+
+The flag was persisted through `redux-localstorage` under the instance-name key; it is now
+persisted by `createPersist` under `<instance>_advanced_settings`. The keys differ, so the
+toggle resets to off once per browser. That matches every options store converted so far,
+none of which migrated their redux-persisted value either.
+
+Worth knowing when reading the row: **UI settings has no advanced fields at all.**
+`UISettings.js` contains zero `isAdvanced`, so its connector was passing a prop nothing
+consumed. The prop is left in place — removing it is a Phase E cleanup, not this row's.
 
 ### The localization endpoint changes shape with the Accept header
 
@@ -761,6 +783,7 @@ If a JS test runner is ever added, remove that line and set
 | 2026-08-18 | #471 | **Organize preview + Unmapped Files.** Two slices retired. First conversion where a page's table prefs move to a zustand options store rather than to React Query. |
 | 2026-08-20 | #487 | **Tags.** `useTags`/`useTagDetails` replace `tagActions`, both tag selectors and `TagsAppState`; the `Tags/useTags.ts` shim that had been a selector wearing a hook's name is now the real query. `TagFilterBuilderRowValueConnector` was a `connect()` whose whole job was reshaping the list, so it became a plain component and the connector count dropped with it. `useAppPage` gates on the query for the same reason it gates on custom filters. Delete writes the removal into the cache but leaves the refetch to SignalR — invalidating `/tag/detail` here as well fetched it twice, measured. `useSortedTagList` copies before sorting: `MovieTagInput` had been sorting the shared list in place, which was harmless against a slice that handed out a fresh array per fetch and is not against a query cache. |
 | 2026-08-20 | #490 | **Provider options + captcha.** `providerOptionActions`, `captchaActions`, `oAuthActions` and their three `AppState` files deleted for `Settings/useProviderOptions.ts`, `Components/Form/useCaptcha.ts` and `OAuth/useOAuth.ts`. `useProviderOptions` does not use `useApiQuery`: that helper keys a POST on the whole body, and the body here is the entire provider form, so every keystroke would be a new cache entry and a new request. It keys on `baseUrl`/`apiPath`/`apiKey`/`authToken` instead, which is what the old slice's `lastActions` de-duplication was approximating — measured, typing in *Name* now fires nothing where the four important fields fire one request each. Two deliberate departures from Sonarr's commits. Sonarr's `DeviceInput` rewrite reads the options as `{value, name}`, but the backend projects `{id, name}` in both apps, so this keeps `.id` — with `.value` the selected device renders as *Unknown (…)*, verified against a stubbed response. And `OAuthInput` keeps dispatching `set({section, saveError})`: Sonarr routes that through a `FormInputGroupContext` Eros does not have, and without it the pop-up-blocked message stops reaching the field. Converting `CaptchaInput` also fixes it — `refreshing`, `siteKey` and `secretToken` were declared as props and never passed by anything, so the ReCAPTCHA widget could not render; no provider in this build declares a `captcha` field, so that path is types-and-lint only. |
+| 2026-08-20 | #494 | **App shell, part 3, and the end of Phase C.** `Settings/advancedSettingsStore` replaces `state.settings.advancedSettings`, its toggle action and its reducer, carved out of `settingsActions` ahead of Phase E. Eleven `connect()` components read the flag, so it is injected by a single `withAdvancedSettings` HOC in the shape of `withScrollPosition`, leaving the wrapped components untouched. `useShowAdvancedSettings` keeps its path and now re-exports from the store, so its five TSX importers did not change. Verified live: the toggle expands General from 18 form groups to 38 and Media Management from 7 to 30, adds the Megabytes Per Minute column to Quality Definitions, survives a reload through `createPersist`, and through the HOC adds exactly the two fields the API marks advanced on Kodi. |
 | 2026-08-20 | #493 | **App shell, part 2.** `App/useTranslations` replaces the `fetchTranslations` thunk; `appActions` and the `app` slice are deleted and `AppState` loses its last app member. Slices 17 to 16. Two things made this less mechanical than it looks, both of them silent failures — the response is PascalCase where Sonarr's is camelCase, and it double-encodes under `fetchJson`'s Accept header. See above. The strings are written from inside the query function rather than an effect so they are in place before the render that unblocks the app. Verified live: translated labels render, holding the request open keeps the app on the loading page with no raw-key frame, and a 500 puts the message on `ErrorPage`. |
 | 2026-08-20 | #492 | **App shell, part 1.** `App/appStore.ts` and `App/messagesStore.ts` take dimensions, connection state, version, sidebar visibility and messages; `createDimensionsSelector.ts` and `MessagesAppState.ts` are deleted and `appActions` is down to translations. 33 files. Six `connect()` components could not call a hook, so they take `isSmallScreen` as an own prop from a small wrapper — see above. The SignalR listener loses its last six `dispatch` calls that were not blocked by another phase. Verified live: resizing across 768px adds and removes the sidebar's inline transform, the toggle moves it between 0 and -210px, a `command` push renders a message that clears itself after its `hideAfter`, and a `version` push opens the Whisparr Updated modal. |
 | 2026-08-20 | #491 | **SignalR.** The row assumed a `SignalRConnector.js` that Phase B had already replaced. What was actually left was two handlers dispatching into a slice that no longer exists — `wanted/cutoff` and `wanted/missing` still wrote to `wanted.cutoffUnmet`/`wanted.missing`, retired in #475 — plus `pagePopulator`, whose emit side had gone missing entirely. The wanted handlers now patch the paged cache through `updatePagedItem`, ported from Sonarr. `pagePopulator` was not restored but retired: all seven React Query registrants came out in favour of invalidating their query keys from the listener, and reconnect now invalidates the whole cache rather than four hand-picked keys. It survives, reasons removed, for Import List Exclusions alone, which still fetches through a redux thunk. The nine remaining dispatches cannot move here: five settings sections and `qualitydefinition` need Phase E's query hooks, `collection` needs Phase D, and `setVersion` plus the five `setAppValue` calls need the app shell. |

--- a/frontend/src/App/State/SettingsAppState.ts
+++ b/frontend/src/App/State/SettingsAppState.ts
@@ -126,7 +126,6 @@ export type LanguageSettingsAppState = AppSectionState<Language>;
 export type UiSettingsAppState = AppSectionItemState<UiSettings>;
 
 interface SettingsAppState {
-  advancedSettings: boolean;
   autoTaggings: AutoTaggingAppState;
   autoTaggingSpecifications: AutoTaggingSpecificationAppState;
   customFormats: CustomFormatAppState;

--- a/frontend/src/Components/withAdvancedSettings.tsx
+++ b/frontend/src/Components/withAdvancedSettings.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { useShowAdvancedSettings } from 'Settings/advancedSettingsStore';
+
+interface WrappedComponentProps {
+  advancedSettings: boolean;
+}
+
+// Eleven `connect()` components read this flag through `mapStateToProps`, which
+// cannot reach a zustand store. Rather than rewrite each of them, the flag is
+// injected as an own prop here and `connect` forwards it untouched, so every
+// wrapped component keeps the prop contract it already had.
+function withAdvancedSettings(
+  WrappedComponent: React.ComponentType<WrappedComponentProps>
+) {
+  function AdvancedSettings(props: object) {
+    const advancedSettings = useShowAdvancedSettings();
+
+    return (
+      <WrappedComponent
+        {...(props as WrappedComponentProps)}
+        advancedSettings={advancedSettings}
+      />
+    );
+  }
+
+  return AdvancedSettings;
+}
+
+export default withAdvancedSettings;

--- a/frontend/src/Helpers/Hooks/useShowAdvancedSettings.ts
+++ b/frontend/src/Helpers/Hooks/useShowAdvancedSettings.ts
@@ -1,8 +1,1 @@
-import { useSelector } from 'react-redux';
-import AppState from 'App/State/AppState';
-
-function useShowAdvancedSettings() {
-  return useSelector((state: AppState) => state.settings.advancedSettings);
-}
-
-export default useShowAdvancedSettings;
+export { useShowAdvancedSettings as default } from 'Settings/advancedSettingsStore';

--- a/frontend/src/Settings/AdvancedSettingsButton.tsx
+++ b/frontend/src/Settings/AdvancedSettingsButton.tsx
@@ -1,11 +1,12 @@
 import classNames from 'classnames';
 import React, { useCallback } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
-import AppState from 'App/State/AppState';
 import Icon from 'Components/Icon';
 import Link from 'Components/Link/Link';
 import { icons } from 'Helpers/Props';
-import { toggleAdvancedSettings } from 'Store/Actions/settingsActions';
+import {
+  toggleShowAdvancedSettings,
+  useShowAdvancedSettings,
+} from 'Settings/advancedSettingsStore';
 import translate from 'Utilities/String/translate';
 import styles from './AdvancedSettingsButton.css';
 
@@ -14,14 +15,11 @@ interface AdvancedSettingsButtonProps {
 }
 
 function AdvancedSettingsButton({ showLabel }: AdvancedSettingsButtonProps) {
-  const showAdvancedSettings = useSelector(
-    (state: AppState) => state.settings.advancedSettings
-  );
-  const dispatch = useDispatch();
+  const showAdvancedSettings = useShowAdvancedSettings();
 
   const handlePress = useCallback(() => {
-    dispatch(toggleAdvancedSettings());
-  }, [dispatch]);
+    toggleShowAdvancedSettings();
+  }, []);
 
   return (
     <Link

--- a/frontend/src/Settings/CustomFormats/CustomFormats/EditCustomFormatModalContentConnector.js
+++ b/frontend/src/Settings/CustomFormats/CustomFormats/EditCustomFormatModalContentConnector.js
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
+import withAdvancedSettings from 'Components/withAdvancedSettings';
 import {
   cloneCustomFormatSpecification,
   deleteCustomFormatSpecification,
@@ -14,12 +15,10 @@ import EditCustomFormatModalContent from './EditCustomFormatModalContent';
 
 function createMapStateToProps() {
   return createSelector(
-    (state) => state.settings.advancedSettings,
     createProviderSettingsSelector('customFormats'),
     (state) => state.settings.customFormatSpecifications,
-    (advancedSettings, customFormat, specifications) => {
+    (customFormat, specifications) => {
       return {
-        advancedSettings,
         ...customFormat,
         specificationsPopulated: specifications.isPopulated,
         specifications: specifications.items,
@@ -101,7 +100,9 @@ EditCustomFormatModalContentConnector.propTypes = {
   onModalClose: PropTypes.func.isRequired,
 };
 
-export default connect(
+export default withAdvancedSettings(
+  connect(
   createMapStateToProps,
   mapDispatchToProps
-)(EditCustomFormatModalContentConnector);
+)(EditCustomFormatModalContentConnector)
+);

--- a/frontend/src/Settings/CustomFormats/CustomFormats/ExportCustomFormatModalContentConnector.js
+++ b/frontend/src/Settings/CustomFormats/CustomFormats/ExportCustomFormatModalContentConnector.js
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
+import withAdvancedSettings from 'Components/withAdvancedSettings';
 import { fetchCustomFormatSpecifications } from 'Store/Actions/settingsActions';
 import createProviderSettingsSelector from 'Store/Selectors/createProviderSettingsSelector';
 import ExportCustomFormatModalContent from './ExportCustomFormatModalContent';
@@ -31,15 +32,13 @@ function replacer(key, value) {
 
 function createMapStateToProps() {
   return createSelector(
-    (state) => state.settings.advancedSettings,
     createProviderSettingsSelector('customFormats'),
     (state) => state.settings.customFormatSpecifications,
-    (advancedSettings, customFormat, specifications) => {
+    (customFormat, specifications) => {
       const json = customFormat.item
         ? JSON.stringify(customFormat.item, replacer, 2)
         : '';
       return {
-        advancedSettings,
         ...customFormat,
         json,
         specificationsPopulated: specifications.isPopulated,
@@ -75,7 +74,9 @@ ExportCustomFormatModalContentConnector.propTypes = {
   fetchCustomFormatSpecifications: PropTypes.func.isRequired,
 };
 
-export default connect(
+export default withAdvancedSettings(
+  connect(
   createMapStateToProps,
   mapDispatchToProps
-)(ExportCustomFormatModalContentConnector);
+)(ExportCustomFormatModalContentConnector)
+);

--- a/frontend/src/Settings/CustomFormats/CustomFormats/ImportCustomFormatModalContentConnector.js
+++ b/frontend/src/Settings/CustomFormats/CustomFormats/ImportCustomFormatModalContentConnector.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
+import withAdvancedSettings from 'Components/withAdvancedSettings';
 import { clearPendingChanges } from 'Store/Actions/baseActions';
 import {
   clearCustomFormatSpecificationPending,
@@ -20,12 +21,10 @@ import ImportCustomFormatModalContent from './ImportCustomFormatModalContent';
 
 function createMapStateToProps() {
   return createSelector(
-    (state) => state.settings.advancedSettings,
     createProviderSettingsSelector('customFormats'),
     (state) => state.settings.customFormatSpecifications,
-    (advancedSettings, customFormat, specifications) => {
+    (customFormat, specifications) => {
       return {
-        advancedSettings,
         ...customFormat,
         specificationsPopulated: specifications.isPopulated,
         specificationSchema: specifications.schema,
@@ -163,7 +162,9 @@ ImportCustomFormatModalContentConnector.propTypes = {
   onModalClose: PropTypes.func.isRequired,
 };
 
-export default connect(
+export default withAdvancedSettings(
+  connect(
   createMapStateToProps,
   mapDispatchToProps
-)(ImportCustomFormatModalContentConnector);
+)(ImportCustomFormatModalContentConnector)
+);

--- a/frontend/src/Settings/CustomFormats/CustomFormats/Specifications/EditSpecificationModalContentConnector.js
+++ b/frontend/src/Settings/CustomFormats/CustomFormats/Specifications/EditSpecificationModalContentConnector.js
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
+import withAdvancedSettings from 'Components/withAdvancedSettings';
 import {
   clearCustomFormatSpecificationPending,
   saveCustomFormatSpecification,
@@ -13,11 +14,9 @@ import EditSpecificationModalContent from './EditSpecificationModalContent';
 
 function createMapStateToProps() {
   return createSelector(
-    (state) => state.settings.advancedSettings,
     createProviderSettingsSelector('customFormatSpecifications'),
-    (advancedSettings, specification) => {
+    (specification) => {
       return {
-        advancedSettings,
         ...specification,
       };
     }
@@ -79,7 +78,9 @@ EditSpecificationModalContentConnector.propTypes = {
   onModalClose: PropTypes.func.isRequired,
 };
 
-export default connect(
+export default withAdvancedSettings(
+  connect(
   createMapStateToProps,
   mapDispatchToProps
-)(EditSpecificationModalContentConnector);
+)(EditSpecificationModalContentConnector)
+);

--- a/frontend/src/Settings/DownloadClients/DownloadClients/EditDownloadClientModalContentConnector.js
+++ b/frontend/src/Settings/DownloadClients/DownloadClients/EditDownloadClientModalContentConnector.js
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
+import withAdvancedSettings from 'Components/withAdvancedSettings';
 import {
   saveDownloadClient,
   setDownloadClientFieldValue,
@@ -13,11 +14,9 @@ import EditDownloadClientModalContent from './EditDownloadClientModalContent';
 
 function createMapStateToProps() {
   return createSelector(
-    (state) => state.settings.advancedSettings,
     createProviderSettingsSelector('downloadClients'),
-    (advancedSettings, downloadClient) => {
+    (downloadClient) => {
       return {
-        advancedSettings,
         ...downloadClient,
       };
     }
@@ -89,7 +88,9 @@ EditDownloadClientModalContentConnector.propTypes = {
   onModalClose: PropTypes.func.isRequired,
 };
 
-export default connect(
+export default withAdvancedSettings(
+  connect(
   createMapStateToProps,
   mapDispatchToProps
-)(EditDownloadClientModalContentConnector);
+)(EditDownloadClientModalContentConnector)
+);

--- a/frontend/src/Settings/DownloadClients/Options/DownloadClientOptionsConnector.js
+++ b/frontend/src/Settings/DownloadClients/Options/DownloadClientOptionsConnector.js
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
+import withAdvancedSettings from 'Components/withAdvancedSettings';
 import { clearPendingChanges } from 'Store/Actions/baseActions';
 import {
   fetchDownloadClientOptions,
@@ -15,11 +16,9 @@ const SECTION = 'downloadClientOptions';
 
 function createMapStateToProps() {
   return createSelector(
-    (state) => state.settings.advancedSettings,
     createSettingsSectionSelector(SECTION),
-    (advancedSettings, sectionSettings) => {
+    (sectionSettings) => {
       return {
-        advancedSettings,
         ...sectionSettings,
       };
     }
@@ -97,7 +96,9 @@ DownloadClientOptionsConnector.propTypes = {
   onChildStateChange: PropTypes.func.isRequired,
 };
 
-export default connect(
+export default withAdvancedSettings(
+  connect(
   createMapStateToProps,
   mapDispatchToProps
-)(DownloadClientOptionsConnector);
+)(DownloadClientOptionsConnector)
+);

--- a/frontend/src/Settings/General/GeneralSettingsConnector.js
+++ b/frontend/src/Settings/General/GeneralSettingsConnector.js
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
 import * as commandNames from 'Commands/commandNames';
 import { useCommandExecuting, useExecuteCommand } from 'Commands/useCommands';
+import { useShowAdvancedSettings } from 'Settings/advancedSettingsStore';
 import { clearPendingChanges } from 'Store/Actions/baseActions';
 import {
   fetchGeneralSettings,
@@ -19,11 +20,9 @@ const SECTION = 'general';
 
 function createMapStateToProps() {
   return createSelector(
-    (state) => state.settings.advancedSettings,
     createSettingsSectionSelector(SECTION),
-    (advancedSettings, sectionSettings, isResettingApiKey) => {
+    (sectionSettings, isResettingApiKey) => {
       return {
-        advancedSettings,
         isResettingApiKey,
         ...sectionSettings,
       };
@@ -113,12 +112,14 @@ const ConnectedGeneralSettings = connect(
 // three status props now go straight to HostSettings and UpdateSettings, which
 // are function components and read the query themselves.
 export default function GeneralSettingsConnector() {
+  const advancedSettings = useShowAdvancedSettings();
   const isWindowsService = useIsWindowsService();
   const executeCommand = useExecuteCommand();
   const isResettingApiKey = useCommandExecuting(commandNames.RESET_API_KEY);
 
   return (
     <ConnectedGeneralSettings
+      advancedSettings={advancedSettings}
       isWindowsService={isWindowsService}
       isResettingApiKey={isResettingApiKey}
       executeCommand={executeCommand}

--- a/frontend/src/Settings/MediaManagement/Naming/Naming.tsx
+++ b/frontend/src/Settings/MediaManagement/Naming/Naming.tsx
@@ -12,6 +12,7 @@ import FormLabel from 'Components/Form/FormLabel';
 import LoadingIndicator from 'Components/Loading/LoadingIndicator';
 import useModalOpenState from 'Helpers/Hooks/useModalOpenState';
 import { inputTypes, kinds, sizes } from 'Helpers/Props';
+import { useShowAdvancedSettings } from 'Settings/advancedSettingsStore';
 import { clearPendingChanges } from 'Store/Actions/baseActions';
 import {
   fetchNamingExamples,
@@ -29,12 +30,10 @@ const SECTION = 'naming';
 
 function createNamingSelector() {
   return createSelector(
-    (state: AppState) => state.settings.advancedSettings,
     (state: AppState) => state.settings.namingExamples,
     createSettingsSectionSelector(SECTION),
-    (advancedSettings, namingExamples, sectionSettings) => {
+    (namingExamples, sectionSettings) => {
       return {
-        advancedSettings,
         examples: namingExamples.item,
         examplesPopulated: namingExamples.isPopulated,
         ...sectionSettings,
@@ -58,8 +57,8 @@ interface NamingModalOptions {
 }
 
 function Naming() {
+  const advancedSettings = useShowAdvancedSettings();
   const {
-    advancedSettings,
     isFetching,
     error,
     settings,

--- a/frontend/src/Settings/Metadata/Metadata/EditMetadataModalContentConnector.js
+++ b/frontend/src/Settings/Metadata/Metadata/EditMetadataModalContentConnector.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
+import withAdvancedSettings from 'Components/withAdvancedSettings';
 import {
   saveMetadata,
   setMetadataFieldValue,
@@ -13,10 +14,9 @@ import EditMetadataModalContent from './EditMetadataModalContent';
 
 function createMapStateToProps() {
   return createSelector(
-    (state) => state.settings.advancedSettings,
     (state, { id }) => id,
     (state) => state.settings.metadata,
-    (advancedSettings, id, metadata) => {
+    (id, metadata) => {
       const { isSaving, saveError, pendingChanges, items } = metadata;
 
       const settings = selectSettings(
@@ -26,7 +26,6 @@ function createMapStateToProps() {
       );
 
       return {
-        advancedSettings,
         id,
         isSaving,
         saveError,
@@ -94,7 +93,9 @@ EditMetadataModalContentConnector.propTypes = {
   onModalClose: PropTypes.func.isRequired,
 };
 
-export default connect(
+export default withAdvancedSettings(
+  connect(
   createMapStateToProps,
   mapDispatchToProps
-)(EditMetadataModalContentConnector);
+)(EditMetadataModalContentConnector)
+);

--- a/frontend/src/Settings/Notifications/Notifications/EditNotificationModalContentConnector.js
+++ b/frontend/src/Settings/Notifications/Notifications/EditNotificationModalContentConnector.js
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
+import withAdvancedSettings from 'Components/withAdvancedSettings';
 import {
   saveNotification,
   setNotificationFieldValues,
@@ -13,11 +14,9 @@ import EditNotificationModalContent from './EditNotificationModalContent';
 
 function createMapStateToProps() {
   return createSelector(
-    (state) => state.settings.advancedSettings,
     createProviderSettingsSelector('notifications'),
-    (advancedSettings, notification) => {
+    (notification) => {
       return {
-        advancedSettings,
         ...notification,
       };
     }
@@ -91,7 +90,9 @@ EditNotificationModalContentConnector.propTypes = {
   onModalClose: PropTypes.func.isRequired,
 };
 
-export default connect(
+export default withAdvancedSettings(
+  connect(
   createMapStateToProps,
   mapDispatchToProps
-)(EditNotificationModalContentConnector);
+)(EditNotificationModalContentConnector)
+);

--- a/frontend/src/Settings/Quality/Definition/QualityDefinitionsConnector.js
+++ b/frontend/src/Settings/Quality/Definition/QualityDefinitionsConnector.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
+import withAdvancedSettings from 'Components/withAdvancedSettings';
 import {
   fetchQualityDefinitions,
   saveQualityDefinitions,
@@ -12,8 +13,7 @@ import QualityDefinitions from './QualityDefinitions';
 function createMapStateToProps() {
   return createSelector(
     (state) => state.settings.qualityDefinitions,
-    (state) => state.settings.advancedSettings,
-    (qualityDefinitions, advancedSettings) => {
+    (qualityDefinitions) => {
       const items = qualityDefinitions.items.map((item) => {
         const pendingChanges = qualityDefinitions.pendingChanges[item.id] || {};
 
@@ -24,7 +24,6 @@ function createMapStateToProps() {
         ...qualityDefinitions,
         items,
         hasPendingChanges: !_.isEmpty(qualityDefinitions.pendingChanges),
-        advancedSettings,
       };
     }
   );
@@ -81,8 +80,10 @@ QualityDefinitionsConnector.propTypes = {
   onChildStateChange: PropTypes.func.isRequired,
 };
 
-export default connect(
-  createMapStateToProps,
-  mapDispatchToProps,
-  null
-)(QualityDefinitionsConnector);
+export default withAdvancedSettings(
+  connect(
+    createMapStateToProps,
+    mapDispatchToProps,
+    null
+  )(QualityDefinitionsConnector)
+);

--- a/frontend/src/Settings/Tags/AutoTagging/Specifications/EditSpecificationModalContent.tsx
+++ b/frontend/src/Settings/Tags/AutoTagging/Specifications/EditSpecificationModalContent.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import AppState from 'App/State/AppState';
 import { AutoTaggingSpecificationAppState } from 'App/State/SettingsAppState';
 import Alert from 'Components/Alert';
 import Form from 'Components/Form/Form';
@@ -16,6 +15,7 @@ import ModalContent from 'Components/Modal/ModalContent';
 import ModalFooter from 'Components/Modal/ModalFooter';
 import ModalHeader from 'Components/Modal/ModalHeader';
 import { inputTypes, kinds } from 'Helpers/Props';
+import { useShowAdvancedSettings } from 'Settings/advancedSettingsStore';
 import {
   clearAutoTaggingSpecificationPending,
   saveAutoTaggingSpecification,
@@ -39,9 +39,7 @@ function EditSpecificationModalContent({
   onDeleteSpecificationPress,
   onModalClose,
 }: EditSpecificationModalContentProps) {
-  const advancedSettings = useSelector(
-    (state: AppState) => state.settings.advancedSettings
-  );
+  const advancedSettings = useShowAdvancedSettings();
 
   const { item, ...otherFormProps } = useSelector(
     createProviderSettingsSelectorHook<

--- a/frontend/src/Settings/UI/UISettingsConnector.js
+++ b/frontend/src/Settings/UI/UISettingsConnector.js
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
+import withAdvancedSettings from 'Components/withAdvancedSettings';
 import { clearPendingChanges } from 'Store/Actions/baseActions';
 import {
   fetchUISettings,
@@ -39,12 +40,10 @@ function createFilteredLanguagesSelector() {
 
 function createMapStateToProps() {
   return createSelector(
-    (state) => state.settings.advancedSettings,
     createSettingsSectionSelector(SECTION),
     createFilteredLanguagesSelector(),
-    (advancedSettings, sectionSettings, languages) => {
+    (sectionSettings, languages) => {
       return {
-        advancedSettings,
         languages: languages.items,
         isLanguagesPopulated: languages.isPopulated,
         ...sectionSettings,
@@ -106,7 +105,6 @@ UISettingsConnector.propTypes = {
   clearPendingChanges: PropTypes.func.isRequired,
 };
 
-export default connect(
-  createMapStateToProps,
-  mapDispatchToProps
-)(UISettingsConnector);
+export default withAdvancedSettings(
+  connect(createMapStateToProps, mapDispatchToProps)(UISettingsConnector)
+);

--- a/frontend/src/Settings/advancedSettingsStore.ts
+++ b/frontend/src/Settings/advancedSettingsStore.ts
@@ -1,0 +1,23 @@
+import { createPersist } from 'Helpers/createPersist';
+
+interface AdvancedSettingsState {
+  showAdvancedSettings: boolean;
+}
+
+// Persisted under its own key rather than the redux blob this replaces, so the
+// toggle resets to off once per browser. It is a view preference with a visible
+// control, and every options store converted so far started fresh the same way.
+const advancedSettingsStore = createPersist<AdvancedSettingsState>(
+  'advanced_settings',
+  () => ({ showAdvancedSettings: false })
+);
+
+export const useShowAdvancedSettings = () => {
+  return advancedSettingsStore((state) => state.showAdvancedSettings);
+};
+
+export const toggleShowAdvancedSettings = () => {
+  advancedSettingsStore.setState((state) => ({
+    showAdvancedSettings: !state.showAdvancedSettings,
+  }));
+};

--- a/frontend/src/Store/Actions/settingsActions.js
+++ b/frontend/src/Store/Actions/settingsActions.js
@@ -62,7 +62,6 @@ export const section = 'settings';
 // State
 
 export const defaultState = {
-  advancedSettings: false,
   autoTaggingSpecifications: autoTaggingSpecifications.defaultState,
   autoTaggings: autoTaggings.defaultState,
   safeForWorkMode: false,
@@ -92,7 +91,6 @@ export const defaultState = {
 };
 
 export const persistState = [
-  'settings.advancedSettings',
   'settings.importListExclusions.pageSize',
   'settings.safeForWorkMode',
 ];
@@ -100,13 +98,11 @@ export const persistState = [
 //
 // Actions Types
 
-export const TOGGLE_ADVANCED_SETTINGS = 'settings/toggleAdvancedSettings';
 export const TOGGLE_SFW_MODE = 'settings/toggleSafeForWorkMode';
 
 //
 // Action Creators
 
-export const toggleAdvancedSettings = createAction(TOGGLE_ADVANCED_SETTINGS);
 export const toggleSafeForWorkMode = createAction(TOGGLE_SFW_MODE);
 
 //
@@ -145,12 +141,6 @@ export const actionHandlers = handleThunks({
 
 export const reducers = createHandleActions(
   {
-    [TOGGLE_ADVANCED_SETTINGS]: (state, { payload }) => {
-      return Object.assign({}, state, {
-        advancedSettings: !state.advancedSettings,
-      });
-    },
-
     [TOGGLE_SFW_MODE]: (state, { payload }) => {
       return Object.assign({}, state, {
         safeForWorkMode: !state.safeForWorkMode,


### PR DESCRIPTION
#### Database Migration

NO

#### Description

App shell part 3 of 3, and the last item in Phase C. `state.settings.advancedSettings`,
its toggle action and its reducer move to `Settings/advancedSettingsStore`, carved out of
`settingsActions` ahead of Phase E. Follows Sonarr's
[7e702380](https://github.com/Sonarr/Sonarr/commit/7e702380).

The row filed this as a boolean with a toggle. It is read by **eleven** `connect()`
components — five under Custom Formats and Download Clients, plus General, Metadata,
Notifications, Quality Definitions and UI — none of which can call a hook, and by five TSX
files through `useShowAdvancedSettings`.

Two things kept the diff small. `useShowAdvancedSettings` already existed as the single
read for the TSX side, so re-pointing that one file at the store left all five importers
untouched. And instead of eleven bespoke wrappers as in #492, the flag is injected by one
`withAdvancedSettings` HOC in the shape of the existing `withScrollPosition` — every wrapped
component keeps the prop contract it already had, so the components are unchanged and the
diff stays in the connectors.

**Verified** live: the toggle takes General settings from 18 form groups to 38 and Media
Management from 7 to 30, adds the Megabytes Per Minute column to Quality Definitions, and
through the HOC adds exactly the two fields the API reports as `advanced` on Kodi
(`Movie Metadata URL`, `Collection Name`). It survives a reload via `createPersist`. Zero
console errors, 20-page sweep clean.

**Two things worth knowing:**

- The flag was persisted by `redux-localstorage` under the instance-name key and is now
  persisted under `<instance>_advanced_settings`, so the toggle resets to off once per
  browser. Every options store converted so far started fresh the same way.
- **UI settings has no advanced fields at all** — `UISettings.js` contains zero
  `isAdvanced`, so its connector was passing a prop nothing consumed. I left the prop in
  place; removing it is a Phase E cleanup, not this row's.

#### Todos

- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)

#### Issues Fixed or Closed by this PR
