### PR TITLE
Fix update checks on the stable branch and blank release notes

### DIFF
--- a/frontend/src/App/AppUpdatedModalContent.tsx
+++ b/frontend/src/App/AppUpdatedModalContent.tsx
@@ -16,6 +16,15 @@ import Update from 'typings/Update';
 import translate from 'Utilities/String/translate';
 import styles from './AppUpdatedModalContent.css';
 
+// A release with no `- New` or `- Fix` lines used to arrive as a single empty string
+// rather than an empty list, which counts as content and renders the "What's new?"
+// block blank instead of falling through to the maintenance-release line. The API no
+// longer sends that, but the modal should not depend on it -- `Updates.tsx` has always
+// filtered blank lines the same way. See Whisparr/Whisparr#1125.
+function hasContent(line: string) {
+  return typeof line === 'string' && line.trim() !== '';
+}
+
 function mergeUpdates(
   items: readonly Update[],
   version: string,
@@ -51,8 +60,10 @@ function mergeUpdates(
     const appliedChanges: Update['changes'] = { new: [], fixed: [] };
     appliedUpdates.forEach((u: Update) => {
       if (u.changes && typeof u.changes === 'object') {
-        appliedChanges.new.push(...u.changes.new);
-        appliedChanges.fixed.push(...u.changes.fixed);
+        appliedChanges.new.push(...(u.changes.new ?? []).filter(hasContent));
+        appliedChanges.fixed.push(
+          ...(u.changes.fixed ?? []).filter(hasContent)
+        );
       }
     });
     const mergedUpdate: Update = Object.assign({}, appliedUpdates[0], {

--- a/src/NzbDrone.Common/Cloud/WhisparrCloudRequestBuilder.cs
+++ b/src/NzbDrone.Common/Cloud/WhisparrCloudRequestBuilder.cs
@@ -8,6 +8,7 @@ namespace NzbDrone.Common.Cloud
         IHttpRequestBuilderFactory WhisparrMetadata { get; }
         IHttpRequestBuilderFactory StashDB { get; }
         IHttpRequestBuilderFactory GithubReleases { get; }
+        IHttpRequestBuilderFactory GithubLatestRelease { get; }
     }
 
     public class WhisparrCloudRequestBuilder : IWhisparrCloudRequestBuilder
@@ -29,6 +30,12 @@ namespace NzbDrone.Common.Cloud
 
             GithubReleases = new HttpRequestBuilder("https://api.github.com/repos/{githubownerrepo}/releases")
                 .CreateFactory();
+
+            // Returns the newest non-draft, non-prerelease release. The stable branch
+            // uses this rather than paging the list, because develop publishes a release
+            // per merge and buries the newest stable one well past any page size.
+            GithubLatestRelease = new HttpRequestBuilder("https://api.github.com/repos/{githubownerrepo}/releases/latest")
+                .CreateFactory();
         }
 
         public IHttpRequestBuilderFactory Services { get; private set; }
@@ -36,6 +43,7 @@ namespace NzbDrone.Common.Cloud
         public IHttpRequestBuilderFactory WhisparrMetadata { get; private set; }
         public IHttpRequestBuilderFactory StashDB { get; private set; }
         public IHttpRequestBuilderFactory GithubReleases { get; private set; }
+        public IHttpRequestBuilderFactory GithubLatestRelease { get; private set; }
 
         public string AuthToken => "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJhdWQiOiIxYTczNzMzMDE5NjFkMDNmOTdmODUzYTg3NmRkMTIxMiIsInN1YiI6IjU4NjRmNTkyYzNhMzY4MGFiNjAxNzUzNCIsInNjb3BlcyI6WyJhcGlfcmVhZCJdLCJ2ZXJzaW9uIjoxfQ.gh1BwogCCKOda6xj9FRMgAAj_RYKMMPC3oNlcBtlmwk";
     }

--- a/src/NzbDrone.Core.Test/UpdateTests/TestData/GithubChoreOnlyReleaseResponse.json
+++ b/src/NzbDrone.Core.Test/UpdateTests/TestData/GithubChoreOnlyReleaseResponse.json
@@ -1,0 +1,79 @@
+{
+  "tag_name": "v3.2.0-release.1",
+  "body": "## What's Changed\n- Chore: bump a dependency (#123)\n- Chore: tidy the build\n",
+  "published_at": "2026-01-15T02:25:55Z",
+  "prerelease": false,
+  "draft": false,
+  "assets": [
+    {
+      "name": "Whisparr.eros.3.2.0-release.1.freebsd-x64.tar.gz",
+      "digest": "sha256:0b2f398d6efab42ee90e17bb04b907e27b63d4b0a37b04aa10f930b6ae83bf33",
+      "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-release.1/Whisparr.eros.3.2.0-release.1.freebsd-x64.tar.gz"
+    },
+    {
+      "name": "Whisparr.eros.3.2.0-release.1.linux-arm.tar.gz",
+      "digest": "sha256:c3d27e7e83c15e2f97433663c4a94b0040033905132195e660e3154f87d99c9e",
+      "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-release.1/Whisparr.eros.3.2.0-release.1.linux-arm.tar.gz"
+    },
+    {
+      "name": "Whisparr.eros.3.2.0-release.1.linux-arm64.tar.gz",
+      "digest": "sha256:27efabe0f733ae8c9d107a801710a5ebf17ed872e0ac314ac617bc9f6c680072",
+      "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-release.1/Whisparr.eros.3.2.0-release.1.linux-arm64.tar.gz"
+    },
+    {
+      "name": "Whisparr.eros.3.2.0-release.1.linux-musl-arm64.tar.gz",
+      "digest": "sha256:9371f20e9c08705ad1fdf7af1c19c6728cf239104536fe931cb64a72867b7a54",
+      "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-release.1/Whisparr.eros.3.2.0-release.1.linux-musl-arm64.tar.gz"
+    },
+    {
+      "name": "Whisparr.eros.3.2.0-release.1.linux-musl-x64.tar.gz",
+      "digest": "sha256:d07fc191395ad06173ce30708231e6a2664be7bb1416cfa87290ffb659a00d73",
+      "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-release.1/Whisparr.eros.3.2.0-release.1.linux-musl-x64.tar.gz"
+    },
+    {
+      "name": "Whisparr.eros.3.2.0-release.1.linux-x64.tar.gz",
+      "digest": "sha256:5e8d78c9e8f1321d78b2bb903be2a900a6206007c773126189fc01fc71054e97",
+      "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-release.1/Whisparr.eros.3.2.0-release.1.linux-x64.tar.gz"
+    },
+    {
+      "name": "Whisparr.eros.3.2.0-release.1.osx-arm64-app.zip",
+      "digest": "sha256:a21c769952845383f116f4edf4c9a0b62daab7f02f5822ecf32f456f2a6d9375",
+      "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-release.1/Whisparr.eros.3.2.0-release.1.osx-arm64-app.zip"
+    },
+    {
+      "name": "Whisparr.eros.3.2.0-release.1.osx-arm64.tar.gz",
+      "digest": "sha256:c2240173b4cd49b758355fccf78cd6b94db24dc3730914382b8a8e138596c419",
+      "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-release.1/Whisparr.eros.3.2.0-release.1.osx-arm64.tar.gz"
+    },
+    {
+      "name": "Whisparr.eros.3.2.0-release.1.osx-x64-app.zip",
+      "digest": "sha256:49d3738d92bf4a4ae5816d35709a989b131ba3111a04e79a789bbeb25d17a14b",
+      "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-release.1/Whisparr.eros.3.2.0-release.1.osx-x64-app.zip"
+    },
+    {
+      "name": "Whisparr.eros.3.2.0-release.1.osx-x64.tar.gz",
+      "digest": "sha256:ca2fa935252bf134036ac6da6f9cb69b2ad6b6aea4559bd60426cd317c29893b",
+      "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-release.1/Whisparr.eros.3.2.0-release.1.osx-x64.tar.gz"
+    },
+    {
+      "name": "Whisparr.eros.3.2.0-release.1.win-x64-installer.exe",
+      "digest": "sha256:c17d8b93ad9d2fa15c6c6107972ad058e2a81403c42952a21676c7302ba2ff73",
+      "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-release.1/Whisparr.eros.3.2.0-release.1.win-x64-installer.exe"
+    },
+    {
+      "name": "Whisparr.eros.3.2.0-release.1.win-x64.zip",
+      "digest": "sha256:2e926320ff48e5eb1c74a6f8d711ba3fdb436cb38bbdb37cfd9d4a9156b65471",
+      "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-release.1/Whisparr.eros.3.2.0-release.1.win-x64.zip"
+    },
+    {
+      "name": "Whisparr.eros.3.2.0-release.1.win-x86-installer.exe",
+      "digest": "sha256:e9cf5cefec5a4434f04d93479b8b752f1318ae05b8368292803d6f0e0ae32772",
+      "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-release.1/Whisparr.eros.3.2.0-release.1.win-x86-installer.exe"
+    },
+    {
+      "name": "Whisparr.eros.3.2.0-release.1.win-x86.zip",
+      "digest": "sha256:0e6acc3ccdd495a23cb8c87e896d3fb1c4745953fd1850d175f39509d493c0f9",
+      "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-release.1/Whisparr.eros.3.2.0-release.1.win-x86.zip"
+    }
+  ]
+}

--- a/src/NzbDrone.Core.Test/UpdateTests/TestData/GithubDevelopOnlyPageResponse.json
+++ b/src/NzbDrone.Core.Test/UpdateTests/TestData/GithubDevelopOnlyPageResponse.json
@@ -1,0 +1,2372 @@
+[
+  {
+    "tag_name": "v3.3.9-develop.1200",
+    "body": "## What's Changed\n* Fix: Remove Duplicate Text in Modal by @JoyboySon in https://github.com/Whisparr/Whisparr-Eros/pull/3\n\n## New Contributors\n* @JoyboySon made their first contribution in https://github.com/Whisparr/Whisparr-Eros/pull/3\n\n**Full Changelog**: https://github.com/Whisparr/Whisparr-Eros/compare/3.2.0-develop.1...v3.2.0-develop.8",
+    "published_at": "2026-01-15T04:24:58Z",
+    "prerelease": true,
+    "draft": false,
+    "assets": [
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.freebsd-x64.tar.gz",
+        "digest": "sha256:7e600f422ad9de8aba5ad7de8a7a217c7ba6464321df1bfe2e6b954a210e4288",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.freebsd-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-arm.tar.gz",
+        "digest": "sha256:609aa587af8d7242b6fc7adbe88e1741f747ca90297e387079170d5e6ff8a7da",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-arm.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-arm64.tar.gz",
+        "digest": "sha256:edd6bce36455201f11847266b63f2f523a48c5917ce2d37ede52612dfa4d5828",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-arm64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-musl-arm64.tar.gz",
+        "digest": "sha256:3cf7b6de34e0ea9008e76bcba7668c39e7cb70ba4ac27cc795a19983faa5f4c6",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-musl-arm64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-musl-x64.tar.gz",
+        "digest": "sha256:e5c57131d0d87574edbab3144f65cb8c1dd5dfe139cf293f4778eece8a63a348",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-musl-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-x64.tar.gz",
+        "digest": "sha256:697facd9727ae84a12dcf2e260e5e7f83112965801d070aab4a1042dd08d1236",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-arm64-app.zip",
+        "digest": "sha256:6fb730e35ef05464e3e1427ac121a16f9b4541ef54fbe188b0cee7353ee5d7de",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-arm64-app.zip"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-arm64.tar.gz",
+        "digest": "sha256:a50d4c2742e561686b43e597887dd0683a1e2fb160e1e8dfe0c46660826cb068",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-arm64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-x64-app.zip",
+        "digest": "sha256:a3721acbefbb832f8f0d9420db6054671fcf6cbe89747d048d398ff00fcf3f6c",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-x64-app.zip"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-x64.tar.gz",
+        "digest": "sha256:060bf1fdb0fa022232847910a18744efcfc5f80bbacdb1a599612de9d45b591d",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x64-installer.exe",
+        "digest": "sha256:b9d509d9c960f3bfe7e189852c701ae10e2bf0ed4314c04855f9029f0d04cf59",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x64-installer.exe"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x64.zip",
+        "digest": "sha256:9155f78fffc7c3a004e708ca1f25b546e30e514a893cd1c57ba09153afb5f11d",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x64.zip"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x86-installer.exe",
+        "digest": "sha256:7227fad4690e7ec812088b03b1efccd277a302fc8250f1ed2703eb41176a502c",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x86-installer.exe"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x86.zip",
+        "digest": "sha256:1570702c35765cf40ef6ecb37d275f9bf91f0b7bd8f41b81ed67da2e2d2bcbee",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x86.zip"
+      }
+    ]
+  },
+  {
+    "tag_name": "v3.3.9-develop.1199",
+    "body": "## What's Changed\n* Fix: Remove Duplicate Text in Modal by @JoyboySon in https://github.com/Whisparr/Whisparr-Eros/pull/3\n\n## New Contributors\n* @JoyboySon made their first contribution in https://github.com/Whisparr/Whisparr-Eros/pull/3\n\n**Full Changelog**: https://github.com/Whisparr/Whisparr-Eros/compare/3.2.0-develop.1...v3.2.0-develop.8",
+    "published_at": "2026-01-15T04:24:58Z",
+    "prerelease": true,
+    "draft": false,
+    "assets": [
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.freebsd-x64.tar.gz",
+        "digest": "sha256:7e600f422ad9de8aba5ad7de8a7a217c7ba6464321df1bfe2e6b954a210e4288",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.freebsd-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-arm.tar.gz",
+        "digest": "sha256:609aa587af8d7242b6fc7adbe88e1741f747ca90297e387079170d5e6ff8a7da",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-arm.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-arm64.tar.gz",
+        "digest": "sha256:edd6bce36455201f11847266b63f2f523a48c5917ce2d37ede52612dfa4d5828",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-arm64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-musl-arm64.tar.gz",
+        "digest": "sha256:3cf7b6de34e0ea9008e76bcba7668c39e7cb70ba4ac27cc795a19983faa5f4c6",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-musl-arm64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-musl-x64.tar.gz",
+        "digest": "sha256:e5c57131d0d87574edbab3144f65cb8c1dd5dfe139cf293f4778eece8a63a348",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-musl-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-x64.tar.gz",
+        "digest": "sha256:697facd9727ae84a12dcf2e260e5e7f83112965801d070aab4a1042dd08d1236",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-arm64-app.zip",
+        "digest": "sha256:6fb730e35ef05464e3e1427ac121a16f9b4541ef54fbe188b0cee7353ee5d7de",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-arm64-app.zip"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-arm64.tar.gz",
+        "digest": "sha256:a50d4c2742e561686b43e597887dd0683a1e2fb160e1e8dfe0c46660826cb068",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-arm64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-x64-app.zip",
+        "digest": "sha256:a3721acbefbb832f8f0d9420db6054671fcf6cbe89747d048d398ff00fcf3f6c",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-x64-app.zip"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-x64.tar.gz",
+        "digest": "sha256:060bf1fdb0fa022232847910a18744efcfc5f80bbacdb1a599612de9d45b591d",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x64-installer.exe",
+        "digest": "sha256:b9d509d9c960f3bfe7e189852c701ae10e2bf0ed4314c04855f9029f0d04cf59",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x64-installer.exe"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x64.zip",
+        "digest": "sha256:9155f78fffc7c3a004e708ca1f25b546e30e514a893cd1c57ba09153afb5f11d",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x64.zip"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x86-installer.exe",
+        "digest": "sha256:7227fad4690e7ec812088b03b1efccd277a302fc8250f1ed2703eb41176a502c",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x86-installer.exe"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x86.zip",
+        "digest": "sha256:1570702c35765cf40ef6ecb37d275f9bf91f0b7bd8f41b81ed67da2e2d2bcbee",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x86.zip"
+      }
+    ]
+  },
+  {
+    "tag_name": "v3.3.9-develop.1198",
+    "body": "## What's Changed\n* Fix: Remove Duplicate Text in Modal by @JoyboySon in https://github.com/Whisparr/Whisparr-Eros/pull/3\n\n## New Contributors\n* @JoyboySon made their first contribution in https://github.com/Whisparr/Whisparr-Eros/pull/3\n\n**Full Changelog**: https://github.com/Whisparr/Whisparr-Eros/compare/3.2.0-develop.1...v3.2.0-develop.8",
+    "published_at": "2026-01-15T04:24:58Z",
+    "prerelease": true,
+    "draft": false,
+    "assets": [
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.freebsd-x64.tar.gz",
+        "digest": "sha256:7e600f422ad9de8aba5ad7de8a7a217c7ba6464321df1bfe2e6b954a210e4288",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.freebsd-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-arm.tar.gz",
+        "digest": "sha256:609aa587af8d7242b6fc7adbe88e1741f747ca90297e387079170d5e6ff8a7da",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-arm.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-arm64.tar.gz",
+        "digest": "sha256:edd6bce36455201f11847266b63f2f523a48c5917ce2d37ede52612dfa4d5828",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-arm64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-musl-arm64.tar.gz",
+        "digest": "sha256:3cf7b6de34e0ea9008e76bcba7668c39e7cb70ba4ac27cc795a19983faa5f4c6",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-musl-arm64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-musl-x64.tar.gz",
+        "digest": "sha256:e5c57131d0d87574edbab3144f65cb8c1dd5dfe139cf293f4778eece8a63a348",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-musl-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-x64.tar.gz",
+        "digest": "sha256:697facd9727ae84a12dcf2e260e5e7f83112965801d070aab4a1042dd08d1236",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-arm64-app.zip",
+        "digest": "sha256:6fb730e35ef05464e3e1427ac121a16f9b4541ef54fbe188b0cee7353ee5d7de",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-arm64-app.zip"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-arm64.tar.gz",
+        "digest": "sha256:a50d4c2742e561686b43e597887dd0683a1e2fb160e1e8dfe0c46660826cb068",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-arm64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-x64-app.zip",
+        "digest": "sha256:a3721acbefbb832f8f0d9420db6054671fcf6cbe89747d048d398ff00fcf3f6c",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-x64-app.zip"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-x64.tar.gz",
+        "digest": "sha256:060bf1fdb0fa022232847910a18744efcfc5f80bbacdb1a599612de9d45b591d",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x64-installer.exe",
+        "digest": "sha256:b9d509d9c960f3bfe7e189852c701ae10e2bf0ed4314c04855f9029f0d04cf59",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x64-installer.exe"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x64.zip",
+        "digest": "sha256:9155f78fffc7c3a004e708ca1f25b546e30e514a893cd1c57ba09153afb5f11d",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x64.zip"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x86-installer.exe",
+        "digest": "sha256:7227fad4690e7ec812088b03b1efccd277a302fc8250f1ed2703eb41176a502c",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x86-installer.exe"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x86.zip",
+        "digest": "sha256:1570702c35765cf40ef6ecb37d275f9bf91f0b7bd8f41b81ed67da2e2d2bcbee",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x86.zip"
+      }
+    ]
+  },
+  {
+    "tag_name": "v3.3.9-develop.1197",
+    "body": "## What's Changed\n* Fix: Remove Duplicate Text in Modal by @JoyboySon in https://github.com/Whisparr/Whisparr-Eros/pull/3\n\n## New Contributors\n* @JoyboySon made their first contribution in https://github.com/Whisparr/Whisparr-Eros/pull/3\n\n**Full Changelog**: https://github.com/Whisparr/Whisparr-Eros/compare/3.2.0-develop.1...v3.2.0-develop.8",
+    "published_at": "2026-01-15T04:24:58Z",
+    "prerelease": true,
+    "draft": false,
+    "assets": [
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.freebsd-x64.tar.gz",
+        "digest": "sha256:7e600f422ad9de8aba5ad7de8a7a217c7ba6464321df1bfe2e6b954a210e4288",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.freebsd-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-arm.tar.gz",
+        "digest": "sha256:609aa587af8d7242b6fc7adbe88e1741f747ca90297e387079170d5e6ff8a7da",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-arm.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-arm64.tar.gz",
+        "digest": "sha256:edd6bce36455201f11847266b63f2f523a48c5917ce2d37ede52612dfa4d5828",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-arm64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-musl-arm64.tar.gz",
+        "digest": "sha256:3cf7b6de34e0ea9008e76bcba7668c39e7cb70ba4ac27cc795a19983faa5f4c6",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-musl-arm64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-musl-x64.tar.gz",
+        "digest": "sha256:e5c57131d0d87574edbab3144f65cb8c1dd5dfe139cf293f4778eece8a63a348",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-musl-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-x64.tar.gz",
+        "digest": "sha256:697facd9727ae84a12dcf2e260e5e7f83112965801d070aab4a1042dd08d1236",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-arm64-app.zip",
+        "digest": "sha256:6fb730e35ef05464e3e1427ac121a16f9b4541ef54fbe188b0cee7353ee5d7de",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-arm64-app.zip"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-arm64.tar.gz",
+        "digest": "sha256:a50d4c2742e561686b43e597887dd0683a1e2fb160e1e8dfe0c46660826cb068",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-arm64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-x64-app.zip",
+        "digest": "sha256:a3721acbefbb832f8f0d9420db6054671fcf6cbe89747d048d398ff00fcf3f6c",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-x64-app.zip"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-x64.tar.gz",
+        "digest": "sha256:060bf1fdb0fa022232847910a18744efcfc5f80bbacdb1a599612de9d45b591d",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x64-installer.exe",
+        "digest": "sha256:b9d509d9c960f3bfe7e189852c701ae10e2bf0ed4314c04855f9029f0d04cf59",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x64-installer.exe"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x64.zip",
+        "digest": "sha256:9155f78fffc7c3a004e708ca1f25b546e30e514a893cd1c57ba09153afb5f11d",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x64.zip"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x86-installer.exe",
+        "digest": "sha256:7227fad4690e7ec812088b03b1efccd277a302fc8250f1ed2703eb41176a502c",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x86-installer.exe"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x86.zip",
+        "digest": "sha256:1570702c35765cf40ef6ecb37d275f9bf91f0b7bd8f41b81ed67da2e2d2bcbee",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x86.zip"
+      }
+    ]
+  },
+  {
+    "tag_name": "v3.3.9-develop.1196",
+    "body": "## What's Changed\n* Fix: Remove Duplicate Text in Modal by @JoyboySon in https://github.com/Whisparr/Whisparr-Eros/pull/3\n\n## New Contributors\n* @JoyboySon made their first contribution in https://github.com/Whisparr/Whisparr-Eros/pull/3\n\n**Full Changelog**: https://github.com/Whisparr/Whisparr-Eros/compare/3.2.0-develop.1...v3.2.0-develop.8",
+    "published_at": "2026-01-15T04:24:58Z",
+    "prerelease": true,
+    "draft": false,
+    "assets": [
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.freebsd-x64.tar.gz",
+        "digest": "sha256:7e600f422ad9de8aba5ad7de8a7a217c7ba6464321df1bfe2e6b954a210e4288",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.freebsd-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-arm.tar.gz",
+        "digest": "sha256:609aa587af8d7242b6fc7adbe88e1741f747ca90297e387079170d5e6ff8a7da",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-arm.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-arm64.tar.gz",
+        "digest": "sha256:edd6bce36455201f11847266b63f2f523a48c5917ce2d37ede52612dfa4d5828",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-arm64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-musl-arm64.tar.gz",
+        "digest": "sha256:3cf7b6de34e0ea9008e76bcba7668c39e7cb70ba4ac27cc795a19983faa5f4c6",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-musl-arm64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-musl-x64.tar.gz",
+        "digest": "sha256:e5c57131d0d87574edbab3144f65cb8c1dd5dfe139cf293f4778eece8a63a348",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-musl-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-x64.tar.gz",
+        "digest": "sha256:697facd9727ae84a12dcf2e260e5e7f83112965801d070aab4a1042dd08d1236",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-arm64-app.zip",
+        "digest": "sha256:6fb730e35ef05464e3e1427ac121a16f9b4541ef54fbe188b0cee7353ee5d7de",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-arm64-app.zip"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-arm64.tar.gz",
+        "digest": "sha256:a50d4c2742e561686b43e597887dd0683a1e2fb160e1e8dfe0c46660826cb068",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-arm64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-x64-app.zip",
+        "digest": "sha256:a3721acbefbb832f8f0d9420db6054671fcf6cbe89747d048d398ff00fcf3f6c",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-x64-app.zip"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-x64.tar.gz",
+        "digest": "sha256:060bf1fdb0fa022232847910a18744efcfc5f80bbacdb1a599612de9d45b591d",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x64-installer.exe",
+        "digest": "sha256:b9d509d9c960f3bfe7e189852c701ae10e2bf0ed4314c04855f9029f0d04cf59",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x64-installer.exe"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x64.zip",
+        "digest": "sha256:9155f78fffc7c3a004e708ca1f25b546e30e514a893cd1c57ba09153afb5f11d",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x64.zip"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x86-installer.exe",
+        "digest": "sha256:7227fad4690e7ec812088b03b1efccd277a302fc8250f1ed2703eb41176a502c",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x86-installer.exe"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x86.zip",
+        "digest": "sha256:1570702c35765cf40ef6ecb37d275f9bf91f0b7bd8f41b81ed67da2e2d2bcbee",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x86.zip"
+      }
+    ]
+  },
+  {
+    "tag_name": "v3.3.9-develop.1195",
+    "body": "## What's Changed\n* Fix: Remove Duplicate Text in Modal by @JoyboySon in https://github.com/Whisparr/Whisparr-Eros/pull/3\n\n## New Contributors\n* @JoyboySon made their first contribution in https://github.com/Whisparr/Whisparr-Eros/pull/3\n\n**Full Changelog**: https://github.com/Whisparr/Whisparr-Eros/compare/3.2.0-develop.1...v3.2.0-develop.8",
+    "published_at": "2026-01-15T04:24:58Z",
+    "prerelease": true,
+    "draft": false,
+    "assets": [
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.freebsd-x64.tar.gz",
+        "digest": "sha256:7e600f422ad9de8aba5ad7de8a7a217c7ba6464321df1bfe2e6b954a210e4288",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.freebsd-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-arm.tar.gz",
+        "digest": "sha256:609aa587af8d7242b6fc7adbe88e1741f747ca90297e387079170d5e6ff8a7da",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-arm.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-arm64.tar.gz",
+        "digest": "sha256:edd6bce36455201f11847266b63f2f523a48c5917ce2d37ede52612dfa4d5828",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-arm64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-musl-arm64.tar.gz",
+        "digest": "sha256:3cf7b6de34e0ea9008e76bcba7668c39e7cb70ba4ac27cc795a19983faa5f4c6",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-musl-arm64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-musl-x64.tar.gz",
+        "digest": "sha256:e5c57131d0d87574edbab3144f65cb8c1dd5dfe139cf293f4778eece8a63a348",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-musl-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-x64.tar.gz",
+        "digest": "sha256:697facd9727ae84a12dcf2e260e5e7f83112965801d070aab4a1042dd08d1236",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-arm64-app.zip",
+        "digest": "sha256:6fb730e35ef05464e3e1427ac121a16f9b4541ef54fbe188b0cee7353ee5d7de",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-arm64-app.zip"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-arm64.tar.gz",
+        "digest": "sha256:a50d4c2742e561686b43e597887dd0683a1e2fb160e1e8dfe0c46660826cb068",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-arm64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-x64-app.zip",
+        "digest": "sha256:a3721acbefbb832f8f0d9420db6054671fcf6cbe89747d048d398ff00fcf3f6c",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-x64-app.zip"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-x64.tar.gz",
+        "digest": "sha256:060bf1fdb0fa022232847910a18744efcfc5f80bbacdb1a599612de9d45b591d",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x64-installer.exe",
+        "digest": "sha256:b9d509d9c960f3bfe7e189852c701ae10e2bf0ed4314c04855f9029f0d04cf59",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x64-installer.exe"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x64.zip",
+        "digest": "sha256:9155f78fffc7c3a004e708ca1f25b546e30e514a893cd1c57ba09153afb5f11d",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x64.zip"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x86-installer.exe",
+        "digest": "sha256:7227fad4690e7ec812088b03b1efccd277a302fc8250f1ed2703eb41176a502c",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x86-installer.exe"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x86.zip",
+        "digest": "sha256:1570702c35765cf40ef6ecb37d275f9bf91f0b7bd8f41b81ed67da2e2d2bcbee",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x86.zip"
+      }
+    ]
+  },
+  {
+    "tag_name": "v3.3.9-develop.1194",
+    "body": "## What's Changed\n* Fix: Remove Duplicate Text in Modal by @JoyboySon in https://github.com/Whisparr/Whisparr-Eros/pull/3\n\n## New Contributors\n* @JoyboySon made their first contribution in https://github.com/Whisparr/Whisparr-Eros/pull/3\n\n**Full Changelog**: https://github.com/Whisparr/Whisparr-Eros/compare/3.2.0-develop.1...v3.2.0-develop.8",
+    "published_at": "2026-01-15T04:24:58Z",
+    "prerelease": true,
+    "draft": false,
+    "assets": [
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.freebsd-x64.tar.gz",
+        "digest": "sha256:7e600f422ad9de8aba5ad7de8a7a217c7ba6464321df1bfe2e6b954a210e4288",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.freebsd-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-arm.tar.gz",
+        "digest": "sha256:609aa587af8d7242b6fc7adbe88e1741f747ca90297e387079170d5e6ff8a7da",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-arm.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-arm64.tar.gz",
+        "digest": "sha256:edd6bce36455201f11847266b63f2f523a48c5917ce2d37ede52612dfa4d5828",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-arm64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-musl-arm64.tar.gz",
+        "digest": "sha256:3cf7b6de34e0ea9008e76bcba7668c39e7cb70ba4ac27cc795a19983faa5f4c6",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-musl-arm64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-musl-x64.tar.gz",
+        "digest": "sha256:e5c57131d0d87574edbab3144f65cb8c1dd5dfe139cf293f4778eece8a63a348",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-musl-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-x64.tar.gz",
+        "digest": "sha256:697facd9727ae84a12dcf2e260e5e7f83112965801d070aab4a1042dd08d1236",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-arm64-app.zip",
+        "digest": "sha256:6fb730e35ef05464e3e1427ac121a16f9b4541ef54fbe188b0cee7353ee5d7de",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-arm64-app.zip"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-arm64.tar.gz",
+        "digest": "sha256:a50d4c2742e561686b43e597887dd0683a1e2fb160e1e8dfe0c46660826cb068",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-arm64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-x64-app.zip",
+        "digest": "sha256:a3721acbefbb832f8f0d9420db6054671fcf6cbe89747d048d398ff00fcf3f6c",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-x64-app.zip"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-x64.tar.gz",
+        "digest": "sha256:060bf1fdb0fa022232847910a18744efcfc5f80bbacdb1a599612de9d45b591d",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x64-installer.exe",
+        "digest": "sha256:b9d509d9c960f3bfe7e189852c701ae10e2bf0ed4314c04855f9029f0d04cf59",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x64-installer.exe"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x64.zip",
+        "digest": "sha256:9155f78fffc7c3a004e708ca1f25b546e30e514a893cd1c57ba09153afb5f11d",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x64.zip"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x86-installer.exe",
+        "digest": "sha256:7227fad4690e7ec812088b03b1efccd277a302fc8250f1ed2703eb41176a502c",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x86-installer.exe"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x86.zip",
+        "digest": "sha256:1570702c35765cf40ef6ecb37d275f9bf91f0b7bd8f41b81ed67da2e2d2bcbee",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x86.zip"
+      }
+    ]
+  },
+  {
+    "tag_name": "v3.3.9-develop.1193",
+    "body": "## What's Changed\n* Fix: Remove Duplicate Text in Modal by @JoyboySon in https://github.com/Whisparr/Whisparr-Eros/pull/3\n\n## New Contributors\n* @JoyboySon made their first contribution in https://github.com/Whisparr/Whisparr-Eros/pull/3\n\n**Full Changelog**: https://github.com/Whisparr/Whisparr-Eros/compare/3.2.0-develop.1...v3.2.0-develop.8",
+    "published_at": "2026-01-15T04:24:58Z",
+    "prerelease": true,
+    "draft": false,
+    "assets": [
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.freebsd-x64.tar.gz",
+        "digest": "sha256:7e600f422ad9de8aba5ad7de8a7a217c7ba6464321df1bfe2e6b954a210e4288",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.freebsd-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-arm.tar.gz",
+        "digest": "sha256:609aa587af8d7242b6fc7adbe88e1741f747ca90297e387079170d5e6ff8a7da",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-arm.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-arm64.tar.gz",
+        "digest": "sha256:edd6bce36455201f11847266b63f2f523a48c5917ce2d37ede52612dfa4d5828",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-arm64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-musl-arm64.tar.gz",
+        "digest": "sha256:3cf7b6de34e0ea9008e76bcba7668c39e7cb70ba4ac27cc795a19983faa5f4c6",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-musl-arm64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-musl-x64.tar.gz",
+        "digest": "sha256:e5c57131d0d87574edbab3144f65cb8c1dd5dfe139cf293f4778eece8a63a348",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-musl-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-x64.tar.gz",
+        "digest": "sha256:697facd9727ae84a12dcf2e260e5e7f83112965801d070aab4a1042dd08d1236",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-arm64-app.zip",
+        "digest": "sha256:6fb730e35ef05464e3e1427ac121a16f9b4541ef54fbe188b0cee7353ee5d7de",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-arm64-app.zip"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-arm64.tar.gz",
+        "digest": "sha256:a50d4c2742e561686b43e597887dd0683a1e2fb160e1e8dfe0c46660826cb068",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-arm64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-x64-app.zip",
+        "digest": "sha256:a3721acbefbb832f8f0d9420db6054671fcf6cbe89747d048d398ff00fcf3f6c",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-x64-app.zip"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-x64.tar.gz",
+        "digest": "sha256:060bf1fdb0fa022232847910a18744efcfc5f80bbacdb1a599612de9d45b591d",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x64-installer.exe",
+        "digest": "sha256:b9d509d9c960f3bfe7e189852c701ae10e2bf0ed4314c04855f9029f0d04cf59",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x64-installer.exe"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x64.zip",
+        "digest": "sha256:9155f78fffc7c3a004e708ca1f25b546e30e514a893cd1c57ba09153afb5f11d",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x64.zip"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x86-installer.exe",
+        "digest": "sha256:7227fad4690e7ec812088b03b1efccd277a302fc8250f1ed2703eb41176a502c",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x86-installer.exe"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x86.zip",
+        "digest": "sha256:1570702c35765cf40ef6ecb37d275f9bf91f0b7bd8f41b81ed67da2e2d2bcbee",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x86.zip"
+      }
+    ]
+  },
+  {
+    "tag_name": "v3.3.9-develop.1192",
+    "body": "## What's Changed\n* Fix: Remove Duplicate Text in Modal by @JoyboySon in https://github.com/Whisparr/Whisparr-Eros/pull/3\n\n## New Contributors\n* @JoyboySon made their first contribution in https://github.com/Whisparr/Whisparr-Eros/pull/3\n\n**Full Changelog**: https://github.com/Whisparr/Whisparr-Eros/compare/3.2.0-develop.1...v3.2.0-develop.8",
+    "published_at": "2026-01-15T04:24:58Z",
+    "prerelease": true,
+    "draft": false,
+    "assets": [
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.freebsd-x64.tar.gz",
+        "digest": "sha256:7e600f422ad9de8aba5ad7de8a7a217c7ba6464321df1bfe2e6b954a210e4288",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.freebsd-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-arm.tar.gz",
+        "digest": "sha256:609aa587af8d7242b6fc7adbe88e1741f747ca90297e387079170d5e6ff8a7da",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-arm.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-arm64.tar.gz",
+        "digest": "sha256:edd6bce36455201f11847266b63f2f523a48c5917ce2d37ede52612dfa4d5828",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-arm64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-musl-arm64.tar.gz",
+        "digest": "sha256:3cf7b6de34e0ea9008e76bcba7668c39e7cb70ba4ac27cc795a19983faa5f4c6",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-musl-arm64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-musl-x64.tar.gz",
+        "digest": "sha256:e5c57131d0d87574edbab3144f65cb8c1dd5dfe139cf293f4778eece8a63a348",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-musl-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-x64.tar.gz",
+        "digest": "sha256:697facd9727ae84a12dcf2e260e5e7f83112965801d070aab4a1042dd08d1236",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-arm64-app.zip",
+        "digest": "sha256:6fb730e35ef05464e3e1427ac121a16f9b4541ef54fbe188b0cee7353ee5d7de",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-arm64-app.zip"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-arm64.tar.gz",
+        "digest": "sha256:a50d4c2742e561686b43e597887dd0683a1e2fb160e1e8dfe0c46660826cb068",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-arm64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-x64-app.zip",
+        "digest": "sha256:a3721acbefbb832f8f0d9420db6054671fcf6cbe89747d048d398ff00fcf3f6c",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-x64-app.zip"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-x64.tar.gz",
+        "digest": "sha256:060bf1fdb0fa022232847910a18744efcfc5f80bbacdb1a599612de9d45b591d",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x64-installer.exe",
+        "digest": "sha256:b9d509d9c960f3bfe7e189852c701ae10e2bf0ed4314c04855f9029f0d04cf59",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x64-installer.exe"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x64.zip",
+        "digest": "sha256:9155f78fffc7c3a004e708ca1f25b546e30e514a893cd1c57ba09153afb5f11d",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x64.zip"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x86-installer.exe",
+        "digest": "sha256:7227fad4690e7ec812088b03b1efccd277a302fc8250f1ed2703eb41176a502c",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x86-installer.exe"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x86.zip",
+        "digest": "sha256:1570702c35765cf40ef6ecb37d275f9bf91f0b7bd8f41b81ed67da2e2d2bcbee",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x86.zip"
+      }
+    ]
+  },
+  {
+    "tag_name": "v3.3.9-develop.1191",
+    "body": "## What's Changed\n* Fix: Remove Duplicate Text in Modal by @JoyboySon in https://github.com/Whisparr/Whisparr-Eros/pull/3\n\n## New Contributors\n* @JoyboySon made their first contribution in https://github.com/Whisparr/Whisparr-Eros/pull/3\n\n**Full Changelog**: https://github.com/Whisparr/Whisparr-Eros/compare/3.2.0-develop.1...v3.2.0-develop.8",
+    "published_at": "2026-01-15T04:24:58Z",
+    "prerelease": true,
+    "draft": false,
+    "assets": [
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.freebsd-x64.tar.gz",
+        "digest": "sha256:7e600f422ad9de8aba5ad7de8a7a217c7ba6464321df1bfe2e6b954a210e4288",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.freebsd-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-arm.tar.gz",
+        "digest": "sha256:609aa587af8d7242b6fc7adbe88e1741f747ca90297e387079170d5e6ff8a7da",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-arm.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-arm64.tar.gz",
+        "digest": "sha256:edd6bce36455201f11847266b63f2f523a48c5917ce2d37ede52612dfa4d5828",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-arm64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-musl-arm64.tar.gz",
+        "digest": "sha256:3cf7b6de34e0ea9008e76bcba7668c39e7cb70ba4ac27cc795a19983faa5f4c6",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-musl-arm64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-musl-x64.tar.gz",
+        "digest": "sha256:e5c57131d0d87574edbab3144f65cb8c1dd5dfe139cf293f4778eece8a63a348",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-musl-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-x64.tar.gz",
+        "digest": "sha256:697facd9727ae84a12dcf2e260e5e7f83112965801d070aab4a1042dd08d1236",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-arm64-app.zip",
+        "digest": "sha256:6fb730e35ef05464e3e1427ac121a16f9b4541ef54fbe188b0cee7353ee5d7de",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-arm64-app.zip"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-arm64.tar.gz",
+        "digest": "sha256:a50d4c2742e561686b43e597887dd0683a1e2fb160e1e8dfe0c46660826cb068",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-arm64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-x64-app.zip",
+        "digest": "sha256:a3721acbefbb832f8f0d9420db6054671fcf6cbe89747d048d398ff00fcf3f6c",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-x64-app.zip"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-x64.tar.gz",
+        "digest": "sha256:060bf1fdb0fa022232847910a18744efcfc5f80bbacdb1a599612de9d45b591d",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x64-installer.exe",
+        "digest": "sha256:b9d509d9c960f3bfe7e189852c701ae10e2bf0ed4314c04855f9029f0d04cf59",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x64-installer.exe"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x64.zip",
+        "digest": "sha256:9155f78fffc7c3a004e708ca1f25b546e30e514a893cd1c57ba09153afb5f11d",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x64.zip"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x86-installer.exe",
+        "digest": "sha256:7227fad4690e7ec812088b03b1efccd277a302fc8250f1ed2703eb41176a502c",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x86-installer.exe"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x86.zip",
+        "digest": "sha256:1570702c35765cf40ef6ecb37d275f9bf91f0b7bd8f41b81ed67da2e2d2bcbee",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x86.zip"
+      }
+    ]
+  },
+  {
+    "tag_name": "v3.3.9-develop.1190",
+    "body": "## What's Changed\n* Fix: Remove Duplicate Text in Modal by @JoyboySon in https://github.com/Whisparr/Whisparr-Eros/pull/3\n\n## New Contributors\n* @JoyboySon made their first contribution in https://github.com/Whisparr/Whisparr-Eros/pull/3\n\n**Full Changelog**: https://github.com/Whisparr/Whisparr-Eros/compare/3.2.0-develop.1...v3.2.0-develop.8",
+    "published_at": "2026-01-15T04:24:58Z",
+    "prerelease": true,
+    "draft": false,
+    "assets": [
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.freebsd-x64.tar.gz",
+        "digest": "sha256:7e600f422ad9de8aba5ad7de8a7a217c7ba6464321df1bfe2e6b954a210e4288",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.freebsd-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-arm.tar.gz",
+        "digest": "sha256:609aa587af8d7242b6fc7adbe88e1741f747ca90297e387079170d5e6ff8a7da",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-arm.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-arm64.tar.gz",
+        "digest": "sha256:edd6bce36455201f11847266b63f2f523a48c5917ce2d37ede52612dfa4d5828",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-arm64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-musl-arm64.tar.gz",
+        "digest": "sha256:3cf7b6de34e0ea9008e76bcba7668c39e7cb70ba4ac27cc795a19983faa5f4c6",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-musl-arm64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-musl-x64.tar.gz",
+        "digest": "sha256:e5c57131d0d87574edbab3144f65cb8c1dd5dfe139cf293f4778eece8a63a348",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-musl-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-x64.tar.gz",
+        "digest": "sha256:697facd9727ae84a12dcf2e260e5e7f83112965801d070aab4a1042dd08d1236",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-arm64-app.zip",
+        "digest": "sha256:6fb730e35ef05464e3e1427ac121a16f9b4541ef54fbe188b0cee7353ee5d7de",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-arm64-app.zip"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-arm64.tar.gz",
+        "digest": "sha256:a50d4c2742e561686b43e597887dd0683a1e2fb160e1e8dfe0c46660826cb068",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-arm64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-x64-app.zip",
+        "digest": "sha256:a3721acbefbb832f8f0d9420db6054671fcf6cbe89747d048d398ff00fcf3f6c",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-x64-app.zip"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-x64.tar.gz",
+        "digest": "sha256:060bf1fdb0fa022232847910a18744efcfc5f80bbacdb1a599612de9d45b591d",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x64-installer.exe",
+        "digest": "sha256:b9d509d9c960f3bfe7e189852c701ae10e2bf0ed4314c04855f9029f0d04cf59",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x64-installer.exe"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x64.zip",
+        "digest": "sha256:9155f78fffc7c3a004e708ca1f25b546e30e514a893cd1c57ba09153afb5f11d",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x64.zip"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x86-installer.exe",
+        "digest": "sha256:7227fad4690e7ec812088b03b1efccd277a302fc8250f1ed2703eb41176a502c",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x86-installer.exe"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x86.zip",
+        "digest": "sha256:1570702c35765cf40ef6ecb37d275f9bf91f0b7bd8f41b81ed67da2e2d2bcbee",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x86.zip"
+      }
+    ]
+  },
+  {
+    "tag_name": "v3.3.9-develop.1189",
+    "body": "## What's Changed\n* Fix: Remove Duplicate Text in Modal by @JoyboySon in https://github.com/Whisparr/Whisparr-Eros/pull/3\n\n## New Contributors\n* @JoyboySon made their first contribution in https://github.com/Whisparr/Whisparr-Eros/pull/3\n\n**Full Changelog**: https://github.com/Whisparr/Whisparr-Eros/compare/3.2.0-develop.1...v3.2.0-develop.8",
+    "published_at": "2026-01-15T04:24:58Z",
+    "prerelease": true,
+    "draft": false,
+    "assets": [
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.freebsd-x64.tar.gz",
+        "digest": "sha256:7e600f422ad9de8aba5ad7de8a7a217c7ba6464321df1bfe2e6b954a210e4288",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.freebsd-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-arm.tar.gz",
+        "digest": "sha256:609aa587af8d7242b6fc7adbe88e1741f747ca90297e387079170d5e6ff8a7da",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-arm.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-arm64.tar.gz",
+        "digest": "sha256:edd6bce36455201f11847266b63f2f523a48c5917ce2d37ede52612dfa4d5828",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-arm64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-musl-arm64.tar.gz",
+        "digest": "sha256:3cf7b6de34e0ea9008e76bcba7668c39e7cb70ba4ac27cc795a19983faa5f4c6",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-musl-arm64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-musl-x64.tar.gz",
+        "digest": "sha256:e5c57131d0d87574edbab3144f65cb8c1dd5dfe139cf293f4778eece8a63a348",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-musl-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-x64.tar.gz",
+        "digest": "sha256:697facd9727ae84a12dcf2e260e5e7f83112965801d070aab4a1042dd08d1236",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-arm64-app.zip",
+        "digest": "sha256:6fb730e35ef05464e3e1427ac121a16f9b4541ef54fbe188b0cee7353ee5d7de",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-arm64-app.zip"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-arm64.tar.gz",
+        "digest": "sha256:a50d4c2742e561686b43e597887dd0683a1e2fb160e1e8dfe0c46660826cb068",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-arm64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-x64-app.zip",
+        "digest": "sha256:a3721acbefbb832f8f0d9420db6054671fcf6cbe89747d048d398ff00fcf3f6c",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-x64-app.zip"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-x64.tar.gz",
+        "digest": "sha256:060bf1fdb0fa022232847910a18744efcfc5f80bbacdb1a599612de9d45b591d",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x64-installer.exe",
+        "digest": "sha256:b9d509d9c960f3bfe7e189852c701ae10e2bf0ed4314c04855f9029f0d04cf59",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x64-installer.exe"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x64.zip",
+        "digest": "sha256:9155f78fffc7c3a004e708ca1f25b546e30e514a893cd1c57ba09153afb5f11d",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x64.zip"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x86-installer.exe",
+        "digest": "sha256:7227fad4690e7ec812088b03b1efccd277a302fc8250f1ed2703eb41176a502c",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x86-installer.exe"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x86.zip",
+        "digest": "sha256:1570702c35765cf40ef6ecb37d275f9bf91f0b7bd8f41b81ed67da2e2d2bcbee",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x86.zip"
+      }
+    ]
+  },
+  {
+    "tag_name": "v3.3.9-develop.1188",
+    "body": "## What's Changed\n* Fix: Remove Duplicate Text in Modal by @JoyboySon in https://github.com/Whisparr/Whisparr-Eros/pull/3\n\n## New Contributors\n* @JoyboySon made their first contribution in https://github.com/Whisparr/Whisparr-Eros/pull/3\n\n**Full Changelog**: https://github.com/Whisparr/Whisparr-Eros/compare/3.2.0-develop.1...v3.2.0-develop.8",
+    "published_at": "2026-01-15T04:24:58Z",
+    "prerelease": true,
+    "draft": false,
+    "assets": [
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.freebsd-x64.tar.gz",
+        "digest": "sha256:7e600f422ad9de8aba5ad7de8a7a217c7ba6464321df1bfe2e6b954a210e4288",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.freebsd-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-arm.tar.gz",
+        "digest": "sha256:609aa587af8d7242b6fc7adbe88e1741f747ca90297e387079170d5e6ff8a7da",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-arm.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-arm64.tar.gz",
+        "digest": "sha256:edd6bce36455201f11847266b63f2f523a48c5917ce2d37ede52612dfa4d5828",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-arm64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-musl-arm64.tar.gz",
+        "digest": "sha256:3cf7b6de34e0ea9008e76bcba7668c39e7cb70ba4ac27cc795a19983faa5f4c6",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-musl-arm64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-musl-x64.tar.gz",
+        "digest": "sha256:e5c57131d0d87574edbab3144f65cb8c1dd5dfe139cf293f4778eece8a63a348",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-musl-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-x64.tar.gz",
+        "digest": "sha256:697facd9727ae84a12dcf2e260e5e7f83112965801d070aab4a1042dd08d1236",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-arm64-app.zip",
+        "digest": "sha256:6fb730e35ef05464e3e1427ac121a16f9b4541ef54fbe188b0cee7353ee5d7de",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-arm64-app.zip"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-arm64.tar.gz",
+        "digest": "sha256:a50d4c2742e561686b43e597887dd0683a1e2fb160e1e8dfe0c46660826cb068",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-arm64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-x64-app.zip",
+        "digest": "sha256:a3721acbefbb832f8f0d9420db6054671fcf6cbe89747d048d398ff00fcf3f6c",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-x64-app.zip"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-x64.tar.gz",
+        "digest": "sha256:060bf1fdb0fa022232847910a18744efcfc5f80bbacdb1a599612de9d45b591d",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x64-installer.exe",
+        "digest": "sha256:b9d509d9c960f3bfe7e189852c701ae10e2bf0ed4314c04855f9029f0d04cf59",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x64-installer.exe"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x64.zip",
+        "digest": "sha256:9155f78fffc7c3a004e708ca1f25b546e30e514a893cd1c57ba09153afb5f11d",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x64.zip"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x86-installer.exe",
+        "digest": "sha256:7227fad4690e7ec812088b03b1efccd277a302fc8250f1ed2703eb41176a502c",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x86-installer.exe"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x86.zip",
+        "digest": "sha256:1570702c35765cf40ef6ecb37d275f9bf91f0b7bd8f41b81ed67da2e2d2bcbee",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x86.zip"
+      }
+    ]
+  },
+  {
+    "tag_name": "v3.3.9-develop.1187",
+    "body": "## What's Changed\n* Fix: Remove Duplicate Text in Modal by @JoyboySon in https://github.com/Whisparr/Whisparr-Eros/pull/3\n\n## New Contributors\n* @JoyboySon made their first contribution in https://github.com/Whisparr/Whisparr-Eros/pull/3\n\n**Full Changelog**: https://github.com/Whisparr/Whisparr-Eros/compare/3.2.0-develop.1...v3.2.0-develop.8",
+    "published_at": "2026-01-15T04:24:58Z",
+    "prerelease": true,
+    "draft": false,
+    "assets": [
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.freebsd-x64.tar.gz",
+        "digest": "sha256:7e600f422ad9de8aba5ad7de8a7a217c7ba6464321df1bfe2e6b954a210e4288",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.freebsd-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-arm.tar.gz",
+        "digest": "sha256:609aa587af8d7242b6fc7adbe88e1741f747ca90297e387079170d5e6ff8a7da",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-arm.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-arm64.tar.gz",
+        "digest": "sha256:edd6bce36455201f11847266b63f2f523a48c5917ce2d37ede52612dfa4d5828",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-arm64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-musl-arm64.tar.gz",
+        "digest": "sha256:3cf7b6de34e0ea9008e76bcba7668c39e7cb70ba4ac27cc795a19983faa5f4c6",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-musl-arm64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-musl-x64.tar.gz",
+        "digest": "sha256:e5c57131d0d87574edbab3144f65cb8c1dd5dfe139cf293f4778eece8a63a348",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-musl-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-x64.tar.gz",
+        "digest": "sha256:697facd9727ae84a12dcf2e260e5e7f83112965801d070aab4a1042dd08d1236",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-arm64-app.zip",
+        "digest": "sha256:6fb730e35ef05464e3e1427ac121a16f9b4541ef54fbe188b0cee7353ee5d7de",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-arm64-app.zip"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-arm64.tar.gz",
+        "digest": "sha256:a50d4c2742e561686b43e597887dd0683a1e2fb160e1e8dfe0c46660826cb068",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-arm64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-x64-app.zip",
+        "digest": "sha256:a3721acbefbb832f8f0d9420db6054671fcf6cbe89747d048d398ff00fcf3f6c",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-x64-app.zip"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-x64.tar.gz",
+        "digest": "sha256:060bf1fdb0fa022232847910a18744efcfc5f80bbacdb1a599612de9d45b591d",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x64-installer.exe",
+        "digest": "sha256:b9d509d9c960f3bfe7e189852c701ae10e2bf0ed4314c04855f9029f0d04cf59",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x64-installer.exe"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x64.zip",
+        "digest": "sha256:9155f78fffc7c3a004e708ca1f25b546e30e514a893cd1c57ba09153afb5f11d",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x64.zip"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x86-installer.exe",
+        "digest": "sha256:7227fad4690e7ec812088b03b1efccd277a302fc8250f1ed2703eb41176a502c",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x86-installer.exe"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x86.zip",
+        "digest": "sha256:1570702c35765cf40ef6ecb37d275f9bf91f0b7bd8f41b81ed67da2e2d2bcbee",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x86.zip"
+      }
+    ]
+  },
+  {
+    "tag_name": "v3.3.9-develop.1186",
+    "body": "## What's Changed\n* Fix: Remove Duplicate Text in Modal by @JoyboySon in https://github.com/Whisparr/Whisparr-Eros/pull/3\n\n## New Contributors\n* @JoyboySon made their first contribution in https://github.com/Whisparr/Whisparr-Eros/pull/3\n\n**Full Changelog**: https://github.com/Whisparr/Whisparr-Eros/compare/3.2.0-develop.1...v3.2.0-develop.8",
+    "published_at": "2026-01-15T04:24:58Z",
+    "prerelease": true,
+    "draft": false,
+    "assets": [
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.freebsd-x64.tar.gz",
+        "digest": "sha256:7e600f422ad9de8aba5ad7de8a7a217c7ba6464321df1bfe2e6b954a210e4288",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.freebsd-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-arm.tar.gz",
+        "digest": "sha256:609aa587af8d7242b6fc7adbe88e1741f747ca90297e387079170d5e6ff8a7da",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-arm.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-arm64.tar.gz",
+        "digest": "sha256:edd6bce36455201f11847266b63f2f523a48c5917ce2d37ede52612dfa4d5828",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-arm64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-musl-arm64.tar.gz",
+        "digest": "sha256:3cf7b6de34e0ea9008e76bcba7668c39e7cb70ba4ac27cc795a19983faa5f4c6",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-musl-arm64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-musl-x64.tar.gz",
+        "digest": "sha256:e5c57131d0d87574edbab3144f65cb8c1dd5dfe139cf293f4778eece8a63a348",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-musl-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-x64.tar.gz",
+        "digest": "sha256:697facd9727ae84a12dcf2e260e5e7f83112965801d070aab4a1042dd08d1236",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-arm64-app.zip",
+        "digest": "sha256:6fb730e35ef05464e3e1427ac121a16f9b4541ef54fbe188b0cee7353ee5d7de",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-arm64-app.zip"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-arm64.tar.gz",
+        "digest": "sha256:a50d4c2742e561686b43e597887dd0683a1e2fb160e1e8dfe0c46660826cb068",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-arm64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-x64-app.zip",
+        "digest": "sha256:a3721acbefbb832f8f0d9420db6054671fcf6cbe89747d048d398ff00fcf3f6c",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-x64-app.zip"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-x64.tar.gz",
+        "digest": "sha256:060bf1fdb0fa022232847910a18744efcfc5f80bbacdb1a599612de9d45b591d",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x64-installer.exe",
+        "digest": "sha256:b9d509d9c960f3bfe7e189852c701ae10e2bf0ed4314c04855f9029f0d04cf59",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x64-installer.exe"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x64.zip",
+        "digest": "sha256:9155f78fffc7c3a004e708ca1f25b546e30e514a893cd1c57ba09153afb5f11d",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x64.zip"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x86-installer.exe",
+        "digest": "sha256:7227fad4690e7ec812088b03b1efccd277a302fc8250f1ed2703eb41176a502c",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x86-installer.exe"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x86.zip",
+        "digest": "sha256:1570702c35765cf40ef6ecb37d275f9bf91f0b7bd8f41b81ed67da2e2d2bcbee",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x86.zip"
+      }
+    ]
+  },
+  {
+    "tag_name": "v3.3.9-develop.1185",
+    "body": "## What's Changed\n* Fix: Remove Duplicate Text in Modal by @JoyboySon in https://github.com/Whisparr/Whisparr-Eros/pull/3\n\n## New Contributors\n* @JoyboySon made their first contribution in https://github.com/Whisparr/Whisparr-Eros/pull/3\n\n**Full Changelog**: https://github.com/Whisparr/Whisparr-Eros/compare/3.2.0-develop.1...v3.2.0-develop.8",
+    "published_at": "2026-01-15T04:24:58Z",
+    "prerelease": true,
+    "draft": false,
+    "assets": [
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.freebsd-x64.tar.gz",
+        "digest": "sha256:7e600f422ad9de8aba5ad7de8a7a217c7ba6464321df1bfe2e6b954a210e4288",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.freebsd-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-arm.tar.gz",
+        "digest": "sha256:609aa587af8d7242b6fc7adbe88e1741f747ca90297e387079170d5e6ff8a7da",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-arm.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-arm64.tar.gz",
+        "digest": "sha256:edd6bce36455201f11847266b63f2f523a48c5917ce2d37ede52612dfa4d5828",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-arm64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-musl-arm64.tar.gz",
+        "digest": "sha256:3cf7b6de34e0ea9008e76bcba7668c39e7cb70ba4ac27cc795a19983faa5f4c6",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-musl-arm64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-musl-x64.tar.gz",
+        "digest": "sha256:e5c57131d0d87574edbab3144f65cb8c1dd5dfe139cf293f4778eece8a63a348",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-musl-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-x64.tar.gz",
+        "digest": "sha256:697facd9727ae84a12dcf2e260e5e7f83112965801d070aab4a1042dd08d1236",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-arm64-app.zip",
+        "digest": "sha256:6fb730e35ef05464e3e1427ac121a16f9b4541ef54fbe188b0cee7353ee5d7de",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-arm64-app.zip"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-arm64.tar.gz",
+        "digest": "sha256:a50d4c2742e561686b43e597887dd0683a1e2fb160e1e8dfe0c46660826cb068",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-arm64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-x64-app.zip",
+        "digest": "sha256:a3721acbefbb832f8f0d9420db6054671fcf6cbe89747d048d398ff00fcf3f6c",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-x64-app.zip"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-x64.tar.gz",
+        "digest": "sha256:060bf1fdb0fa022232847910a18744efcfc5f80bbacdb1a599612de9d45b591d",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x64-installer.exe",
+        "digest": "sha256:b9d509d9c960f3bfe7e189852c701ae10e2bf0ed4314c04855f9029f0d04cf59",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x64-installer.exe"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x64.zip",
+        "digest": "sha256:9155f78fffc7c3a004e708ca1f25b546e30e514a893cd1c57ba09153afb5f11d",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x64.zip"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x86-installer.exe",
+        "digest": "sha256:7227fad4690e7ec812088b03b1efccd277a302fc8250f1ed2703eb41176a502c",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x86-installer.exe"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x86.zip",
+        "digest": "sha256:1570702c35765cf40ef6ecb37d275f9bf91f0b7bd8f41b81ed67da2e2d2bcbee",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x86.zip"
+      }
+    ]
+  },
+  {
+    "tag_name": "v3.3.9-develop.1184",
+    "body": "## What's Changed\n* Fix: Remove Duplicate Text in Modal by @JoyboySon in https://github.com/Whisparr/Whisparr-Eros/pull/3\n\n## New Contributors\n* @JoyboySon made their first contribution in https://github.com/Whisparr/Whisparr-Eros/pull/3\n\n**Full Changelog**: https://github.com/Whisparr/Whisparr-Eros/compare/3.2.0-develop.1...v3.2.0-develop.8",
+    "published_at": "2026-01-15T04:24:58Z",
+    "prerelease": true,
+    "draft": false,
+    "assets": [
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.freebsd-x64.tar.gz",
+        "digest": "sha256:7e600f422ad9de8aba5ad7de8a7a217c7ba6464321df1bfe2e6b954a210e4288",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.freebsd-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-arm.tar.gz",
+        "digest": "sha256:609aa587af8d7242b6fc7adbe88e1741f747ca90297e387079170d5e6ff8a7da",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-arm.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-arm64.tar.gz",
+        "digest": "sha256:edd6bce36455201f11847266b63f2f523a48c5917ce2d37ede52612dfa4d5828",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-arm64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-musl-arm64.tar.gz",
+        "digest": "sha256:3cf7b6de34e0ea9008e76bcba7668c39e7cb70ba4ac27cc795a19983faa5f4c6",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-musl-arm64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-musl-x64.tar.gz",
+        "digest": "sha256:e5c57131d0d87574edbab3144f65cb8c1dd5dfe139cf293f4778eece8a63a348",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-musl-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-x64.tar.gz",
+        "digest": "sha256:697facd9727ae84a12dcf2e260e5e7f83112965801d070aab4a1042dd08d1236",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-arm64-app.zip",
+        "digest": "sha256:6fb730e35ef05464e3e1427ac121a16f9b4541ef54fbe188b0cee7353ee5d7de",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-arm64-app.zip"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-arm64.tar.gz",
+        "digest": "sha256:a50d4c2742e561686b43e597887dd0683a1e2fb160e1e8dfe0c46660826cb068",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-arm64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-x64-app.zip",
+        "digest": "sha256:a3721acbefbb832f8f0d9420db6054671fcf6cbe89747d048d398ff00fcf3f6c",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-x64-app.zip"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-x64.tar.gz",
+        "digest": "sha256:060bf1fdb0fa022232847910a18744efcfc5f80bbacdb1a599612de9d45b591d",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x64-installer.exe",
+        "digest": "sha256:b9d509d9c960f3bfe7e189852c701ae10e2bf0ed4314c04855f9029f0d04cf59",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x64-installer.exe"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x64.zip",
+        "digest": "sha256:9155f78fffc7c3a004e708ca1f25b546e30e514a893cd1c57ba09153afb5f11d",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x64.zip"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x86-installer.exe",
+        "digest": "sha256:7227fad4690e7ec812088b03b1efccd277a302fc8250f1ed2703eb41176a502c",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x86-installer.exe"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x86.zip",
+        "digest": "sha256:1570702c35765cf40ef6ecb37d275f9bf91f0b7bd8f41b81ed67da2e2d2bcbee",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x86.zip"
+      }
+    ]
+  },
+  {
+    "tag_name": "v3.3.9-develop.1183",
+    "body": "## What's Changed\n* Fix: Remove Duplicate Text in Modal by @JoyboySon in https://github.com/Whisparr/Whisparr-Eros/pull/3\n\n## New Contributors\n* @JoyboySon made their first contribution in https://github.com/Whisparr/Whisparr-Eros/pull/3\n\n**Full Changelog**: https://github.com/Whisparr/Whisparr-Eros/compare/3.2.0-develop.1...v3.2.0-develop.8",
+    "published_at": "2026-01-15T04:24:58Z",
+    "prerelease": true,
+    "draft": false,
+    "assets": [
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.freebsd-x64.tar.gz",
+        "digest": "sha256:7e600f422ad9de8aba5ad7de8a7a217c7ba6464321df1bfe2e6b954a210e4288",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.freebsd-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-arm.tar.gz",
+        "digest": "sha256:609aa587af8d7242b6fc7adbe88e1741f747ca90297e387079170d5e6ff8a7da",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-arm.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-arm64.tar.gz",
+        "digest": "sha256:edd6bce36455201f11847266b63f2f523a48c5917ce2d37ede52612dfa4d5828",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-arm64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-musl-arm64.tar.gz",
+        "digest": "sha256:3cf7b6de34e0ea9008e76bcba7668c39e7cb70ba4ac27cc795a19983faa5f4c6",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-musl-arm64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-musl-x64.tar.gz",
+        "digest": "sha256:e5c57131d0d87574edbab3144f65cb8c1dd5dfe139cf293f4778eece8a63a348",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-musl-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-x64.tar.gz",
+        "digest": "sha256:697facd9727ae84a12dcf2e260e5e7f83112965801d070aab4a1042dd08d1236",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-arm64-app.zip",
+        "digest": "sha256:6fb730e35ef05464e3e1427ac121a16f9b4541ef54fbe188b0cee7353ee5d7de",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-arm64-app.zip"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-arm64.tar.gz",
+        "digest": "sha256:a50d4c2742e561686b43e597887dd0683a1e2fb160e1e8dfe0c46660826cb068",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-arm64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-x64-app.zip",
+        "digest": "sha256:a3721acbefbb832f8f0d9420db6054671fcf6cbe89747d048d398ff00fcf3f6c",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-x64-app.zip"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-x64.tar.gz",
+        "digest": "sha256:060bf1fdb0fa022232847910a18744efcfc5f80bbacdb1a599612de9d45b591d",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x64-installer.exe",
+        "digest": "sha256:b9d509d9c960f3bfe7e189852c701ae10e2bf0ed4314c04855f9029f0d04cf59",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x64-installer.exe"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x64.zip",
+        "digest": "sha256:9155f78fffc7c3a004e708ca1f25b546e30e514a893cd1c57ba09153afb5f11d",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x64.zip"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x86-installer.exe",
+        "digest": "sha256:7227fad4690e7ec812088b03b1efccd277a302fc8250f1ed2703eb41176a502c",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x86-installer.exe"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x86.zip",
+        "digest": "sha256:1570702c35765cf40ef6ecb37d275f9bf91f0b7bd8f41b81ed67da2e2d2bcbee",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x86.zip"
+      }
+    ]
+  },
+  {
+    "tag_name": "v3.3.9-develop.1182",
+    "body": "## What's Changed\n* Fix: Remove Duplicate Text in Modal by @JoyboySon in https://github.com/Whisparr/Whisparr-Eros/pull/3\n\n## New Contributors\n* @JoyboySon made their first contribution in https://github.com/Whisparr/Whisparr-Eros/pull/3\n\n**Full Changelog**: https://github.com/Whisparr/Whisparr-Eros/compare/3.2.0-develop.1...v3.2.0-develop.8",
+    "published_at": "2026-01-15T04:24:58Z",
+    "prerelease": true,
+    "draft": false,
+    "assets": [
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.freebsd-x64.tar.gz",
+        "digest": "sha256:7e600f422ad9de8aba5ad7de8a7a217c7ba6464321df1bfe2e6b954a210e4288",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.freebsd-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-arm.tar.gz",
+        "digest": "sha256:609aa587af8d7242b6fc7adbe88e1741f747ca90297e387079170d5e6ff8a7da",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-arm.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-arm64.tar.gz",
+        "digest": "sha256:edd6bce36455201f11847266b63f2f523a48c5917ce2d37ede52612dfa4d5828",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-arm64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-musl-arm64.tar.gz",
+        "digest": "sha256:3cf7b6de34e0ea9008e76bcba7668c39e7cb70ba4ac27cc795a19983faa5f4c6",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-musl-arm64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-musl-x64.tar.gz",
+        "digest": "sha256:e5c57131d0d87574edbab3144f65cb8c1dd5dfe139cf293f4778eece8a63a348",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-musl-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-x64.tar.gz",
+        "digest": "sha256:697facd9727ae84a12dcf2e260e5e7f83112965801d070aab4a1042dd08d1236",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-arm64-app.zip",
+        "digest": "sha256:6fb730e35ef05464e3e1427ac121a16f9b4541ef54fbe188b0cee7353ee5d7de",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-arm64-app.zip"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-arm64.tar.gz",
+        "digest": "sha256:a50d4c2742e561686b43e597887dd0683a1e2fb160e1e8dfe0c46660826cb068",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-arm64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-x64-app.zip",
+        "digest": "sha256:a3721acbefbb832f8f0d9420db6054671fcf6cbe89747d048d398ff00fcf3f6c",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-x64-app.zip"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-x64.tar.gz",
+        "digest": "sha256:060bf1fdb0fa022232847910a18744efcfc5f80bbacdb1a599612de9d45b591d",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x64-installer.exe",
+        "digest": "sha256:b9d509d9c960f3bfe7e189852c701ae10e2bf0ed4314c04855f9029f0d04cf59",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x64-installer.exe"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x64.zip",
+        "digest": "sha256:9155f78fffc7c3a004e708ca1f25b546e30e514a893cd1c57ba09153afb5f11d",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x64.zip"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x86-installer.exe",
+        "digest": "sha256:7227fad4690e7ec812088b03b1efccd277a302fc8250f1ed2703eb41176a502c",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x86-installer.exe"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x86.zip",
+        "digest": "sha256:1570702c35765cf40ef6ecb37d275f9bf91f0b7bd8f41b81ed67da2e2d2bcbee",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x86.zip"
+      }
+    ]
+  },
+  {
+    "tag_name": "v3.3.9-develop.1181",
+    "body": "## What's Changed\n* Fix: Remove Duplicate Text in Modal by @JoyboySon in https://github.com/Whisparr/Whisparr-Eros/pull/3\n\n## New Contributors\n* @JoyboySon made their first contribution in https://github.com/Whisparr/Whisparr-Eros/pull/3\n\n**Full Changelog**: https://github.com/Whisparr/Whisparr-Eros/compare/3.2.0-develop.1...v3.2.0-develop.8",
+    "published_at": "2026-01-15T04:24:58Z",
+    "prerelease": true,
+    "draft": false,
+    "assets": [
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.freebsd-x64.tar.gz",
+        "digest": "sha256:7e600f422ad9de8aba5ad7de8a7a217c7ba6464321df1bfe2e6b954a210e4288",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.freebsd-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-arm.tar.gz",
+        "digest": "sha256:609aa587af8d7242b6fc7adbe88e1741f747ca90297e387079170d5e6ff8a7da",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-arm.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-arm64.tar.gz",
+        "digest": "sha256:edd6bce36455201f11847266b63f2f523a48c5917ce2d37ede52612dfa4d5828",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-arm64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-musl-arm64.tar.gz",
+        "digest": "sha256:3cf7b6de34e0ea9008e76bcba7668c39e7cb70ba4ac27cc795a19983faa5f4c6",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-musl-arm64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-musl-x64.tar.gz",
+        "digest": "sha256:e5c57131d0d87574edbab3144f65cb8c1dd5dfe139cf293f4778eece8a63a348",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-musl-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-x64.tar.gz",
+        "digest": "sha256:697facd9727ae84a12dcf2e260e5e7f83112965801d070aab4a1042dd08d1236",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-arm64-app.zip",
+        "digest": "sha256:6fb730e35ef05464e3e1427ac121a16f9b4541ef54fbe188b0cee7353ee5d7de",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-arm64-app.zip"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-arm64.tar.gz",
+        "digest": "sha256:a50d4c2742e561686b43e597887dd0683a1e2fb160e1e8dfe0c46660826cb068",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-arm64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-x64-app.zip",
+        "digest": "sha256:a3721acbefbb832f8f0d9420db6054671fcf6cbe89747d048d398ff00fcf3f6c",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-x64-app.zip"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-x64.tar.gz",
+        "digest": "sha256:060bf1fdb0fa022232847910a18744efcfc5f80bbacdb1a599612de9d45b591d",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x64-installer.exe",
+        "digest": "sha256:b9d509d9c960f3bfe7e189852c701ae10e2bf0ed4314c04855f9029f0d04cf59",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x64-installer.exe"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x64.zip",
+        "digest": "sha256:9155f78fffc7c3a004e708ca1f25b546e30e514a893cd1c57ba09153afb5f11d",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x64.zip"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x86-installer.exe",
+        "digest": "sha256:7227fad4690e7ec812088b03b1efccd277a302fc8250f1ed2703eb41176a502c",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x86-installer.exe"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x86.zip",
+        "digest": "sha256:1570702c35765cf40ef6ecb37d275f9bf91f0b7bd8f41b81ed67da2e2d2bcbee",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x86.zip"
+      }
+    ]
+  },
+  {
+    "tag_name": "v3.3.9-develop.1180",
+    "body": "## What's Changed\n* Fix: Remove Duplicate Text in Modal by @JoyboySon in https://github.com/Whisparr/Whisparr-Eros/pull/3\n\n## New Contributors\n* @JoyboySon made their first contribution in https://github.com/Whisparr/Whisparr-Eros/pull/3\n\n**Full Changelog**: https://github.com/Whisparr/Whisparr-Eros/compare/3.2.0-develop.1...v3.2.0-develop.8",
+    "published_at": "2026-01-15T04:24:58Z",
+    "prerelease": true,
+    "draft": false,
+    "assets": [
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.freebsd-x64.tar.gz",
+        "digest": "sha256:7e600f422ad9de8aba5ad7de8a7a217c7ba6464321df1bfe2e6b954a210e4288",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.freebsd-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-arm.tar.gz",
+        "digest": "sha256:609aa587af8d7242b6fc7adbe88e1741f747ca90297e387079170d5e6ff8a7da",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-arm.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-arm64.tar.gz",
+        "digest": "sha256:edd6bce36455201f11847266b63f2f523a48c5917ce2d37ede52612dfa4d5828",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-arm64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-musl-arm64.tar.gz",
+        "digest": "sha256:3cf7b6de34e0ea9008e76bcba7668c39e7cb70ba4ac27cc795a19983faa5f4c6",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-musl-arm64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-musl-x64.tar.gz",
+        "digest": "sha256:e5c57131d0d87574edbab3144f65cb8c1dd5dfe139cf293f4778eece8a63a348",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-musl-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-x64.tar.gz",
+        "digest": "sha256:697facd9727ae84a12dcf2e260e5e7f83112965801d070aab4a1042dd08d1236",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-arm64-app.zip",
+        "digest": "sha256:6fb730e35ef05464e3e1427ac121a16f9b4541ef54fbe188b0cee7353ee5d7de",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-arm64-app.zip"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-arm64.tar.gz",
+        "digest": "sha256:a50d4c2742e561686b43e597887dd0683a1e2fb160e1e8dfe0c46660826cb068",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-arm64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-x64-app.zip",
+        "digest": "sha256:a3721acbefbb832f8f0d9420db6054671fcf6cbe89747d048d398ff00fcf3f6c",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-x64-app.zip"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-x64.tar.gz",
+        "digest": "sha256:060bf1fdb0fa022232847910a18744efcfc5f80bbacdb1a599612de9d45b591d",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x64-installer.exe",
+        "digest": "sha256:b9d509d9c960f3bfe7e189852c701ae10e2bf0ed4314c04855f9029f0d04cf59",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x64-installer.exe"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x64.zip",
+        "digest": "sha256:9155f78fffc7c3a004e708ca1f25b546e30e514a893cd1c57ba09153afb5f11d",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x64.zip"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x86-installer.exe",
+        "digest": "sha256:7227fad4690e7ec812088b03b1efccd277a302fc8250f1ed2703eb41176a502c",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x86-installer.exe"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x86.zip",
+        "digest": "sha256:1570702c35765cf40ef6ecb37d275f9bf91f0b7bd8f41b81ed67da2e2d2bcbee",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x86.zip"
+      }
+    ]
+  },
+  {
+    "tag_name": "v3.3.9-develop.1179",
+    "body": "## What's Changed\n* Fix: Remove Duplicate Text in Modal by @JoyboySon in https://github.com/Whisparr/Whisparr-Eros/pull/3\n\n## New Contributors\n* @JoyboySon made their first contribution in https://github.com/Whisparr/Whisparr-Eros/pull/3\n\n**Full Changelog**: https://github.com/Whisparr/Whisparr-Eros/compare/3.2.0-develop.1...v3.2.0-develop.8",
+    "published_at": "2026-01-15T04:24:58Z",
+    "prerelease": true,
+    "draft": false,
+    "assets": [
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.freebsd-x64.tar.gz",
+        "digest": "sha256:7e600f422ad9de8aba5ad7de8a7a217c7ba6464321df1bfe2e6b954a210e4288",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.freebsd-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-arm.tar.gz",
+        "digest": "sha256:609aa587af8d7242b6fc7adbe88e1741f747ca90297e387079170d5e6ff8a7da",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-arm.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-arm64.tar.gz",
+        "digest": "sha256:edd6bce36455201f11847266b63f2f523a48c5917ce2d37ede52612dfa4d5828",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-arm64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-musl-arm64.tar.gz",
+        "digest": "sha256:3cf7b6de34e0ea9008e76bcba7668c39e7cb70ba4ac27cc795a19983faa5f4c6",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-musl-arm64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-musl-x64.tar.gz",
+        "digest": "sha256:e5c57131d0d87574edbab3144f65cb8c1dd5dfe139cf293f4778eece8a63a348",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-musl-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-x64.tar.gz",
+        "digest": "sha256:697facd9727ae84a12dcf2e260e5e7f83112965801d070aab4a1042dd08d1236",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-arm64-app.zip",
+        "digest": "sha256:6fb730e35ef05464e3e1427ac121a16f9b4541ef54fbe188b0cee7353ee5d7de",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-arm64-app.zip"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-arm64.tar.gz",
+        "digest": "sha256:a50d4c2742e561686b43e597887dd0683a1e2fb160e1e8dfe0c46660826cb068",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-arm64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-x64-app.zip",
+        "digest": "sha256:a3721acbefbb832f8f0d9420db6054671fcf6cbe89747d048d398ff00fcf3f6c",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-x64-app.zip"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-x64.tar.gz",
+        "digest": "sha256:060bf1fdb0fa022232847910a18744efcfc5f80bbacdb1a599612de9d45b591d",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x64-installer.exe",
+        "digest": "sha256:b9d509d9c960f3bfe7e189852c701ae10e2bf0ed4314c04855f9029f0d04cf59",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x64-installer.exe"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x64.zip",
+        "digest": "sha256:9155f78fffc7c3a004e708ca1f25b546e30e514a893cd1c57ba09153afb5f11d",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x64.zip"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x86-installer.exe",
+        "digest": "sha256:7227fad4690e7ec812088b03b1efccd277a302fc8250f1ed2703eb41176a502c",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x86-installer.exe"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x86.zip",
+        "digest": "sha256:1570702c35765cf40ef6ecb37d275f9bf91f0b7bd8f41b81ed67da2e2d2bcbee",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x86.zip"
+      }
+    ]
+  },
+  {
+    "tag_name": "v3.3.9-develop.1178",
+    "body": "## What's Changed\n* Fix: Remove Duplicate Text in Modal by @JoyboySon in https://github.com/Whisparr/Whisparr-Eros/pull/3\n\n## New Contributors\n* @JoyboySon made their first contribution in https://github.com/Whisparr/Whisparr-Eros/pull/3\n\n**Full Changelog**: https://github.com/Whisparr/Whisparr-Eros/compare/3.2.0-develop.1...v3.2.0-develop.8",
+    "published_at": "2026-01-15T04:24:58Z",
+    "prerelease": true,
+    "draft": false,
+    "assets": [
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.freebsd-x64.tar.gz",
+        "digest": "sha256:7e600f422ad9de8aba5ad7de8a7a217c7ba6464321df1bfe2e6b954a210e4288",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.freebsd-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-arm.tar.gz",
+        "digest": "sha256:609aa587af8d7242b6fc7adbe88e1741f747ca90297e387079170d5e6ff8a7da",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-arm.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-arm64.tar.gz",
+        "digest": "sha256:edd6bce36455201f11847266b63f2f523a48c5917ce2d37ede52612dfa4d5828",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-arm64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-musl-arm64.tar.gz",
+        "digest": "sha256:3cf7b6de34e0ea9008e76bcba7668c39e7cb70ba4ac27cc795a19983faa5f4c6",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-musl-arm64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-musl-x64.tar.gz",
+        "digest": "sha256:e5c57131d0d87574edbab3144f65cb8c1dd5dfe139cf293f4778eece8a63a348",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-musl-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-x64.tar.gz",
+        "digest": "sha256:697facd9727ae84a12dcf2e260e5e7f83112965801d070aab4a1042dd08d1236",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-arm64-app.zip",
+        "digest": "sha256:6fb730e35ef05464e3e1427ac121a16f9b4541ef54fbe188b0cee7353ee5d7de",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-arm64-app.zip"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-arm64.tar.gz",
+        "digest": "sha256:a50d4c2742e561686b43e597887dd0683a1e2fb160e1e8dfe0c46660826cb068",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-arm64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-x64-app.zip",
+        "digest": "sha256:a3721acbefbb832f8f0d9420db6054671fcf6cbe89747d048d398ff00fcf3f6c",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-x64-app.zip"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-x64.tar.gz",
+        "digest": "sha256:060bf1fdb0fa022232847910a18744efcfc5f80bbacdb1a599612de9d45b591d",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x64-installer.exe",
+        "digest": "sha256:b9d509d9c960f3bfe7e189852c701ae10e2bf0ed4314c04855f9029f0d04cf59",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x64-installer.exe"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x64.zip",
+        "digest": "sha256:9155f78fffc7c3a004e708ca1f25b546e30e514a893cd1c57ba09153afb5f11d",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x64.zip"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x86-installer.exe",
+        "digest": "sha256:7227fad4690e7ec812088b03b1efccd277a302fc8250f1ed2703eb41176a502c",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x86-installer.exe"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x86.zip",
+        "digest": "sha256:1570702c35765cf40ef6ecb37d275f9bf91f0b7bd8f41b81ed67da2e2d2bcbee",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x86.zip"
+      }
+    ]
+  },
+  {
+    "tag_name": "v3.3.9-develop.1177",
+    "body": "## What's Changed\n* Fix: Remove Duplicate Text in Modal by @JoyboySon in https://github.com/Whisparr/Whisparr-Eros/pull/3\n\n## New Contributors\n* @JoyboySon made their first contribution in https://github.com/Whisparr/Whisparr-Eros/pull/3\n\n**Full Changelog**: https://github.com/Whisparr/Whisparr-Eros/compare/3.2.0-develop.1...v3.2.0-develop.8",
+    "published_at": "2026-01-15T04:24:58Z",
+    "prerelease": true,
+    "draft": false,
+    "assets": [
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.freebsd-x64.tar.gz",
+        "digest": "sha256:7e600f422ad9de8aba5ad7de8a7a217c7ba6464321df1bfe2e6b954a210e4288",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.freebsd-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-arm.tar.gz",
+        "digest": "sha256:609aa587af8d7242b6fc7adbe88e1741f747ca90297e387079170d5e6ff8a7da",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-arm.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-arm64.tar.gz",
+        "digest": "sha256:edd6bce36455201f11847266b63f2f523a48c5917ce2d37ede52612dfa4d5828",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-arm64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-musl-arm64.tar.gz",
+        "digest": "sha256:3cf7b6de34e0ea9008e76bcba7668c39e7cb70ba4ac27cc795a19983faa5f4c6",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-musl-arm64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-musl-x64.tar.gz",
+        "digest": "sha256:e5c57131d0d87574edbab3144f65cb8c1dd5dfe139cf293f4778eece8a63a348",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-musl-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-x64.tar.gz",
+        "digest": "sha256:697facd9727ae84a12dcf2e260e5e7f83112965801d070aab4a1042dd08d1236",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-arm64-app.zip",
+        "digest": "sha256:6fb730e35ef05464e3e1427ac121a16f9b4541ef54fbe188b0cee7353ee5d7de",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-arm64-app.zip"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-arm64.tar.gz",
+        "digest": "sha256:a50d4c2742e561686b43e597887dd0683a1e2fb160e1e8dfe0c46660826cb068",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-arm64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-x64-app.zip",
+        "digest": "sha256:a3721acbefbb832f8f0d9420db6054671fcf6cbe89747d048d398ff00fcf3f6c",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-x64-app.zip"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-x64.tar.gz",
+        "digest": "sha256:060bf1fdb0fa022232847910a18744efcfc5f80bbacdb1a599612de9d45b591d",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x64-installer.exe",
+        "digest": "sha256:b9d509d9c960f3bfe7e189852c701ae10e2bf0ed4314c04855f9029f0d04cf59",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x64-installer.exe"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x64.zip",
+        "digest": "sha256:9155f78fffc7c3a004e708ca1f25b546e30e514a893cd1c57ba09153afb5f11d",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x64.zip"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x86-installer.exe",
+        "digest": "sha256:7227fad4690e7ec812088b03b1efccd277a302fc8250f1ed2703eb41176a502c",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x86-installer.exe"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x86.zip",
+        "digest": "sha256:1570702c35765cf40ef6ecb37d275f9bf91f0b7bd8f41b81ed67da2e2d2bcbee",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x86.zip"
+      }
+    ]
+  },
+  {
+    "tag_name": "v3.3.9-develop.1176",
+    "body": "## What's Changed\n* Fix: Remove Duplicate Text in Modal by @JoyboySon in https://github.com/Whisparr/Whisparr-Eros/pull/3\n\n## New Contributors\n* @JoyboySon made their first contribution in https://github.com/Whisparr/Whisparr-Eros/pull/3\n\n**Full Changelog**: https://github.com/Whisparr/Whisparr-Eros/compare/3.2.0-develop.1...v3.2.0-develop.8",
+    "published_at": "2026-01-15T04:24:58Z",
+    "prerelease": true,
+    "draft": false,
+    "assets": [
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.freebsd-x64.tar.gz",
+        "digest": "sha256:7e600f422ad9de8aba5ad7de8a7a217c7ba6464321df1bfe2e6b954a210e4288",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.freebsd-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-arm.tar.gz",
+        "digest": "sha256:609aa587af8d7242b6fc7adbe88e1741f747ca90297e387079170d5e6ff8a7da",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-arm.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-arm64.tar.gz",
+        "digest": "sha256:edd6bce36455201f11847266b63f2f523a48c5917ce2d37ede52612dfa4d5828",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-arm64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-musl-arm64.tar.gz",
+        "digest": "sha256:3cf7b6de34e0ea9008e76bcba7668c39e7cb70ba4ac27cc795a19983faa5f4c6",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-musl-arm64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-musl-x64.tar.gz",
+        "digest": "sha256:e5c57131d0d87574edbab3144f65cb8c1dd5dfe139cf293f4778eece8a63a348",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-musl-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-x64.tar.gz",
+        "digest": "sha256:697facd9727ae84a12dcf2e260e5e7f83112965801d070aab4a1042dd08d1236",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-arm64-app.zip",
+        "digest": "sha256:6fb730e35ef05464e3e1427ac121a16f9b4541ef54fbe188b0cee7353ee5d7de",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-arm64-app.zip"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-arm64.tar.gz",
+        "digest": "sha256:a50d4c2742e561686b43e597887dd0683a1e2fb160e1e8dfe0c46660826cb068",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-arm64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-x64-app.zip",
+        "digest": "sha256:a3721acbefbb832f8f0d9420db6054671fcf6cbe89747d048d398ff00fcf3f6c",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-x64-app.zip"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-x64.tar.gz",
+        "digest": "sha256:060bf1fdb0fa022232847910a18744efcfc5f80bbacdb1a599612de9d45b591d",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x64-installer.exe",
+        "digest": "sha256:b9d509d9c960f3bfe7e189852c701ae10e2bf0ed4314c04855f9029f0d04cf59",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x64-installer.exe"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x64.zip",
+        "digest": "sha256:9155f78fffc7c3a004e708ca1f25b546e30e514a893cd1c57ba09153afb5f11d",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x64.zip"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x86-installer.exe",
+        "digest": "sha256:7227fad4690e7ec812088b03b1efccd277a302fc8250f1ed2703eb41176a502c",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x86-installer.exe"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x86.zip",
+        "digest": "sha256:1570702c35765cf40ef6ecb37d275f9bf91f0b7bd8f41b81ed67da2e2d2bcbee",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x86.zip"
+      }
+    ]
+  },
+  {
+    "tag_name": "v3.3.9-develop.1175",
+    "body": "## What's Changed\n* Fix: Remove Duplicate Text in Modal by @JoyboySon in https://github.com/Whisparr/Whisparr-Eros/pull/3\n\n## New Contributors\n* @JoyboySon made their first contribution in https://github.com/Whisparr/Whisparr-Eros/pull/3\n\n**Full Changelog**: https://github.com/Whisparr/Whisparr-Eros/compare/3.2.0-develop.1...v3.2.0-develop.8",
+    "published_at": "2026-01-15T04:24:58Z",
+    "prerelease": true,
+    "draft": false,
+    "assets": [
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.freebsd-x64.tar.gz",
+        "digest": "sha256:7e600f422ad9de8aba5ad7de8a7a217c7ba6464321df1bfe2e6b954a210e4288",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.freebsd-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-arm.tar.gz",
+        "digest": "sha256:609aa587af8d7242b6fc7adbe88e1741f747ca90297e387079170d5e6ff8a7da",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-arm.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-arm64.tar.gz",
+        "digest": "sha256:edd6bce36455201f11847266b63f2f523a48c5917ce2d37ede52612dfa4d5828",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-arm64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-musl-arm64.tar.gz",
+        "digest": "sha256:3cf7b6de34e0ea9008e76bcba7668c39e7cb70ba4ac27cc795a19983faa5f4c6",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-musl-arm64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-musl-x64.tar.gz",
+        "digest": "sha256:e5c57131d0d87574edbab3144f65cb8c1dd5dfe139cf293f4778eece8a63a348",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-musl-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-x64.tar.gz",
+        "digest": "sha256:697facd9727ae84a12dcf2e260e5e7f83112965801d070aab4a1042dd08d1236",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-arm64-app.zip",
+        "digest": "sha256:6fb730e35ef05464e3e1427ac121a16f9b4541ef54fbe188b0cee7353ee5d7de",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-arm64-app.zip"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-arm64.tar.gz",
+        "digest": "sha256:a50d4c2742e561686b43e597887dd0683a1e2fb160e1e8dfe0c46660826cb068",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-arm64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-x64-app.zip",
+        "digest": "sha256:a3721acbefbb832f8f0d9420db6054671fcf6cbe89747d048d398ff00fcf3f6c",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-x64-app.zip"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-x64.tar.gz",
+        "digest": "sha256:060bf1fdb0fa022232847910a18744efcfc5f80bbacdb1a599612de9d45b591d",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x64-installer.exe",
+        "digest": "sha256:b9d509d9c960f3bfe7e189852c701ae10e2bf0ed4314c04855f9029f0d04cf59",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x64-installer.exe"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x64.zip",
+        "digest": "sha256:9155f78fffc7c3a004e708ca1f25b546e30e514a893cd1c57ba09153afb5f11d",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x64.zip"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x86-installer.exe",
+        "digest": "sha256:7227fad4690e7ec812088b03b1efccd277a302fc8250f1ed2703eb41176a502c",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x86-installer.exe"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x86.zip",
+        "digest": "sha256:1570702c35765cf40ef6ecb37d275f9bf91f0b7bd8f41b81ed67da2e2d2bcbee",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x86.zip"
+      }
+    ]
+  },
+  {
+    "tag_name": "v3.3.9-develop.1174",
+    "body": "## What's Changed\n* Fix: Remove Duplicate Text in Modal by @JoyboySon in https://github.com/Whisparr/Whisparr-Eros/pull/3\n\n## New Contributors\n* @JoyboySon made their first contribution in https://github.com/Whisparr/Whisparr-Eros/pull/3\n\n**Full Changelog**: https://github.com/Whisparr/Whisparr-Eros/compare/3.2.0-develop.1...v3.2.0-develop.8",
+    "published_at": "2026-01-15T04:24:58Z",
+    "prerelease": true,
+    "draft": false,
+    "assets": [
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.freebsd-x64.tar.gz",
+        "digest": "sha256:7e600f422ad9de8aba5ad7de8a7a217c7ba6464321df1bfe2e6b954a210e4288",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.freebsd-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-arm.tar.gz",
+        "digest": "sha256:609aa587af8d7242b6fc7adbe88e1741f747ca90297e387079170d5e6ff8a7da",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-arm.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-arm64.tar.gz",
+        "digest": "sha256:edd6bce36455201f11847266b63f2f523a48c5917ce2d37ede52612dfa4d5828",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-arm64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-musl-arm64.tar.gz",
+        "digest": "sha256:3cf7b6de34e0ea9008e76bcba7668c39e7cb70ba4ac27cc795a19983faa5f4c6",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-musl-arm64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-musl-x64.tar.gz",
+        "digest": "sha256:e5c57131d0d87574edbab3144f65cb8c1dd5dfe139cf293f4778eece8a63a348",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-musl-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-x64.tar.gz",
+        "digest": "sha256:697facd9727ae84a12dcf2e260e5e7f83112965801d070aab4a1042dd08d1236",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-arm64-app.zip",
+        "digest": "sha256:6fb730e35ef05464e3e1427ac121a16f9b4541ef54fbe188b0cee7353ee5d7de",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-arm64-app.zip"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-arm64.tar.gz",
+        "digest": "sha256:a50d4c2742e561686b43e597887dd0683a1e2fb160e1e8dfe0c46660826cb068",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-arm64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-x64-app.zip",
+        "digest": "sha256:a3721acbefbb832f8f0d9420db6054671fcf6cbe89747d048d398ff00fcf3f6c",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-x64-app.zip"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-x64.tar.gz",
+        "digest": "sha256:060bf1fdb0fa022232847910a18744efcfc5f80bbacdb1a599612de9d45b591d",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x64-installer.exe",
+        "digest": "sha256:b9d509d9c960f3bfe7e189852c701ae10e2bf0ed4314c04855f9029f0d04cf59",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x64-installer.exe"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x64.zip",
+        "digest": "sha256:9155f78fffc7c3a004e708ca1f25b546e30e514a893cd1c57ba09153afb5f11d",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x64.zip"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x86-installer.exe",
+        "digest": "sha256:7227fad4690e7ec812088b03b1efccd277a302fc8250f1ed2703eb41176a502c",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x86-installer.exe"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x86.zip",
+        "digest": "sha256:1570702c35765cf40ef6ecb37d275f9bf91f0b7bd8f41b81ed67da2e2d2bcbee",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x86.zip"
+      }
+    ]
+  },
+  {
+    "tag_name": "v3.3.9-develop.1173",
+    "body": "## What's Changed\n* Fix: Remove Duplicate Text in Modal by @JoyboySon in https://github.com/Whisparr/Whisparr-Eros/pull/3\n\n## New Contributors\n* @JoyboySon made their first contribution in https://github.com/Whisparr/Whisparr-Eros/pull/3\n\n**Full Changelog**: https://github.com/Whisparr/Whisparr-Eros/compare/3.2.0-develop.1...v3.2.0-develop.8",
+    "published_at": "2026-01-15T04:24:58Z",
+    "prerelease": true,
+    "draft": false,
+    "assets": [
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.freebsd-x64.tar.gz",
+        "digest": "sha256:7e600f422ad9de8aba5ad7de8a7a217c7ba6464321df1bfe2e6b954a210e4288",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.freebsd-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-arm.tar.gz",
+        "digest": "sha256:609aa587af8d7242b6fc7adbe88e1741f747ca90297e387079170d5e6ff8a7da",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-arm.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-arm64.tar.gz",
+        "digest": "sha256:edd6bce36455201f11847266b63f2f523a48c5917ce2d37ede52612dfa4d5828",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-arm64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-musl-arm64.tar.gz",
+        "digest": "sha256:3cf7b6de34e0ea9008e76bcba7668c39e7cb70ba4ac27cc795a19983faa5f4c6",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-musl-arm64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-musl-x64.tar.gz",
+        "digest": "sha256:e5c57131d0d87574edbab3144f65cb8c1dd5dfe139cf293f4778eece8a63a348",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-musl-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-x64.tar.gz",
+        "digest": "sha256:697facd9727ae84a12dcf2e260e5e7f83112965801d070aab4a1042dd08d1236",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-arm64-app.zip",
+        "digest": "sha256:6fb730e35ef05464e3e1427ac121a16f9b4541ef54fbe188b0cee7353ee5d7de",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-arm64-app.zip"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-arm64.tar.gz",
+        "digest": "sha256:a50d4c2742e561686b43e597887dd0683a1e2fb160e1e8dfe0c46660826cb068",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-arm64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-x64-app.zip",
+        "digest": "sha256:a3721acbefbb832f8f0d9420db6054671fcf6cbe89747d048d398ff00fcf3f6c",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-x64-app.zip"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-x64.tar.gz",
+        "digest": "sha256:060bf1fdb0fa022232847910a18744efcfc5f80bbacdb1a599612de9d45b591d",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x64-installer.exe",
+        "digest": "sha256:b9d509d9c960f3bfe7e189852c701ae10e2bf0ed4314c04855f9029f0d04cf59",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x64-installer.exe"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x64.zip",
+        "digest": "sha256:9155f78fffc7c3a004e708ca1f25b546e30e514a893cd1c57ba09153afb5f11d",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x64.zip"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x86-installer.exe",
+        "digest": "sha256:7227fad4690e7ec812088b03b1efccd277a302fc8250f1ed2703eb41176a502c",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x86-installer.exe"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x86.zip",
+        "digest": "sha256:1570702c35765cf40ef6ecb37d275f9bf91f0b7bd8f41b81ed67da2e2d2bcbee",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x86.zip"
+      }
+    ]
+  },
+  {
+    "tag_name": "v3.3.9-develop.1172",
+    "body": "## What's Changed\n* Fix: Remove Duplicate Text in Modal by @JoyboySon in https://github.com/Whisparr/Whisparr-Eros/pull/3\n\n## New Contributors\n* @JoyboySon made their first contribution in https://github.com/Whisparr/Whisparr-Eros/pull/3\n\n**Full Changelog**: https://github.com/Whisparr/Whisparr-Eros/compare/3.2.0-develop.1...v3.2.0-develop.8",
+    "published_at": "2026-01-15T04:24:58Z",
+    "prerelease": true,
+    "draft": false,
+    "assets": [
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.freebsd-x64.tar.gz",
+        "digest": "sha256:7e600f422ad9de8aba5ad7de8a7a217c7ba6464321df1bfe2e6b954a210e4288",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.freebsd-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-arm.tar.gz",
+        "digest": "sha256:609aa587af8d7242b6fc7adbe88e1741f747ca90297e387079170d5e6ff8a7da",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-arm.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-arm64.tar.gz",
+        "digest": "sha256:edd6bce36455201f11847266b63f2f523a48c5917ce2d37ede52612dfa4d5828",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-arm64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-musl-arm64.tar.gz",
+        "digest": "sha256:3cf7b6de34e0ea9008e76bcba7668c39e7cb70ba4ac27cc795a19983faa5f4c6",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-musl-arm64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-musl-x64.tar.gz",
+        "digest": "sha256:e5c57131d0d87574edbab3144f65cb8c1dd5dfe139cf293f4778eece8a63a348",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-musl-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-x64.tar.gz",
+        "digest": "sha256:697facd9727ae84a12dcf2e260e5e7f83112965801d070aab4a1042dd08d1236",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-arm64-app.zip",
+        "digest": "sha256:6fb730e35ef05464e3e1427ac121a16f9b4541ef54fbe188b0cee7353ee5d7de",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-arm64-app.zip"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-arm64.tar.gz",
+        "digest": "sha256:a50d4c2742e561686b43e597887dd0683a1e2fb160e1e8dfe0c46660826cb068",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-arm64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-x64-app.zip",
+        "digest": "sha256:a3721acbefbb832f8f0d9420db6054671fcf6cbe89747d048d398ff00fcf3f6c",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-x64-app.zip"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-x64.tar.gz",
+        "digest": "sha256:060bf1fdb0fa022232847910a18744efcfc5f80bbacdb1a599612de9d45b591d",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x64-installer.exe",
+        "digest": "sha256:b9d509d9c960f3bfe7e189852c701ae10e2bf0ed4314c04855f9029f0d04cf59",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x64-installer.exe"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x64.zip",
+        "digest": "sha256:9155f78fffc7c3a004e708ca1f25b546e30e514a893cd1c57ba09153afb5f11d",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x64.zip"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x86-installer.exe",
+        "digest": "sha256:7227fad4690e7ec812088b03b1efccd277a302fc8250f1ed2703eb41176a502c",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x86-installer.exe"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x86.zip",
+        "digest": "sha256:1570702c35765cf40ef6ecb37d275f9bf91f0b7bd8f41b81ed67da2e2d2bcbee",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x86.zip"
+      }
+    ]
+  },
+  {
+    "tag_name": "v3.3.9-develop.1171",
+    "body": "## What's Changed\n* Fix: Remove Duplicate Text in Modal by @JoyboySon in https://github.com/Whisparr/Whisparr-Eros/pull/3\n\n## New Contributors\n* @JoyboySon made their first contribution in https://github.com/Whisparr/Whisparr-Eros/pull/3\n\n**Full Changelog**: https://github.com/Whisparr/Whisparr-Eros/compare/3.2.0-develop.1...v3.2.0-develop.8",
+    "published_at": "2026-01-15T04:24:58Z",
+    "prerelease": true,
+    "draft": false,
+    "assets": [
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.freebsd-x64.tar.gz",
+        "digest": "sha256:7e600f422ad9de8aba5ad7de8a7a217c7ba6464321df1bfe2e6b954a210e4288",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.freebsd-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-arm.tar.gz",
+        "digest": "sha256:609aa587af8d7242b6fc7adbe88e1741f747ca90297e387079170d5e6ff8a7da",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-arm.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-arm64.tar.gz",
+        "digest": "sha256:edd6bce36455201f11847266b63f2f523a48c5917ce2d37ede52612dfa4d5828",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-arm64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-musl-arm64.tar.gz",
+        "digest": "sha256:3cf7b6de34e0ea9008e76bcba7668c39e7cb70ba4ac27cc795a19983faa5f4c6",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-musl-arm64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-musl-x64.tar.gz",
+        "digest": "sha256:e5c57131d0d87574edbab3144f65cb8c1dd5dfe139cf293f4778eece8a63a348",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-musl-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.linux-x64.tar.gz",
+        "digest": "sha256:697facd9727ae84a12dcf2e260e5e7f83112965801d070aab4a1042dd08d1236",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.linux-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-arm64-app.zip",
+        "digest": "sha256:6fb730e35ef05464e3e1427ac121a16f9b4541ef54fbe188b0cee7353ee5d7de",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-arm64-app.zip"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-arm64.tar.gz",
+        "digest": "sha256:a50d4c2742e561686b43e597887dd0683a1e2fb160e1e8dfe0c46660826cb068",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-arm64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-x64-app.zip",
+        "digest": "sha256:a3721acbefbb832f8f0d9420db6054671fcf6cbe89747d048d398ff00fcf3f6c",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-x64-app.zip"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.osx-x64.tar.gz",
+        "digest": "sha256:060bf1fdb0fa022232847910a18744efcfc5f80bbacdb1a599612de9d45b591d",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.osx-x64.tar.gz"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x64-installer.exe",
+        "digest": "sha256:b9d509d9c960f3bfe7e189852c701ae10e2bf0ed4314c04855f9029f0d04cf59",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x64-installer.exe"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x64.zip",
+        "digest": "sha256:9155f78fffc7c3a004e708ca1f25b546e30e514a893cd1c57ba09153afb5f11d",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x64.zip"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x86-installer.exe",
+        "digest": "sha256:7227fad4690e7ec812088b03b1efccd277a302fc8250f1ed2703eb41176a502c",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x86-installer.exe"
+      },
+      {
+        "name": "Whisparr.eros-develop.3.2.0-develop.8.win-x86.zip",
+        "digest": "sha256:1570702c35765cf40ef6ecb37d275f9bf91f0b7bd8f41b81ed67da2e2d2bcbee",
+        "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-develop.8/Whisparr.eros-develop.3.2.0-develop.8.win-x86.zip"
+      }
+    ]
+  }
+]

--- a/src/NzbDrone.Core.Test/UpdateTests/TestData/GithubDraftReleaseResponse.json
+++ b/src/NzbDrone.Core.Test/UpdateTests/TestData/GithubDraftReleaseResponse.json
@@ -1,0 +1,79 @@
+{
+  "tag_name": "v3.2.0-release.1",
+  "body": "- Initial migration to new repo\r\n- Initial build process migration to native GitHub actions\r\n- Initial migration of client app to .NET 10\r\n",
+  "published_at": "2026-01-15T02:25:55Z",
+  "prerelease": false,
+  "draft": true,
+  "assets": [
+    {
+      "name": "Whisparr.eros.3.2.0-release.1.freebsd-x64.tar.gz",
+      "digest": "sha256:0b2f398d6efab42ee90e17bb04b907e27b63d4b0a37b04aa10f930b6ae83bf33",
+      "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-release.1/Whisparr.eros.3.2.0-release.1.freebsd-x64.tar.gz"
+    },
+    {
+      "name": "Whisparr.eros.3.2.0-release.1.linux-arm.tar.gz",
+      "digest": "sha256:c3d27e7e83c15e2f97433663c4a94b0040033905132195e660e3154f87d99c9e",
+      "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-release.1/Whisparr.eros.3.2.0-release.1.linux-arm.tar.gz"
+    },
+    {
+      "name": "Whisparr.eros.3.2.0-release.1.linux-arm64.tar.gz",
+      "digest": "sha256:27efabe0f733ae8c9d107a801710a5ebf17ed872e0ac314ac617bc9f6c680072",
+      "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-release.1/Whisparr.eros.3.2.0-release.1.linux-arm64.tar.gz"
+    },
+    {
+      "name": "Whisparr.eros.3.2.0-release.1.linux-musl-arm64.tar.gz",
+      "digest": "sha256:9371f20e9c08705ad1fdf7af1c19c6728cf239104536fe931cb64a72867b7a54",
+      "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-release.1/Whisparr.eros.3.2.0-release.1.linux-musl-arm64.tar.gz"
+    },
+    {
+      "name": "Whisparr.eros.3.2.0-release.1.linux-musl-x64.tar.gz",
+      "digest": "sha256:d07fc191395ad06173ce30708231e6a2664be7bb1416cfa87290ffb659a00d73",
+      "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-release.1/Whisparr.eros.3.2.0-release.1.linux-musl-x64.tar.gz"
+    },
+    {
+      "name": "Whisparr.eros.3.2.0-release.1.linux-x64.tar.gz",
+      "digest": "sha256:5e8d78c9e8f1321d78b2bb903be2a900a6206007c773126189fc01fc71054e97",
+      "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-release.1/Whisparr.eros.3.2.0-release.1.linux-x64.tar.gz"
+    },
+    {
+      "name": "Whisparr.eros.3.2.0-release.1.osx-arm64-app.zip",
+      "digest": "sha256:a21c769952845383f116f4edf4c9a0b62daab7f02f5822ecf32f456f2a6d9375",
+      "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-release.1/Whisparr.eros.3.2.0-release.1.osx-arm64-app.zip"
+    },
+    {
+      "name": "Whisparr.eros.3.2.0-release.1.osx-arm64.tar.gz",
+      "digest": "sha256:c2240173b4cd49b758355fccf78cd6b94db24dc3730914382b8a8e138596c419",
+      "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-release.1/Whisparr.eros.3.2.0-release.1.osx-arm64.tar.gz"
+    },
+    {
+      "name": "Whisparr.eros.3.2.0-release.1.osx-x64-app.zip",
+      "digest": "sha256:49d3738d92bf4a4ae5816d35709a989b131ba3111a04e79a789bbeb25d17a14b",
+      "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-release.1/Whisparr.eros.3.2.0-release.1.osx-x64-app.zip"
+    },
+    {
+      "name": "Whisparr.eros.3.2.0-release.1.osx-x64.tar.gz",
+      "digest": "sha256:ca2fa935252bf134036ac6da6f9cb69b2ad6b6aea4559bd60426cd317c29893b",
+      "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-release.1/Whisparr.eros.3.2.0-release.1.osx-x64.tar.gz"
+    },
+    {
+      "name": "Whisparr.eros.3.2.0-release.1.win-x64-installer.exe",
+      "digest": "sha256:c17d8b93ad9d2fa15c6c6107972ad058e2a81403c42952a21676c7302ba2ff73",
+      "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-release.1/Whisparr.eros.3.2.0-release.1.win-x64-installer.exe"
+    },
+    {
+      "name": "Whisparr.eros.3.2.0-release.1.win-x64.zip",
+      "digest": "sha256:2e926320ff48e5eb1c74a6f8d711ba3fdb436cb38bbdb37cfd9d4a9156b65471",
+      "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-release.1/Whisparr.eros.3.2.0-release.1.win-x64.zip"
+    },
+    {
+      "name": "Whisparr.eros.3.2.0-release.1.win-x86-installer.exe",
+      "digest": "sha256:e9cf5cefec5a4434f04d93479b8b752f1318ae05b8368292803d6f0e0ae32772",
+      "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-release.1/Whisparr.eros.3.2.0-release.1.win-x86-installer.exe"
+    },
+    {
+      "name": "Whisparr.eros.3.2.0-release.1.win-x86.zip",
+      "digest": "sha256:0e6acc3ccdd495a23cb8c87e896d3fb1c4745953fd1850d175f39509d493c0f9",
+      "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-release.1/Whisparr.eros.3.2.0-release.1.win-x86.zip"
+    }
+  ]
+}

--- a/src/NzbDrone.Core.Test/UpdateTests/TestData/GithubLatestReleaseResponse.json
+++ b/src/NzbDrone.Core.Test/UpdateTests/TestData/GithubLatestReleaseResponse.json
@@ -1,0 +1,79 @@
+{
+  "tag_name": "v3.2.0-release.1",
+  "body": "- Initial migration to new repo\r\n- Initial build process migration to native GitHub actions\r\n- Initial migration of client app to .NET 10\r\n",
+  "published_at": "2026-01-15T02:25:55Z",
+  "prerelease": false,
+  "draft": false,
+  "assets": [
+    {
+      "name": "Whisparr.eros.3.2.0-release.1.freebsd-x64.tar.gz",
+      "digest": "sha256:0b2f398d6efab42ee90e17bb04b907e27b63d4b0a37b04aa10f930b6ae83bf33",
+      "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-release.1/Whisparr.eros.3.2.0-release.1.freebsd-x64.tar.gz"
+    },
+    {
+      "name": "Whisparr.eros.3.2.0-release.1.linux-arm.tar.gz",
+      "digest": "sha256:c3d27e7e83c15e2f97433663c4a94b0040033905132195e660e3154f87d99c9e",
+      "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-release.1/Whisparr.eros.3.2.0-release.1.linux-arm.tar.gz"
+    },
+    {
+      "name": "Whisparr.eros.3.2.0-release.1.linux-arm64.tar.gz",
+      "digest": "sha256:27efabe0f733ae8c9d107a801710a5ebf17ed872e0ac314ac617bc9f6c680072",
+      "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-release.1/Whisparr.eros.3.2.0-release.1.linux-arm64.tar.gz"
+    },
+    {
+      "name": "Whisparr.eros.3.2.0-release.1.linux-musl-arm64.tar.gz",
+      "digest": "sha256:9371f20e9c08705ad1fdf7af1c19c6728cf239104536fe931cb64a72867b7a54",
+      "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-release.1/Whisparr.eros.3.2.0-release.1.linux-musl-arm64.tar.gz"
+    },
+    {
+      "name": "Whisparr.eros.3.2.0-release.1.linux-musl-x64.tar.gz",
+      "digest": "sha256:d07fc191395ad06173ce30708231e6a2664be7bb1416cfa87290ffb659a00d73",
+      "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-release.1/Whisparr.eros.3.2.0-release.1.linux-musl-x64.tar.gz"
+    },
+    {
+      "name": "Whisparr.eros.3.2.0-release.1.linux-x64.tar.gz",
+      "digest": "sha256:5e8d78c9e8f1321d78b2bb903be2a900a6206007c773126189fc01fc71054e97",
+      "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-release.1/Whisparr.eros.3.2.0-release.1.linux-x64.tar.gz"
+    },
+    {
+      "name": "Whisparr.eros.3.2.0-release.1.osx-arm64-app.zip",
+      "digest": "sha256:a21c769952845383f116f4edf4c9a0b62daab7f02f5822ecf32f456f2a6d9375",
+      "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-release.1/Whisparr.eros.3.2.0-release.1.osx-arm64-app.zip"
+    },
+    {
+      "name": "Whisparr.eros.3.2.0-release.1.osx-arm64.tar.gz",
+      "digest": "sha256:c2240173b4cd49b758355fccf78cd6b94db24dc3730914382b8a8e138596c419",
+      "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-release.1/Whisparr.eros.3.2.0-release.1.osx-arm64.tar.gz"
+    },
+    {
+      "name": "Whisparr.eros.3.2.0-release.1.osx-x64-app.zip",
+      "digest": "sha256:49d3738d92bf4a4ae5816d35709a989b131ba3111a04e79a789bbeb25d17a14b",
+      "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-release.1/Whisparr.eros.3.2.0-release.1.osx-x64-app.zip"
+    },
+    {
+      "name": "Whisparr.eros.3.2.0-release.1.osx-x64.tar.gz",
+      "digest": "sha256:ca2fa935252bf134036ac6da6f9cb69b2ad6b6aea4559bd60426cd317c29893b",
+      "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-release.1/Whisparr.eros.3.2.0-release.1.osx-x64.tar.gz"
+    },
+    {
+      "name": "Whisparr.eros.3.2.0-release.1.win-x64-installer.exe",
+      "digest": "sha256:c17d8b93ad9d2fa15c6c6107972ad058e2a81403c42952a21676c7302ba2ff73",
+      "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-release.1/Whisparr.eros.3.2.0-release.1.win-x64-installer.exe"
+    },
+    {
+      "name": "Whisparr.eros.3.2.0-release.1.win-x64.zip",
+      "digest": "sha256:2e926320ff48e5eb1c74a6f8d711ba3fdb436cb38bbdb37cfd9d4a9156b65471",
+      "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-release.1/Whisparr.eros.3.2.0-release.1.win-x64.zip"
+    },
+    {
+      "name": "Whisparr.eros.3.2.0-release.1.win-x86-installer.exe",
+      "digest": "sha256:e9cf5cefec5a4434f04d93479b8b752f1318ae05b8368292803d6f0e0ae32772",
+      "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-release.1/Whisparr.eros.3.2.0-release.1.win-x86-installer.exe"
+    },
+    {
+      "name": "Whisparr.eros.3.2.0-release.1.win-x86.zip",
+      "digest": "sha256:0e6acc3ccdd495a23cb8c87e896d3fb1c4745953fd1850d175f39509d493c0f9",
+      "browser_download_url": "https://github.com/Whisparr/Whisparr-Eros/releases/download/v3.2.0-release.1/Whisparr.eros.3.2.0-release.1.win-x86.zip"
+    }
+  ]
+}

--- a/src/NzbDrone.Core.Test/UpdateTests/UpdatePackageProviderFixture.cs
+++ b/src/NzbDrone.Core.Test/UpdateTests/UpdatePackageProviderFixture.cs
@@ -3,8 +3,10 @@ using System.Linq;
 using FluentAssertions;
 using Moq;
 using NUnit.Framework;
+using NzbDrone.Common.Cloud;
 using NzbDrone.Common.EnvironmentInfo;
 using NzbDrone.Common.Extensions;
+using NzbDrone.Common.Http;
 using NzbDrone.Core.Configuration;
 using NzbDrone.Core.Test.Framework;
 using NzbDrone.Core.Update;
@@ -13,31 +15,64 @@ namespace NzbDrone.Core.Test.UpdateTests
 {
     public class UpdatePackageProviderFixture : CoreTest<GithubUpdatePackageProvider>
     {
+        private const string ListUrl = "https://api.github.com/repos/{githubownerrepo}/releases";
+        private const string LatestUrl = "https://api.github.com/repos/{githubownerrepo}/releases/latest";
+
         [SetUp]
         public void Setup()
         {
-            // Mock IWhisparrCloudRequestBuilder to ensure GithubReleases.Create() returns a working builder
-            var realBuilder = new NzbDrone.Common.Http.HttpRequestBuilder("https://api.github.com/repos/{githubownerrepo}/releases");
-            var mockBuilderFactory = new Moq.Mock<NzbDrone.Common.Http.IHttpRequestBuilderFactory>();
-            mockBuilderFactory.Setup(f => f.Create()).Returns(realBuilder);
-            var mockCloudRequestBuilder = new Moq.Mock<NzbDrone.Common.Cloud.IWhisparrCloudRequestBuilder>();
-            mockCloudRequestBuilder.SetupGet(c => c.GithubReleases).Returns(mockBuilderFactory.Object);
-            Mocker.SetConstant<NzbDrone.Common.Cloud.IWhisparrCloudRequestBuilder>(mockCloudRequestBuilder.Object);
+            var mockCloudRequestBuilder = new Mock<IWhisparrCloudRequestBuilder>();
+            mockCloudRequestBuilder.SetupGet(c => c.GithubReleases).Returns(BuilderFor(ListUrl));
+            mockCloudRequestBuilder.SetupGet(c => c.GithubLatestRelease).Returns(BuilderFor(LatestUrl));
+            Mocker.SetConstant<IWhisparrCloudRequestBuilder>(mockCloudRequestBuilder.Object);
 
             Mocker.GetMock<IPlatformInfo>().SetupGet(c => c.Version).Returns(new Version("9.9.9"));
             Mocker.GetMock<IConfigFileProvider>()
                 .SetupGet(c => c.GithubOwnerRepo)
                 .Returns("whisparr/whisparr-eros");
 
-            // Mock IHttpClient to return a simulated GitHub releases API response from file
-            var testDataPath = System.IO.Path.Combine(AppContext.BaseDirectory, "UpdateTests", "TestData", "GithubReleasesResponse.json");
-            var fakeResponse = System.IO.File.ReadAllText(testDataPath);
-            var request = new NzbDrone.Common.Http.HttpRequest("https://api.github.com/repos/whisparr/whisparr-eros/releases?per_page=5");
-            var headers = new NzbDrone.Common.Http.HttpHeader();
-            var httpResponse = new NzbDrone.Common.Http.HttpResponse(request, headers, fakeResponse, System.Net.HttpStatusCode.OK);
-            Mocker.GetMock<NzbDrone.Common.Http.IHttpClient>()
-                .Setup(c => c.Get(It.IsAny<NzbDrone.Common.Http.HttpRequest>()))
-                .Returns(httpResponse);
+            // Both endpoints are stubbed by default. The list endpoint returns one stable and
+            // one develop release; the latest endpoint returns the stable one on its own.
+            GivenList("GithubReleasesResponse.json");
+            GivenLatest("GithubLatestReleaseResponse.json");
+        }
+
+        private static IHttpRequestBuilderFactory BuilderFor(string url)
+        {
+            var factory = new Mock<IHttpRequestBuilderFactory>();
+            factory.Setup(f => f.Create()).Returns(() => new HttpRequestBuilder(url));
+            return factory.Object;
+        }
+
+        private static string ReadTestData(string fileName)
+        {
+            var path = System.IO.Path.Combine(AppContext.BaseDirectory, "UpdateTests", "TestData", fileName);
+            return System.IO.File.ReadAllText(path);
+        }
+
+        private static HttpResponse ResponseFor(string url, string content, System.Net.HttpStatusCode statusCode)
+        {
+            return new HttpResponse(new HttpRequest(url), new HttpHeader(), content, statusCode);
+        }
+
+        /// <summary>Stubs the paged release-list endpoint.</summary>
+        private void GivenList(string fileName, System.Net.HttpStatusCode statusCode = System.Net.HttpStatusCode.OK)
+        {
+            var content = statusCode == System.Net.HttpStatusCode.OK ? ReadTestData(fileName) : "{}";
+
+            Mocker.GetMock<IHttpClient>()
+                .Setup(c => c.Get(It.Is<HttpRequest>(r => !r.Url.ToString().Contains("/releases/latest"))))
+                .Returns(ResponseFor("https://api.github.com/repos/whisparr/whisparr-eros/releases", content, statusCode));
+        }
+
+        /// <summary>Stubs the single-release "latest" endpoint.</summary>
+        private void GivenLatest(string fileName, System.Net.HttpStatusCode statusCode = System.Net.HttpStatusCode.OK)
+        {
+            var content = statusCode == System.Net.HttpStatusCode.OK ? ReadTestData(fileName) : "{}";
+
+            Mocker.GetMock<IHttpClient>()
+                .Setup(c => c.Get(It.Is<HttpRequest>(r => r.Url.ToString().Contains("/releases/latest"))))
+                .Returns(ResponseFor("https://api.github.com/repos/whisparr/whisparr-eros/releases/latest", content, statusCode));
         }
 
         [Test]
@@ -66,13 +101,6 @@ namespace NzbDrone.Core.Test.UpdateTests
             var recent = Subject.GetRecentUpdates(branch, new Version(3, 0), null);
             var recentWithChanges = recent.Where(c => c.Changes != null);
 
-            // Console output for validation
-            Console.WriteLine($"Recent updates count: {recent.Count}");
-            foreach (var update in recent)
-            {
-                Console.WriteLine($"Update: Version={update.Version}, FileName={update.FileName}, Hash={update.Hash}, Branch={update.Branch}, ReleaseDate={update.ReleaseDate}");
-            }
-
             recent.Should().NotBeEmpty();
             recent.Should().OnlyContain(c => c.Hash.IsNotNullOrWhiteSpace());
             recent.Should().OnlyContain(c => c.FileName.Contains("Whisparr"));
@@ -85,6 +113,87 @@ namespace NzbDrone.Core.Test.UpdateTests
             }
 
             recent.Should().OnlyContain(c => c.Branch == branch);
+        }
+
+        [Test]
+        public void should_find_stable_update_when_the_release_list_is_all_develop()
+        {
+            // The regression this fixes: eros-develop publishes a release per merge, so every
+            // entry in the first page of the list is a prerelease and the stable branch used
+            // to come back empty. The latest-release endpoint is not affected by that.
+            GivenList("GithubDevelopOnlyPageResponse.json");
+
+            var update = Subject.GetLatestUpdate("eros", new Version(2, 0, 0));
+
+            update.Should().NotBeNull();
+            update.Version.ToString().Should().NotContain("develop");
+        }
+
+        [Test]
+        public void should_not_offer_a_stable_release_to_a_develop_branch()
+        {
+            var update = Subject.GetLatestUpdate("eros-develop", new Version(2, 0, 0));
+
+            update.Should().NotBeNull();
+            update.Version.ToString().Should().Contain("develop");
+        }
+
+        [Test]
+        public void should_ignore_a_draft_release()
+        {
+            GivenLatest("GithubDraftReleaseResponse.json");
+            GivenList("GithubDevelopOnlyPageResponse.json");
+
+            Subject.GetLatestUpdate("eros", new Version(2, 0, 0)).Should().BeNull();
+        }
+
+        [Test]
+        public void should_fall_back_to_the_release_list_when_there_is_no_latest_release()
+        {
+            // A repository with no stable release answers 404 here.
+            GivenLatest("GithubLatestReleaseResponse.json", System.Net.HttpStatusCode.NotFound);
+
+            Subject.GetLatestUpdate("eros", new Version(2, 0, 0)).Should().NotBeNull();
+        }
+
+        [Test]
+        public void should_leave_changes_empty_for_a_chore_only_release()
+        {
+            // Whisparr/Whisparr#1125: a release with no "- New"/"- Fix" lines used to produce
+            // a single empty string, which the update modal reads as real content and renders
+            // as a blank "What's new?" instead of the maintenance-release line.
+            GivenLatest("GithubChoreOnlyReleaseResponse.json");
+
+            var update = Subject.GetLatestUpdate("eros", new Version(2, 0, 0));
+
+            update.Should().NotBeNull();
+            update.Changes.New.Should().BeEmpty();
+            update.Changes.Fixed.Should().BeEmpty();
+        }
+
+        [Test]
+        public void should_cap_the_number_of_packages_returned()
+        {
+            // A single page of 100 can be almost entirely develop releases. The Updates page
+            // renders one row per package, so the list must not grow just because the page
+            // size did.
+            GivenList("GithubDevelopOnlyPageResponse.json");
+
+            Subject.GetRecentUpdates("eros-develop", new Version(3, 0), null)
+                .Count.Should().BeLessThanOrEqualTo(25);
+        }
+
+        [Test]
+        public void should_cap_the_number_of_pages_requested()
+        {
+            // Unauthenticated GitHub allows 60 requests an hour per IP, and this runs on every
+            // load of System -> Updates, so the paging loop must not be unbounded.
+            GivenList("GithubDevelopOnlyPageResponse.json");
+
+            Subject.GetRecentUpdates("eros", new Version(3, 0), null);
+
+            Mocker.GetMock<IHttpClient>()
+                .Verify(c => c.Get(It.IsAny<HttpRequest>()), Times.AtMost(3));
         }
     }
 }

--- a/src/NzbDrone.Core.Test/Whisparr.Core.Test.csproj
+++ b/src/NzbDrone.Core.Test/Whisparr.Core.Test.csproj
@@ -4,7 +4,7 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- Test data files to be copied to output directory during builds -->
-    <None Update="UpdateTests/TestData/GithubReleasesResponse.json">
+    <None Update="UpdateTests/TestData/*.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>

--- a/src/NzbDrone.Core/Update/GithubUpdatePackageProvider.cs
+++ b/src/NzbDrone.Core/Update/GithubUpdatePackageProvider.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Runtime.InteropServices;
 using System.Text.Json;
 using System.Text.RegularExpressions;
@@ -18,6 +19,18 @@ namespace NzbDrone.Core.Update
 {
     public class GithubUpdatePackageProvider : IUpdatePackageProvider
     {
+        private const int PageSize = 100;
+        private const int MaxPages = 3;
+
+        // Enough matches to stop paging early. Deliberately low: a page of 100 is ~3MB, and
+        // page one currently holds four stable releases, so this keeps the common case to a
+        // single request while still paging when stable releases are sparser than that.
+        private const int WantedPackages = 3;
+
+        // Ceiling on what is handed back, matching the old per_page=25 behaviour. A single
+        // page of 100 can contain ~96 develop releases, and the Updates page renders each.
+        private const int MaxPackages = 25;
+
         private readonly IPlatformInfo _platformInfo;
         private readonly IAnalyticsService _analyticsService;
         private readonly IConfigFileProvider _configFileProvider;
@@ -52,8 +65,15 @@ namespace NzbDrone.Core.Update
         public UpdatePackage GetLatestUpdate(string branch, Version currentVersion)
         {
             _logger.Debug("Checking for latest update (branch: {0}, currentVersion: {1})", branch, currentVersion);
-            var updates = GetRecentUpdates(branch, currentVersion);
-            var latest = updates.FirstOrDefault();
+
+            // A stable branch asks GitHub for the newest non-prerelease release directly.
+            // Paging the full list does not work here: develop publishes a release per
+            // merge, so the newest stable release sits far past any page size we would
+            // pick, and every entry in that window gets filtered out.
+            var latest = IsDevelopBranch(branch)
+                ? GetRecentUpdates(branch, currentVersion).FirstOrDefault()
+                : GetLatestStableUpdate(branch) ?? GetRecentUpdates(branch, currentVersion).FirstOrDefault();
+
             if (latest != null)
             {
                 _logger.Info("Update found: {0} ({1})", latest.Version, latest.FileName);
@@ -93,139 +113,273 @@ namespace NzbDrone.Core.Update
                 currentVersion,
                 previousVersion);
 
-            var builder = _cloudRequestBuilder.GithubReleases.Create();
-            builder.SetSegment("githubownerrepo", ownerRepo);
-            builder.AddQueryParam("per_page", "25");
+            var packages = new List<UpdatePackage>();
+
+            // Page until we have enough matching releases or hit the cap. The cap matters:
+            // unauthenticated GitHub allows 60 requests an hour per IP, and this runs on
+            // every load of System -> Updates, not just on the six-hourly check.
+            for (var page = 1; page <= MaxPages && packages.Count < WantedPackages; page++)
+            {
+                var builder = _cloudRequestBuilder.GithubReleases.Create();
+                builder.SetSegment("githubownerrepo", ownerRepo);
+                builder.AddQueryParam("per_page", PageSize.ToString());
+
+                if (page > 1)
+                {
+                    builder.AddQueryParam("page", page.ToString());
+                }
+
+                var request = builder.Build();
+                _logger.Debug($"Requesting: {request.Url}");
+
+                List<GithubRelease> releases;
+
+                try
+                {
+                    var response = _httpClient.Get(request);
+                    _logger.Trace($"GitHub API response: {response.StatusCode}, {response.Content?.Length ?? 0} bytes");
+
+                    releases = JsonSerializer.Deserialize<List<GithubRelease>>(response.Content) ?? new List<GithubRelease>();
+                }
+                catch (Exception ex) when (page > 1)
+                {
+                    // GitHub returns the occasional transient 5xx. Losing a later page costs
+                    // a few changelog entries; letting it throw would blank the whole page.
+                    _logger.Debug(ex, "Failed to fetch page {0} of releases; returning what we have.", page);
+                    break;
+                }
+
+                foreach (var release in releases)
+                {
+                    if (!MatchesBranch(release, branch))
+                    {
+                        continue;
+                    }
+
+                    if (TryBuildPackage(release, branch, out var package))
+                    {
+                        packages.Add(package);
+                    }
+
+                    if (packages.Count >= MaxPackages)
+                    {
+                        break;
+                    }
+                }
+
+                if (packages.Count >= MaxPackages)
+                {
+                    break;
+                }
+
+                // A short page is the end of the list; there is nothing further to ask for.
+                if (releases.Count < PageSize)
+                {
+                    break;
+                }
+            }
+
+            _logger.Debug($"Total updates found: {packages.Count}");
+            return packages;
+        }
+
+        /// <summary>
+        /// Asks GitHub for the newest non-draft, non-prerelease release. Returns null if the
+        /// repository has no stable release yet, or if the request or the release is unusable.
+        /// </summary>
+        private UpdatePackage GetLatestStableUpdate(string branch)
+        {
+            var builder = _cloudRequestBuilder.GithubLatestRelease.Create();
+            builder.SetSegment("githubownerrepo", _configFileProvider.GithubOwnerRepo);
 
             var request = builder.Build();
+
+            // A repository with no stable release answers 404 here; fall back to the list.
+            request.SuppressHttpError = true;
+
             _logger.Debug($"Requesting: {request.Url}");
 
             var response = _httpClient.Get(request);
             _logger.Trace($"GitHub API response: {response.StatusCode}, {response.Content?.Length ?? 0} bytes");
 
-            var releases = JsonSerializer.Deserialize<List<GithubRelease>>(response.Content) ?? new List<GithubRelease>();
+            if (response.StatusCode != HttpStatusCode.OK)
+            {
+                _logger.Debug("No latest release available ({0}); falling back to the release list.", response.StatusCode);
+                return null;
+            }
+
+            var release = JsonSerializer.Deserialize<GithubRelease>(response.Content);
+
+            if (release == null)
+            {
+                _logger.Debug("Latest release response could not be read; falling back to the release list.");
+                return null;
+            }
+
+            // This endpoint is documented to exclude drafts and prereleases, but run the same
+            // check as the list path rather than trusting that -- both paths must agree on
+            // what counts as a release for this branch.
+            if (!MatchesBranch(release, branch))
+            {
+                return null;
+            }
+
+            return TryBuildPackage(release, branch, out var package) ? package : null;
+        }
+
+        /// <summary>
+        /// Decides whether a release belongs to the requested branch. GitHub's own
+        /// <c>prerelease</c> flag is the source of truth; the tag-name check is kept as a
+        /// fallback in case a release is ever published without the flag set correctly.
+        /// </summary>
+        private bool MatchesBranch(GithubRelease release, string branch)
+        {
+            if (release.draft)
+            {
+                _logger.Debug($"Skipping draft {release.tag_name}.");
+                return false;
+            }
+
+            if (string.IsNullOrEmpty(branch))
+            {
+                return true;
+            }
+
+            var wantsPrerelease = IsDevelopBranch(branch);
+            var tagLower = release.tag_name?.ToLowerInvariant() ?? string.Empty;
+            var tagLooksLikePrerelease = tagLower.Contains("develop");
+
+            if (release.prerelease != wantsPrerelease)
+            {
+                _logger.Debug($"Skipping {release.tag_name} (prerelease={release.prerelease}) for branch {branch}.");
+                return false;
+            }
+
+            if (tagLooksLikePrerelease != wantsPrerelease)
+            {
+                _logger.Debug($"Skipping {release.tag_name}: tag does not match branch {branch}.");
+                return false;
+            }
+
+            return true;
+        }
+
+        private static bool IsDevelopBranch(string branch)
+        {
+            return branch?.ToLowerInvariant().Contains("develop") == true;
+        }
+
+        /// <summary>
+        /// Builds an <see cref="UpdatePackage"/> from a release, selecting the asset for the
+        /// running OS and architecture. Shared by the list and latest-release paths.
+        /// </summary>
+        private bool TryBuildPackage(GithubRelease release, string branch, out UpdatePackage package)
+        {
+            package = null;
+
+            if (release.assets == null)
+            {
+                _logger.Debug($"Release {release.tag_name} has no package assets, skipping.");
+                return false;
+            }
 
             var osAssetString = GetOsAssetString(OsInfo.Os);
             var arch = RuntimeInformation.OSArchitecture.ToString().ToLowerInvariant();
 
-            var packages = new List<UpdatePackage>();
-            foreach (var release in releases)
+            // Prefer .tar.gz for Osx, fallback to .zip/.app
+            GithubAsset asset = null;
+            if (OsInfo.Os == Os.Osx)
             {
-                // Filter out releases that do not match the requested branch
-                // For example, if branch is 'eros-develop', skip tags like 'v3.2.0-release.27'
-                // You may need to adjust this logic if your tag naming changes
-                if (!string.IsNullOrEmpty(branch))
-                {
-                    var tagLower = release.tag_name.ToLowerInvariant();
-                    var branchLower = branch.ToLowerInvariant();
-
-                    // If branch is exactly 'eros', skip prerelease tags
-                    if (branchLower == "eros" && tagLower.Contains("develop"))
-                    {
-                        _logger.Debug($"Skipping prerelease {release.tag_name} for stable branch {branch}.");
-                        continue;
-                    }
-
-                    // If branch contains 'develop', skip tags with 'release' and vice versa
-                    if (branchLower.Contains("develop") && !tagLower.Contains("develop"))
-                    {
-                        _logger.Debug($"Skipping release {release.tag_name} because it is a release tag and branch is {branch}.");
-                        continue;
-                    }
-                }
-
-                if (release.assets == null)
-                {
-                    _logger.Debug($"Release {release.tag_name} has no package assets, skipping.");
-                    continue;
-                }
-
-                // Prefer .tar.gz for Osx, fallback to .zip/.app
-                GithubAsset asset = null;
-                if (OsInfo.Os == Os.Osx)
-                {
-                    asset = release.assets.FirstOrDefault(a =>
-                        a.name.Contains(osAssetString, StringComparison.OrdinalIgnoreCase) &&
-                        a.name.Contains(arch, StringComparison.OrdinalIgnoreCase) &&
-                        a.name.EndsWith(".tar.gz", StringComparison.OrdinalIgnoreCase));
-                    if (asset == null)
-                    {
-                        asset = release.assets.FirstOrDefault(a =>
-                            a.name.Contains(osAssetString, StringComparison.OrdinalIgnoreCase) &&
-                            a.name.Contains(arch, StringComparison.OrdinalIgnoreCase) &&
-                            (a.name.EndsWith(".zip", StringComparison.OrdinalIgnoreCase) || a.name.EndsWith(".app", StringComparison.OrdinalIgnoreCase)));
-                    }
-                }
-                else if (OsInfo.Os == Os.Windows)
-                {
-                    asset = release.assets.FirstOrDefault(a =>
-                        a.name.Contains(osAssetString, StringComparison.OrdinalIgnoreCase) &&
-                        a.name.Contains(arch, StringComparison.OrdinalIgnoreCase) &&
-                        a.name.EndsWith(".zip", StringComparison.OrdinalIgnoreCase));
-                }
-                else if (OsInfo.Os == Os.Linux)
-                {
-                    // Exclude musl assets for non-musl Linux: "linux" matches "linux-musl-x64" too
-                    asset = release.assets.FirstOrDefault(a =>
-                        a.name.Contains(osAssetString, StringComparison.OrdinalIgnoreCase) &&
-                        a.name.Contains(arch, StringComparison.OrdinalIgnoreCase) &&
-                        !a.name.Contains("musl", StringComparison.OrdinalIgnoreCase));
-                }
-                else
-                {
-                    asset = release.assets.FirstOrDefault(a =>
-                        a.name.Contains(osAssetString, StringComparison.OrdinalIgnoreCase) &&
-                        a.name.Contains(arch, StringComparison.OrdinalIgnoreCase));
-                }
-
+                asset = release.assets.FirstOrDefault(a =>
+                    a.name.Contains(osAssetString, StringComparison.OrdinalIgnoreCase) &&
+                    a.name.Contains(arch, StringComparison.OrdinalIgnoreCase) &&
+                    a.name.EndsWith(".tar.gz", StringComparison.OrdinalIgnoreCase));
                 if (asset == null)
                 {
-                    _logger.Debug("No asset found for release {0} matching OS asset string '{1}' and arch '{2}'",
-                        release.tag_name,
-                        osAssetString,
-                        arch);
-                    continue;
+                    asset = release.assets.FirstOrDefault(a =>
+                        a.name.Contains(osAssetString, StringComparison.OrdinalIgnoreCase) &&
+                        a.name.Contains(arch, StringComparison.OrdinalIgnoreCase) &&
+                        (a.name.EndsWith(".zip", StringComparison.OrdinalIgnoreCase) || a.name.EndsWith(".app", StringComparison.OrdinalIgnoreCase)));
                 }
-
-                _logger.Debug($"Found update: {release.tag_name} - {asset.name}");
-                var tag = release.tag_name.TrimStart('v');
-
-                // Attempt to strip "what's new", as it's repetitive in our UI
-                var body = release?.body != null
-                    ? Regex.Replace(release.body, @"^## What's Changed\s*\r?\n", "", RegexOptions.Multiline, RegexDefaults.Timeout)
-                    : string.Empty;
-
-                // Strip out lines that are not New: or Fix:
-                body = string.Join("\n",
-                    body.Split('\n')
-                        .Where(line => line.StartsWith("- New", StringComparison.OrdinalIgnoreCase) ||
-                                       line.StartsWith("- Fix", StringComparison.OrdinalIgnoreCase))
-                        .Select(line => line.Trim()));
-
-                var version = SemVersion.Parse(tag);
-                if (version == null)
-                {
-                    _logger.Warn("Could not parse semver from tag '{0}' (parsed: '{1}'). Skipping this release.",
-                        release.tag_name,
-                        tag);
-                    continue;
-                }
-
-                var semverVersion = version;
-                packages.Add(new UpdatePackage
-                {
-                    Version = semverVersion,
-                    ReleaseDate = release.published_at,
-                    FileName = asset.name,
-                    Url = asset.browser_download_url,
-                    Changes = new UpdateChanges { New = new List<string> { body } },
-                    Hash = asset.digest.Replace("sha256:", "", StringComparison.OrdinalIgnoreCase),
-                    Branch = branch
-                });
+            }
+            else if (OsInfo.Os == Os.Windows)
+            {
+                asset = release.assets.FirstOrDefault(a =>
+                    a.name.Contains(osAssetString, StringComparison.OrdinalIgnoreCase) &&
+                    a.name.Contains(arch, StringComparison.OrdinalIgnoreCase) &&
+                    a.name.EndsWith(".zip", StringComparison.OrdinalIgnoreCase));
+            }
+            else if (OsInfo.Os == Os.Linux)
+            {
+                // Exclude musl assets for non-musl Linux: "linux" matches "linux-musl-x64" too
+                asset = release.assets.FirstOrDefault(a =>
+                    a.name.Contains(osAssetString, StringComparison.OrdinalIgnoreCase) &&
+                    a.name.Contains(arch, StringComparison.OrdinalIgnoreCase) &&
+                    !a.name.Contains("musl", StringComparison.OrdinalIgnoreCase));
+            }
+            else
+            {
+                asset = release.assets.FirstOrDefault(a =>
+                    a.name.Contains(osAssetString, StringComparison.OrdinalIgnoreCase) &&
+                    a.name.Contains(arch, StringComparison.OrdinalIgnoreCase));
             }
 
-            _logger.Debug($"Total updates found: {packages.Count}");
-            return packages;
+            if (asset == null)
+            {
+                _logger.Debug("No asset found for release {0} matching OS asset string '{1}' and arch '{2}'",
+                    release.tag_name,
+                    osAssetString,
+                    arch);
+                return false;
+            }
+
+            _logger.Debug($"Found update: {release.tag_name} - {asset.name}");
+            var tag = release.tag_name.TrimStart('v');
+
+            // Attempt to strip "what's new", as it's repetitive in our UI
+            var body = release.body != null
+                ? Regex.Replace(release.body, @"^## What's Changed\s*\r?\n", "", RegexOptions.Multiline, RegexDefaults.Timeout)
+                : string.Empty;
+
+            // Strip out lines that are not New: or Fix:
+            body = string.Join("\n",
+                body.Split('\n')
+                    .Where(line => line.StartsWith("- New", StringComparison.OrdinalIgnoreCase) ||
+                                   line.StartsWith("- Fix", StringComparison.OrdinalIgnoreCase))
+                    .Select(line => line.Trim()));
+
+            var version = SemVersion.Parse(tag);
+            if (version == null)
+            {
+                _logger.Warn("Could not parse semver from tag '{0}' (parsed: '{1}'). Skipping this release.",
+                    release.tag_name,
+                    tag);
+                return false;
+            }
+
+            // A chore-only release filters down to nothing. Leave the list empty rather than
+            // handing the UI a single empty string: the "What's new?" modal decides whether
+            // to show its maintenance-release fallback by looking at the length of this list,
+            // and a one-element list of "" reads as real content and renders blank.
+            var changes = new UpdateChanges();
+
+            if (!string.IsNullOrWhiteSpace(body))
+            {
+                changes.New = new List<string> { body };
+            }
+
+            package = new UpdatePackage
+            {
+                Version = version,
+                ReleaseDate = release.published_at,
+                FileName = asset.name,
+                Url = asset.browser_download_url,
+                Changes = changes,
+                Hash = asset.digest?.Replace("sha256:", "", StringComparison.OrdinalIgnoreCase),
+                Branch = branch
+            };
+
+            return true;
         }
 
         /// <summary> Converts a GitHub release version string to a .NET Version object.</summary>
@@ -287,6 +441,12 @@ namespace NzbDrone.Core.Update
         {
             /// <summary>The tag name of the release.</summary>
             public string tag_name { get; set; }
+
+            /// <summary>Whether GitHub marks this release as a prerelease. Develop builds set this.</summary>
+            public bool prerelease { get; set; }
+
+            /// <summary>Whether the release is still a draft and should never be offered.</summary>
+            public bool draft { get; set; }
 
             /// <summary>The body/description of the release.</summary>
             public string body { get; set; }


### PR DESCRIPTION
#### Database Migration

NO

#### Description

Two faults in the same update path.

**Stable installs could not see updates at all.** `GetRecentUpdates` asked GitHub for 25
releases and dropped anything tagged `develop` — but `eros-develop` publishes a release per
merge, so all 25 were prereleases, every one was skipped, and the check logged *"No update
found from GitHub releases"*. The newest stable release is currently **41st** in the list,
and that gap grows with every merge, so no fixed page size fixes it.

`GET /releases` has no server-side filter for this (only `per_page`/`page`), but
`/releases/latest` returns the newest non-draft, non-prerelease release — exactly the split
here, since every develop build is already flagged `prerelease`. The stable branch now asks
for that directly, in one request, falling back to the list if the repo has no stable
release yet. The response shape is identical to an element of the list, so the existing DTO
is reused and per-release handling is shared through `TryBuildPackage` rather than
duplicated.

Filtering now uses GitHub's `prerelease` and `draft` flags, keeping the tag match as a
fallback. `GetRecentUpdates` pages, capped at 3 pages and 25 packages — unauthenticated
GitHub allows 60 requests/hour per IP and this runs on *every* load of System → Updates, and
the package cap stops that page growing to a full page of develop builds. A failure on a
later page returns what was collected instead of discarding the list.

**Whisparr/Whisparr#1125 — blank "What's new?".** A release with no `- New`/`- Fix` lines
produced `New = [""]`, a one-element list holding an empty string. The modal decides whether
to show its maintenance-release line from that list's length, so it read as real content and
rendered blank. The provider now leaves the list empty, and `mergeUpdates` ignores blank
entries so the modal is right against an older backend too. `Updates.tsx` has always
filtered blank lines; the modal never did, which is why only the modal was affected.

**Verified** against the live repo on both branches:

| | Before | After |
| --- | --- | --- |
| `Branch=eros`, `/api/v3/update` | **0 updates** | 4 updates, 1 request |
| `Branch=eros`, update check | *"No update found"* | `/releases/latest` → `3.3.8-release.1097`, 1 request |
| `Branch=eros-develop` | 25 updates | 25 updates (capped), 1 request, nothing stable leaked |

For Whisparr/Whisparr-Eros#847, driven in a browser: with `changes.new = [""]` the modal now renders
*"Maintenance Release: Bug fixes and other improvements. See the commits on GitHub"* with a
working commits link, and a real changelog still renders "What's new?" unchanged. The live
API now returns `{"new": [], "fixed": []}` for chore-only releases.

11 tests, including one that reproduces each bug against today's code.

#### Todos

- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)

#### Issues Fixed or Closed by this PR

- Fixes Whisparr/Whisparr-Eros#847
