### PR TITLE
new: release year naming token on scene

### DIFF
--- a/frontend/src/Settings/MediaManagement/Naming/NamingModal.tsx
+++ b/frontend/src/Settings/MediaManagement/Naming/NamingModal.tsx
@@ -195,6 +195,7 @@ const sceneTokens = [
   },
 
   { token: '{Release Date}', example: '2009-02-04' },
+  { token: '{Release Year}', example: '2009' },
   { token: '{Release ShortDate}', example: '09 02 04' },
   { token: '{Scene Code}', example: '12345' },
 ];
@@ -346,7 +347,7 @@ function NamingModal(props: NamingModalProps) {
   return (
     <Modal isOpen={isOpen} onModalClose={onModalClose}>
       <ModalContent onModalClose={onModalClose}>
-        <ModalHeader>{translate('movieFileNameTokens')}</ModalHeader>
+        <ModalHeader>{translate('FileNameTokens')}</ModalHeader>
 
         <ModalBody>
           <div className={styles.namingSelectContainer}>

--- a/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/FileNameBuilderFixture.cs
+++ b/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/FileNameBuilderFixture.cs
@@ -198,6 +198,46 @@ namespace NzbDrone.Core.Test.OrganizerTests.FileNameBuilderTests
         }
 
         [Test]
+        public void scene_release_year_format()
+        {
+            _scene.MovieMetadata.Value.Year = 0; // SkyHook only populates the year for movies
+            _namingConfig.StandardSceneFormat = "{Studio Title} - {Release-Year} - {Scene Title}";
+
+            Subject.BuildFileName(_scene, _movieFile)
+                .Should().Be("Pure Taboo - 2025 - The Last Train Home");
+        }
+
+        [Test]
+        public void scene_release_year_uses_metadata_year_when_available()
+        {
+            _scene.MovieMetadata.Value.Year = 1998;
+            _namingConfig.StandardSceneFormat = "{Release Year}";
+
+            Subject.BuildFileName(_scene, _movieFile)
+                .Should().Be("1998");
+        }
+
+        [Test]
+        public void scene_release_year_empty_when_no_release_date_or_year()
+        {
+            _scene.MovieMetadata.Value.Year = 0;
+            _scene.MovieMetadata.Value.ReleaseDate = null;
+            _namingConfig.StandardSceneFormat = "{Studio Title} - {Release-Year}";
+
+            Subject.BuildFileName(_scene, _movieFile)
+                .Should().Be("Pure Taboo");
+        }
+
+        [Test]
+        public void scene_folder_release_year_format()
+        {
+            _namingConfig.SceneFolderFormat = "{Studio Title}/{Release Year}";
+
+            Subject.GetMovieFolder(_scene, _namingConfig)
+                .Should().Be(Path.Combine("Pure Taboo", "2025"));
+        }
+
+        [Test]
         public void scene_performers_format()
         {
             _namingConfig.StandardSceneFormat = "{Studio Title} - {Release-Date} - {Scene Title} [{Scene Performers}]";

--- a/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
@@ -173,7 +173,7 @@ namespace NzbDrone.Core.Organizer
                 AddSceneTitlePlaceholderTokens(tokenHandlers, movie);
             }
 
-            AddReleaseDateTokens(tokenHandlers, movie.Year);
+            AddReleaseDateTokens(tokenHandlers, movie);
             AddIdTokens(tokenHandlers, movie);
             AddQualityTokens(tokenHandlers, movie, movieFile);
             AddMediaInfoTokens(tokenHandlers, movieFile);
@@ -252,7 +252,7 @@ namespace NzbDrone.Core.Organizer
             }
 
             AddStudioTokens(tokenHandlers, movie);
-            AddReleaseDateTokens(tokenHandlers, movie.Year);
+            AddReleaseDateTokens(tokenHandlers, movie);
             AddIdTokens(tokenHandlers, movie);
 
             var splitPatterns = pattern.Split(new char[] { '\\', '/' }, StringSplitOptions.RemoveEmptyEntries);
@@ -546,15 +546,34 @@ namespace NzbDrone.Core.Organizer
             }
         }
 
-        private void AddReleaseDateTokens(Dictionary<string, Func<TokenMatch, string>> tokenHandlers, int releaseYear)
+        private void AddReleaseDateTokens(Dictionary<string, Func<TokenMatch, string>> tokenHandlers, Movie movie)
         {
+            var releaseYear = GetReleaseYear(movie);
+
             if (releaseYear == 0)
             {
                 tokenHandlers["{Release Year}"] = m => string.Empty;
                 return;
             }
 
-            tokenHandlers["{Release Year}"] = m => string.Format("{0}", releaseYear.ToString()); // Do I need m.CustomFormat?
+            tokenHandlers["{Release Year}"] = m => releaseYear.ToString(CultureInfo.InvariantCulture);
+        }
+
+        private static int GetReleaseYear(Movie movie)
+        {
+            // The SkyHook metadata source only populates the year for movies, so scenes can
+            // have a release date but no year. Derive it from the release date in that case.
+            if (movie.Year > 1800)
+            {
+                return movie.Year;
+            }
+
+            if (DateTime.TryParse(movie.MovieMetadata.Value.ReleaseDate, out var parsedReleaseDate))
+            {
+                return parsedReleaseDate.Year;
+            }
+
+            return 0;
         }
 
         private void AddIdTokens(Dictionary<string, Func<TokenMatch, string>> tokenHandlers, Movie movie)


### PR DESCRIPTION
Adds {Release Year} as a valid file/folder token for scene naming.

#### Database Migration

NO

#### Screenshot(s) (if UI related)

<details>
<!-- paste screenshots below here.-->

<!-- paste screenshots above here.  MAKE SURE THE ARE SFW -->
</details>

#### Todos

- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)

#### Issues Fixed or Closed by this PR

<!-- If multiple, put each on a separate line -->

- Fixes whisparr/whisparr#1103
