### PR TITLE
Radarr 2026-03: contain HTTP file mappers, locale-safe URL parsing, Inno Setup URL

### DIFF
--- a/.github/upstream/state.json
+++ b/.github/upstream/state.json
@@ -5,8 +5,8 @@
       "repo": "Radarr/Radarr",
       "branch": "develop",
       "owns": "backend",
-      "highWater": "89110c2cc8ec671d718cf34acc845f66d475a427",
-      "highWaterNote": "2025-12-29 'version bump to 6.1.1'. Every Radarr develop commit from 2025-10-01 through this point is dispositioned (2026-01 and 2026-02 had no upstream commits at all), so the pointer is safe to sit here. Advance it only when everything at or before the new mark is settled."
+      "highWater": "4b85fab05bc37a51c2e673673d9cabd4113fedd8",
+      "highWaterNote": "2026-03-29 'Fixed: Downloading backups when path contains a trailing slash'. Everything on Radarr develop from 2025-10-01 through this point is dispositioned. Advance only when everything at or before the new mark is settled."
     },
     "sonarr": {
       "repo": "Sonarr/Sonarr",
@@ -125,6 +125,60 @@
         "month": "2025-10",
         "disposition": "adapt",
         "reason": "Upstream's restructure (handler moved into MovieIndexPosterSelect, overlay 36px->100%, linkProps dropped) is Redux-era Radarr shape we deliberately do not follow. Took only the URL fix it carries: our ctrl/cmd-click built '/movie/${foreignId}' with no url base and the wrong identifier, while the normal link uses titleSlug. Now '${window.Whisparr.urlBase}/movie/${titleSlug}'."
+      },
+      "1a2b90bf3660cb937042b9fb12ce5e24a0d67bbb": {
+        "subject": "Improve HTTP file mappers",
+        "month": "2026-03",
+        "disposition": "adapt",
+        "reason": "Path-traversal containment, not the refactor the subject suggests: Map() now resolves the full path and returns null if it escapes a new abstract FolderPath. Adapted to our tree, which has no UrlBaseReplacementResourceMapperBase and keeps HtmlPath/UrlBase as fields. Verified against the live 6969 instance first - not currently exploitable, ASP.NET normalises every vector before routing and a canary above appdata returns 404 - so this is defence in depth, not a live bug fix."
+      },
+      "4b85fab05bc37a51c2e673673d9cabd4113fedd8": {
+        "subject": "Fixed: Downloading backups when path contains a trailing slash",
+        "month": "2026-03",
+        "disposition": "pick",
+        "reason": "Follow-up to the containment change: a backup folder configured with a trailing separator would otherwise fail the FolderPath prefix check. Only meaningful once 1a2b90bf3 is in."
+      },
+      "1ce378356645c21dcb3fb9d583958aa778263f84": {
+        "subject": "Fixed: Parsing URLs on some systems due to Locale",
+        "month": "2026-03",
+        "disposition": "adapt",
+        "reason": "Real bug: RegexOptions.IgnoreCase without CultureInvariant uses the current culture, so under tr-TR the host class [-_A-Z0-9.] stops matching a lowercase i. Took RegexOptions.CultureInvariant rather than upstream's switch to [GeneratedRegex], which would mean dropping our RegexDefaults.Timeout convention."
+      },
+      "8ae71b54a784ec333d37dc2d62a22ab3c9825214": {
+        "subject": "chore: Fix innosetup download URI",
+        "month": "2026-03",
+        "disposition": "adapt",
+        "reason": "files.jrsoftware.org/is/6/innosetup-6.2.2.exe is a live 404; the GitHub releases URL returns 200 (both checked). Took only the URL line, kept our INNOVERSION default that upstream's version drops, and left their whitespace churn."
+      },
+      "7885404c2c2a850365c42608720f551aab9d180a": {
+        "subject": "Bump ImageSharp to 3.1.12",
+        "month": "2026-03",
+        "disposition": "have",
+        "reason": "Whisparr.Core.csproj already references SixLabors.ImageSharp 3.1.12 - the same version."
+      },
+      "7062b3a1786d8825648ef70a277a29233b85e118": {
+        "subject": "Bump MailKit to 4.15.1",
+        "month": "2026-03",
+        "disposition": "have",
+        "reason": "Whisparr.Core.csproj is on MailKit 4.17.0, ahead of upstream's 4.15.1."
+      },
+      "f1513ca39e7179030eb84ac3769bdc6e41b9c05b": {
+        "subject": "Multiple Translations updated by Weblate",
+        "month": "2026-03",
+        "disposition": "skip",
+        "reason": "Weblate-generated translation files. Ours come from our own Weblate project, never from upstream cherry-picks."
+      },
+      "cf0d6b014222a6424bae52dbbb55849a6f874d2f": {
+        "subject": "Chore: Sonar Cloud version bump",
+        "month": "2026-03",
+        "disposition": "skip",
+        "reason": "Touches azure-pipelines.yml only. Our Sonar setup lives in .github/workflows/sonarqube.yml."
+      },
+      "079e2136ee6d3b579329f18deaf2e59ed20d93ee": {
+        "subject": "version bump to 6.1.2",
+        "month": "2026-03",
+        "disposition": "skip",
+        "reason": "Touches azure-pipelines.yml only. We do not have that file and version independently of Radarr."
       }
     },
     "sonarr": {}

--- a/UPSTREAM_SYNC.md
+++ b/UPSTREAM_SYNC.md
@@ -7,30 +7,17 @@ See `.github/upstream/state.json` for the machine state and the `sync-upstream` 
 
 ## radarr — Radarr/Radarr `develop`
 
-Owns: **backend**. High-water mark: `89110c2cc8`.
+Owns: **backend**. High-water mark: `4b85fab05b`.
 
-**82 outstanding.**
+**73 outstanding.**
 
 | Month | Total | be | fe | be+fe | chore |
 | --- | ---: | ---: | ---: | ---: | ---: |
-| 2026-03 | 9 | 6 | 0 | 0 | 3 |
 | 2026-04 | 6 | 4 | 0 | 0 | 2 |
 | 2026-05 | 12 | 10 | 0 | 0 | 2 |
 | 2026-06 | 5 | 4 | 0 | 0 | 1 |
 | 2026-07 | 18 | 15 | 0 | 0 | 3 |
 | 2026-08 | 32 | 18 | 8 | 4 | 2 |
-
-### 2026-03
-
-- `be   ` [`1a2b90bf3`](https://github.com/Radarr/Radarr/commit/1a2b90bf3660cb937042b9fb12ce5e24a0d67bbb) Improve HTTP file mappers — *Mark McDowall*
-- `be   ` [`1ce378356`](https://github.com/Radarr/Radarr/commit/1ce378356645c21dcb3fb9d583958aa778263f84) Fixed: Parsing URLs on some systems due to Locale — *Bogdan*
-- `be   ` [`7885404c2`](https://github.com/Radarr/Radarr/commit/7885404c2c2a850365c42608720f551aab9d180a) Bump ImageSharp to 3.1.12 — *Auggie*
-- `be   ` [`7062b3a17`](https://github.com/Radarr/Radarr/commit/7062b3a1786d8825648ef70a277a29233b85e118) Bump MailKit to 4.15.1 — *Auggie*
-- `be   ` [`f1513ca39`](https://github.com/Radarr/Radarr/commit/f1513ca39e7179030eb84ac3769bdc6e41b9c05b) Multiple Translations updated by Weblate — *Weblate*
-- `chore` [`cf0d6b014`](https://github.com/Radarr/Radarr/commit/cf0d6b014222a6424bae52dbbb55849a6f874d2f) Chore: Sonar Cloud version bump — *RobinDadswell*
-- `chore` [`079e2136e`](https://github.com/Radarr/Radarr/commit/079e2136ee6d3b579329f18deaf2e59ed20d93ee) version bump to 6.1.2 — *RobinDadswell*
-- `chore` [`8ae71b54a`](https://github.com/Radarr/Radarr/commit/8ae71b54a784ec333d37dc2d62a22ab3c9825214) chore: Fix innosetup download URI — *Auggie*
-- `be   ` [`4b85fab05`](https://github.com/Radarr/Radarr/commit/4b85fab05bc37a51c2e673673d9cabd4113fedd8) Fixed: Downloading backups when path contains a trailing slash — *Mark McDowall*
 
 ### 2026-04
 
@@ -226,3 +213,12 @@ Commits reviewed and dispositioned. Skips carry their reason.
 | [`4c0072918`](https://github.com/Radarr/Radarr/commit/4c007291833246d3ed78e6f396fc7e60cc9ca70c) | Fix: (#11303) collection API error when using `Movie CollectionThe` (#11304) | `skip` | Fixes the {Movie CollectionThe} token, which we do not have. Bug cannot reproduce here. Separately surfaced that our {Movie Collection} token is advertised in NamingModal.tsx but has no FileNameBuilder handler - filed on its own, not fixed here. |
 | [`a12683502`](https://github.com/Radarr/Radarr/commit/a12683502849fdc739b0e41505905a38aa416e90) | New: Parse Group GiLG | `skip` | Parser change under the skip-by-default rule. Would reproduce (our ExceptionReleaseGroupRegex matches upstream's pre-change form), but GiLG is a movie-scene release group we do not need to carry. |
 | [`89110c2cc`](https://github.com/Radarr/Radarr/commit/89110c2cc8ec671d718cf34acc845f66d475a427) | version bump to 6.1.1 | `skip` | Touches azure-pipelines.yml only. We do not have that file; we build on GitHub Actions. |
+| [`1a2b90bf3`](https://github.com/Radarr/Radarr/commit/1a2b90bf3660cb937042b9fb12ce5e24a0d67bbb) | Improve HTTP file mappers | `adapt` | Path-traversal containment, not the refactor the subject suggests: Map() now resolves the full path and returns null if it escapes a new abstract FolderPath. Adapted to our tree, which has no UrlBaseReplacementResourceMapperBase and keeps HtmlPath/UrlBase as fields. Verified against the live 6969 instance first - not currently exploitable, ASP.NET normalises every vector before routing and a canary above appdata returns 404 - so this is defence in depth, not a live bug fix. |
+| [`4b85fab05`](https://github.com/Radarr/Radarr/commit/4b85fab05bc37a51c2e673673d9cabd4113fedd8) | Fixed: Downloading backups when path contains a trailing slash | `pick` | Follow-up to the containment change: a backup folder configured with a trailing separator would otherwise fail the FolderPath prefix check. Only meaningful once 1a2b90bf3 is in. |
+| [`1ce378356`](https://github.com/Radarr/Radarr/commit/1ce378356645c21dcb3fb9d583958aa778263f84) | Fixed: Parsing URLs on some systems due to Locale | `adapt` | Real bug: RegexOptions.IgnoreCase without CultureInvariant uses the current culture, so under tr-TR the host class [-_A-Z0-9.] stops matching a lowercase i. Took RegexOptions.CultureInvariant rather than upstream's switch to [GeneratedRegex], which would mean dropping our RegexDefaults.Timeout convention. |
+| [`8ae71b54a`](https://github.com/Radarr/Radarr/commit/8ae71b54a784ec333d37dc2d62a22ab3c9825214) | chore: Fix innosetup download URI | `adapt` | files.jrsoftware.org/is/6/innosetup-6.2.2.exe is a live 404; the GitHub releases URL returns 200 (both checked). Took only the URL line, kept our INNOVERSION default that upstream's version drops, and left their whitespace churn. |
+| [`7885404c2`](https://github.com/Radarr/Radarr/commit/7885404c2c2a850365c42608720f551aab9d180a) | Bump ImageSharp to 3.1.12 | `have` | Whisparr.Core.csproj already references SixLabors.ImageSharp 3.1.12 - the same version. |
+| [`7062b3a17`](https://github.com/Radarr/Radarr/commit/7062b3a1786d8825648ef70a277a29233b85e118) | Bump MailKit to 4.15.1 | `have` | Whisparr.Core.csproj is on MailKit 4.17.0, ahead of upstream's 4.15.1. |
+| [`f1513ca39`](https://github.com/Radarr/Radarr/commit/f1513ca39e7179030eb84ac3769bdc6e41b9c05b) | Multiple Translations updated by Weblate | `skip` | Weblate-generated translation files. Ours come from our own Weblate project, never from upstream cherry-picks. |
+| [`cf0d6b014`](https://github.com/Radarr/Radarr/commit/cf0d6b014222a6424bae52dbbb55849a6f874d2f) | Chore: Sonar Cloud version bump | `skip` | Touches azure-pipelines.yml only. Our Sonar setup lives in .github/workflows/sonarqube.yml. |
+| [`079e2136e`](https://github.com/Radarr/Radarr/commit/079e2136ee6d3b579329f18deaf2e59ed20d93ee) | version bump to 6.1.2 | `skip` | Touches azure-pipelines.yml only. We do not have that file and version independently of Radarr. |

--- a/build.sh
+++ b/build.sh
@@ -254,7 +254,8 @@ InstallInno()
     ProgressStart "Installing portable Inno Setup"
 
     rm -rf _inno
-    curl -s --output innosetup.exe "https://files.jrsoftware.org/is/6/innosetup-${INNOVERSION:-6.2.2}.exe"
+    local innoVersion="${INNOVERSION:-6.2.2}"
+    curl -s -L --output innosetup.exe "https://github.com/jrsoftware/issrc/releases/download/is-${innoVersion//./_}/innosetup-${innoVersion}.exe"
     mkdir _inno
     ./innosetup.exe //portable=1 //silent //currentuser //dir=.\\_inno
     rm innosetup.exe

--- a/src/NzbDrone.Api.Test/Frontend/Mappers/StaticResourceMapperBaseFixture.cs
+++ b/src/NzbDrone.Api.Test/Frontend/Mappers/StaticResourceMapperBaseFixture.cs
@@ -1,0 +1,96 @@
+using System.IO;
+using FluentAssertions;
+using NLog;
+using NUnit.Framework;
+using NzbDrone.Common.Disk;
+using NzbDrone.Test.Common;
+using Whisparr.Http.Frontend.Mappers;
+
+namespace NzbDrone.Api.Test.Frontend.Mappers
+{
+    [TestFixture]
+    public class StaticResourceMapperBaseFixture : TestBase
+    {
+        private string _folder;
+        private TestMapper _subject;
+
+        [SetUp]
+        public void Setup()
+        {
+            _folder = Path.Combine(Path.GetTempPath(), "whisparr_mapper_" + Path.GetRandomFileName());
+            Directory.CreateDirectory(_folder);
+
+            _subject = new TestMapper(_folder, Mocker.GetMock<IDiskProvider>().Object, LogManager.GetCurrentClassLogger());
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (Directory.Exists(_folder))
+            {
+                Directory.Delete(_folder, true);
+            }
+        }
+
+        [Test]
+        public void should_map_a_path_inside_the_folder()
+        {
+            _subject.Map("/resource/poster.jpg")
+                    .Should().Be(Path.Combine(_folder, "poster.jpg"));
+        }
+
+        [Test]
+        public void should_map_a_path_in_a_nested_folder()
+        {
+            _subject.Map("/resource/performer/1/headshot.jpg")
+                    .Should().Be(Path.Combine(_folder, "performer", "1", "headshot.jpg"));
+        }
+
+        [TestCase("/resource/../escaped.txt")]
+        [TestCase("/resource/../../escaped.txt")]
+        [TestCase("/resource/nested/../../escaped.txt")]
+        public void should_return_null_when_the_path_escapes_the_folder(string resourceUrl)
+        {
+            _subject.Map(resourceUrl).Should().BeNull();
+        }
+
+        [Test]
+        public void should_return_null_for_a_sibling_folder_sharing_the_name_prefix()
+        {
+            // _folder + "-other" starts with the folder name but is not inside it.
+            _subject.Map("/resource/../" + Path.GetFileName(_folder) + "-other/escaped.txt")
+                    .Should().BeNull();
+        }
+
+        [Test]
+        public void should_return_null_when_the_folder_itself_is_requested()
+        {
+            _subject.Map("/resource/").Should().BeNull();
+        }
+
+        private sealed class TestMapper : StaticResourceMapperBase
+        {
+            private readonly string _folderPath;
+
+            public TestMapper(string folderPath, IDiskProvider diskProvider, Logger logger)
+                : base(diskProvider, logger)
+            {
+                _folderPath = folderPath;
+            }
+
+            protected override string FolderPath => _folderPath;
+
+            protected override string MapPath(string resourceUrl)
+            {
+                var path = resourceUrl.Replace("/resource/", "").Replace('/', Path.DirectorySeparatorChar);
+
+                return Path.Combine(_folderPath, path);
+            }
+
+            public override bool CanHandle(string resourceUrl)
+            {
+                return resourceUrl.StartsWith("/resource/");
+            }
+        }
+    }
+}

--- a/src/NzbDrone.Api.Test/Frontend/Mappers/StaticResourceMapperBaseFixture.cs
+++ b/src/NzbDrone.Api.Test/Frontend/Mappers/StaticResourceMapperBaseFixture.cs
@@ -1,6 +1,9 @@
 using System.IO;
+using System.Threading.Tasks;
 using FluentAssertions;
 using NLog;
+using NLog.Config;
+using NLog.Targets;
 using NUnit.Framework;
 using NzbDrone.Common.Disk;
 using NzbDrone.Test.Common;
@@ -66,6 +69,23 @@ namespace NzbDrone.Api.Test.Frontend.Mappers
         public void should_return_null_when_the_folder_itself_is_requested()
         {
             _subject.Map("/resource/").Should().BeNull();
+        }
+
+        [Test]
+        public async Task should_not_let_a_refused_url_forge_a_log_line()
+        {
+            var target = new MemoryTarget { Layout = "${message}" };
+            var config = new LoggingConfiguration();
+            config.AddRuleForAllLevels(target);
+
+            var factory = new LogFactory { Configuration = config };
+            var mapper = new TestMapper(_folder, Mocker.GetMock<IDiskProvider>().Object, factory.GetLogger("test"));
+
+            await mapper.GetResponse("/resource/../escaped.txt\r\nWARN  Forged log line");
+
+            target.Logs.Should().ContainSingle();
+            target.Logs[0].Should().NotContain("\r").And.NotContain("\n");
+            target.Logs[0].Should().Contain("Forged log line");
         }
 
         private sealed class TestMapper : StaticResourceMapperBase

--- a/src/NzbDrone.Common/Http/HttpUri.cs
+++ b/src/NzbDrone.Common/Http/HttpUri.cs
@@ -8,7 +8,7 @@ namespace NzbDrone.Common.Http
 {
     public class HttpUri : IEquatable<HttpUri>
     {
-        private static readonly Regex RegexUri = new Regex(@"^(?:(?<scheme>[a-z]+):)?(?://(?<host>[-_A-Z0-9.]+|\[[[A-F0-9:]+\])(?::(?<port>[0-9]{1,5}))?)?(?<path>(?:(?:(?<=^)|/+)[^/?#\r\n]+)+/*|/+)?(?:\?(?<query>[^#\r\n]*))?(?:\#(?<fragment>.*))?$", RegexOptions.Compiled | RegexOptions.IgnoreCase, RegexDefaults.Timeout);
+        private static readonly Regex RegexUri = new Regex(@"^(?:(?<scheme>[a-z]+):)?(?://(?<host>[-_A-Z0-9.]+|\[[[A-F0-9:]+\])(?::(?<port>[0-9]{1,5}))?)?(?<path>(?:(?:(?<=^)|/+)[^/?#\r\n]+)+/*|/+)?(?:\?(?<query>[^#\r\n]*))?(?:\#(?<fragment>.*))?$", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant, RegexDefaults.Timeout);
 
         private readonly string _uri;
         public string FullUri => _uri;

--- a/src/Whisparr.Http/Frontend/Mappers/BackupFileMapper.cs
+++ b/src/Whisparr.Http/Frontend/Mappers/BackupFileMapper.cs
@@ -15,7 +15,9 @@ namespace Whisparr.Http.Frontend.Mappers
             _backupService = backupService;
         }
 
-        public override string Map(string resourceUrl)
+        protected override string FolderPath => _backupService.GetBackupFolder().TrimEnd(Path.DirectorySeparatorChar);
+
+        protected override string MapPath(string resourceUrl)
         {
             var path = resourceUrl.Replace("/backup/", "").Replace('/', Path.DirectorySeparatorChar);
 

--- a/src/Whisparr.Http/Frontend/Mappers/BrowserConfig.cs
+++ b/src/Whisparr.Http/Frontend/Mappers/BrowserConfig.cs
@@ -18,7 +18,9 @@ namespace Whisparr.Http.Frontend.Mappers
             _configFileProvider = configFileProvider;
         }
 
-        public override string Map(string resourceUrl)
+        protected override string FolderPath => Path.Combine(_appFolderInfo.StartUpFolder, _configFileProvider.UiFolder);
+
+        protected override string MapPath(string resourceUrl)
         {
             var path = resourceUrl.Replace('/', Path.DirectorySeparatorChar);
             path = path.Trim(Path.DirectorySeparatorChar);

--- a/src/Whisparr.Http/Frontend/Mappers/CacheBreakerProvider.cs
+++ b/src/Whisparr.Http/Frontend/Mappers/CacheBreakerProvider.cs
@@ -37,6 +37,12 @@ namespace Whisparr.Http.Frontend.Mappers
 
             var mapper = _diskMappers.Single(m => m.CanHandle(resourceUrl));
             var pathToFile = mapper.Map(resourceUrl);
+
+            if (pathToFile == null)
+            {
+                return resourceUrl;
+            }
+
             var hash = _hashProvider.ComputeMd5(pathToFile).ToBase64();
 
             return resourceUrl + "?h=" + hash.Trim('=');

--- a/src/Whisparr.Http/Frontend/Mappers/FaviconMapper.cs
+++ b/src/Whisparr.Http/Frontend/Mappers/FaviconMapper.cs
@@ -18,7 +18,9 @@ namespace Whisparr.Http.Frontend.Mappers
             _configFileProvider = configFileProvider;
         }
 
-        public override string Map(string resourceUrl)
+        protected override string FolderPath => Path.Combine(_appFolderInfo.StartUpFolder, _configFileProvider.UiFolder);
+
+        protected override string MapPath(string resourceUrl)
         {
             var fileName = "favicon.ico";
 

--- a/src/Whisparr.Http/Frontend/Mappers/IndexHtmlMapper.cs
+++ b/src/Whisparr.Http/Frontend/Mappers/IndexHtmlMapper.cs
@@ -10,6 +10,7 @@ namespace Whisparr.Http.Frontend.Mappers
     public class IndexHtmlMapper : HtmlMapperBase
     {
         private readonly IConfigFileProvider _configFileProvider;
+        private readonly string _folderPath;
 
         public IndexHtmlMapper(IAppFolderInfo appFolderInfo,
                                IDiskProvider diskProvider,
@@ -20,11 +21,15 @@ namespace Whisparr.Http.Frontend.Mappers
         {
             _configFileProvider = configFileProvider;
 
-            HtmlPath = Path.Combine(appFolderInfo.StartUpFolder, _configFileProvider.UiFolder, "index.html");
+            _folderPath = Path.Combine(appFolderInfo.StartUpFolder, configFileProvider.UiFolder);
+
+            HtmlPath = Path.Combine(_folderPath, "index.html");
             UrlBase = configFileProvider.UrlBase;
         }
 
-        public override string Map(string resourceUrl)
+        protected override string FolderPath => _folderPath;
+
+        protected override string MapPath(string resourceUrl)
         {
             return HtmlPath;
         }

--- a/src/Whisparr.Http/Frontend/Mappers/LogFileMapper.cs
+++ b/src/Whisparr.Http/Frontend/Mappers/LogFileMapper.cs
@@ -16,7 +16,9 @@ namespace Whisparr.Http.Frontend.Mappers
             _appFolderInfo = appFolderInfo;
         }
 
-        public override string Map(string resourceUrl)
+        protected override string FolderPath => _appFolderInfo.GetLogFolder();
+
+        protected override string MapPath(string resourceUrl)
         {
             var path = resourceUrl.Replace('/', Path.DirectorySeparatorChar);
             path = Path.GetFileName(path);

--- a/src/Whisparr.Http/Frontend/Mappers/LoginHtmlMapper.cs
+++ b/src/Whisparr.Http/Frontend/Mappers/LoginHtmlMapper.cs
@@ -10,6 +10,7 @@ namespace Whisparr.Http.Frontend.Mappers
     public class LoginHtmlMapper : HtmlMapperBase
     {
         private readonly IConfigFileProvider _configFileProvider;
+        private readonly string _folderPath;
 
         public LoginHtmlMapper(IAppFolderInfo appFolderInfo,
                                IDiskProvider diskProvider,
@@ -19,11 +20,15 @@ namespace Whisparr.Http.Frontend.Mappers
             : base(diskProvider, cacheBreakProviderFactory, logger)
         {
             _configFileProvider = configFileProvider;
-            HtmlPath = Path.Combine(appFolderInfo.StartUpFolder, configFileProvider.UiFolder, "login.html");
+            _folderPath = Path.Combine(appFolderInfo.StartUpFolder, configFileProvider.UiFolder);
+
+            HtmlPath = Path.Combine(_folderPath, "login.html");
             UrlBase = configFileProvider.UrlBase;
         }
 
-        public override string Map(string resourceUrl)
+        protected override string FolderPath => _folderPath;
+
+        protected override string MapPath(string resourceUrl)
         {
             return HtmlPath;
         }

--- a/src/Whisparr.Http/Frontend/Mappers/ManifestMapper.cs
+++ b/src/Whisparr.Http/Frontend/Mappers/ManifestMapper.cs
@@ -18,7 +18,9 @@ namespace Whisparr.Http.Frontend.Mappers
             _configFileProvider = configFileProvider;
         }
 
-        public override string Map(string resourceUrl)
+        protected override string FolderPath => Path.Combine(_appFolderInfo.StartUpFolder, _configFileProvider.UiFolder);
+
+        protected override string MapPath(string resourceUrl)
         {
             var path = resourceUrl.Replace('/', Path.DirectorySeparatorChar);
             path = path.Trim(Path.DirectorySeparatorChar);

--- a/src/Whisparr.Http/Frontend/Mappers/MediaCoverMapper.cs
+++ b/src/Whisparr.Http/Frontend/Mappers/MediaCoverMapper.cs
@@ -23,7 +23,9 @@ namespace Whisparr.Http.Frontend.Mappers
             _diskProvider = diskProvider;
         }
 
-        public override string Map(string resourceUrl)
+        protected override string FolderPath => _appFolderInfo.GetAppDataPath();
+
+        protected override string MapPath(string resourceUrl)
         {
             var path = resourceUrl.Replace('/', Path.DirectorySeparatorChar);
             path = path.Trim(Path.DirectorySeparatorChar);

--- a/src/Whisparr.Http/Frontend/Mappers/RobotsTxtMapper.cs
+++ b/src/Whisparr.Http/Frontend/Mappers/RobotsTxtMapper.cs
@@ -18,7 +18,9 @@ namespace Whisparr.Http.Frontend.Mappers
             _configFileProvider = configFileProvider;
         }
 
-        public override string Map(string resourceUrl)
+        protected override string FolderPath => Path.Combine(_appFolderInfo.StartUpFolder, _configFileProvider.UiFolder);
+
+        protected override string MapPath(string resourceUrl)
         {
             var path = Path.Combine("Content", "robots.txt");
 

--- a/src/Whisparr.Http/Frontend/Mappers/StaticResourceMapper.cs
+++ b/src/Whisparr.Http/Frontend/Mappers/StaticResourceMapper.cs
@@ -18,7 +18,9 @@ namespace Whisparr.Http.Frontend.Mappers
             _configFileProvider = configFileProvider;
         }
 
-        public override string Map(string resourceUrl)
+        protected override string FolderPath => Path.Combine(_appFolderInfo.StartUpFolder, _configFileProvider.UiFolder);
+
+        protected override string MapPath(string resourceUrl)
         {
             var path = resourceUrl.Replace('/', Path.DirectorySeparatorChar);
             path = path.Trim(Path.DirectorySeparatorChar);

--- a/src/Whisparr.Http/Frontend/Mappers/StaticResourceMapperBase.cs
+++ b/src/Whisparr.Http/Frontend/Mappers/StaticResourceMapperBase.cs
@@ -27,13 +27,32 @@ namespace Whisparr.Http.Frontend.Mappers
             _caseSensitive = RuntimeInfo.IsProduction ? DiskProviderBase.PathStringComparison : StringComparison.OrdinalIgnoreCase;
         }
 
-        public abstract string Map(string resourceUrl);
+        protected abstract string FolderPath { get; }
+
+        protected abstract string MapPath(string resourceUrl);
 
         public abstract bool CanHandle(string resourceUrl);
+
+        // Resolve the mapped path and refuse anything that escapes FolderPath, so a
+        // crafted resource url cannot walk out of the folder the mapper owns.
+        public string Map(string resourceUrl)
+        {
+            var filePath = Path.GetFullPath(MapPath(resourceUrl));
+            var parentPath = Path.GetFullPath(FolderPath) + Path.DirectorySeparatorChar;
+
+            return filePath.StartsWith(parentPath, _caseSensitive) ? filePath : null;
+        }
 
         public Task<IActionResult> GetResponse(string resourceUrl)
         {
             var filePath = Map(resourceUrl);
+
+            if (filePath == null)
+            {
+                _logger.Warn("Resource {0} resolves outside of {1}", resourceUrl, FolderPath);
+
+                return Task.FromResult<IActionResult>(null);
+            }
 
             if (_diskProvider.FileExists(filePath, _caseSensitive))
             {

--- a/src/Whisparr.Http/Frontend/Mappers/StaticResourceMapperBase.cs
+++ b/src/Whisparr.Http/Frontend/Mappers/StaticResourceMapperBase.cs
@@ -8,6 +8,7 @@ using Microsoft.Net.Http.Headers;
 using NLog;
 using NzbDrone.Common.Disk;
 using NzbDrone.Common.EnvironmentInfo;
+using NzbDrone.Common.Extensions;
 
 namespace Whisparr.Http.Frontend.Mappers
 {
@@ -49,7 +50,7 @@ namespace Whisparr.Http.Frontend.Mappers
 
             if (filePath == null)
             {
-                _logger.Warn("Resource {0} resolves outside of {1}", resourceUrl, FolderPath);
+                _logger.Warn("Resource {0} resolves outside of {1}", ForLog(resourceUrl), FolderPath);
 
                 return Task.FromResult<IActionResult>(null);
             }
@@ -70,6 +71,25 @@ namespace Whisparr.Http.Frontend.Mappers
             _logger.Warn("File {0} not found", filePath);
 
             return Task.FromResult<IActionResult>(null);
+        }
+
+        // The resource url comes straight from the request, so strip anything that could
+        // forge a new log line before it reaches the log.
+        private static string ForLog(string resourceUrl)
+        {
+            if (resourceUrl.IsNullOrWhiteSpace())
+            {
+                return string.Empty;
+            }
+
+            var cleaned = new StringBuilder(resourceUrl.Length);
+
+            foreach (var c in resourceUrl)
+            {
+                cleaned.Append(char.IsControl(c) ? '_' : c);
+            }
+
+            return cleaned.ToString();
         }
 
         protected virtual Stream GetContentStream(string filePath)

--- a/src/Whisparr.Http/Frontend/Mappers/UpdateLogFileMapper.cs
+++ b/src/Whisparr.Http/Frontend/Mappers/UpdateLogFileMapper.cs
@@ -16,7 +16,9 @@ namespace Whisparr.Http.Frontend.Mappers
             _appFolderInfo = appFolderInfo;
         }
 
-        public override string Map(string resourceUrl)
+        protected override string FolderPath => _appFolderInfo.GetUpdateLogFolder();
+
+        protected override string MapPath(string resourceUrl)
         {
             var path = resourceUrl.Replace('/', Path.DirectorySeparatorChar);
             path = Path.GetFileName(path);


### PR DESCRIPTION
#### Database Migration

NO

#### Description

Radarr `develop` 2026-03: nine commits reviewed, three adapted, one picked, two already in our tree, three skipped. High-water mark advances to `4b85fab05` (2026-03-29); Radarr backlog 82 → 73.

**Contain HTTP file mappers to the folder they own** (radarr/radarr@1a2b90bf3 + @4b85fab05). Upstream's "Improve HTTP file mappers" is really path-traversal containment — `Map()` resolves the full path and returns null if it escapes a new abstract `FolderPath`. `MediaCoverMapper` was the weakest, checking only that the url started with `/MediaCover/` with no traversal filtering.

I tested the live instance before writing anything: none of the vectors reach the mapper. Plain `..` normalises to the SPA, encoded `..%2f` returns 404, and a canary file placed above appdata returns 404. **This is defence in depth, not a live bug fix** — it removes the dependency on ASP.NET normalisation being the only guard. Adapted rather than taken wholesale, since we have no `UrlBaseReplacementResourceMapperBase` and the HTML mappers keep `HtmlPath`/`UrlBase` as fields.

**Parse URLs correctly under locales with a dotless i** (radarr/radarr@1ce378356). `RegexOptions.IgnoreCase` without `CultureInvariant` folds case by current culture, so under tr-TR the host class `[-_A-Z0-9.]` stops matching a lowercase `i`. Took `CultureInvariant` rather than upstream's switch to `[GeneratedRegex]`, which would have dropped our `RegexDefaults.Timeout` convention.

**Fix the Inno Setup download URL** (radarr/radarr@8ae71b54a). `files.jrsoftware.org/is/6/innosetup-6.2.2.exe` is a live 404, so the Windows installer build silently downloaded an error page; the GitHub releases URL returns 200. Both checked. Kept our `${INNOVERSION:-6.2.2}` default, which upstream's version drops — theirs would build `is-/innosetup-.exe` with the variable unset.

Skipped: ImageSharp and MailKit bumps (we are at or ahead of both), Weblate translations, and two `azure-pipelines.yml`-only commits.

#### Todos

- [x] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)

Adds `StaticResourceMapperBaseFixture` — the mappers had no coverage at all. 5 of its 7 cases fail with the containment reverted, and one covers a sibling folder sharing a name prefix that a naive `StartsWith` would let through. No new user-facing strings, so no translation keys.

Verified: solution builds with 0 warnings (`TreatWarningsAsErrors` is on), Api.Test 27/27, Common.Test 570 passed / 39 skipped.

#### Issues Fixed or Closed by this PR

<!-- none -->
