### PR TITLE
Radarr 2026-04: fix SizeSuffix stack overflow, log media info quality title

### DIFF
--- a/.github/upstream/state.json
+++ b/.github/upstream/state.json
@@ -5,8 +5,8 @@
       "repo": "Radarr/Radarr",
       "branch": "develop",
       "owns": "backend",
-      "highWater": "4b85fab05bc37a51c2e673673d9cabd4113fedd8",
-      "highWaterNote": "2026-03-29 'Fixed: Downloading backups when path contains a trailing slash'. Everything on Radarr develop from 2025-10-01 through this point is dispositioned. Advance only when everything at or before the new mark is settled."
+      "highWater": "0134fdedcaff8eaeb6baaeee95e873a2b4881221",
+      "highWaterNote": "2026-04-29 'Prevent overflow exception for big numbers in SizeSuffix and Fluent.Round'. Everything on Radarr develop from 2025-10-01 through this point is dispositioned. Advance only when everything at or before the new mark is settled."
     },
     "sonarr": {
       "repo": "Sonarr/Sonarr",
@@ -179,6 +179,42 @@
         "month": "2026-03",
         "disposition": "skip",
         "reason": "Touches azure-pipelines.yml only. We do not have that file and version independently of Radarr."
+      },
+      "331ce4579ce2f3d7cb06d82c0e62c42148acacb8": {
+        "subject": "Close issues that don't follow issue templates",
+        "month": "2026-04",
+        "disposition": "skip",
+        "reason": "Adds .github/workflows/close_invalid_issues.yml, which auto-closes issues that do not follow the templates. Declined deliberately, not for lack of the file: we are not seeing template compliance problems, so the workflow would only add a way to close reporters' issues automatically. Revisit only if that changes."
+      },
+      "662324775ed72ea39589a2a8f9d7ffec39bca644": {
+        "subject": "version bump to 6.2.0",
+        "month": "2026-04",
+        "disposition": "skip",
+        "reason": "Touches azure-pipelines.yml only. We do not have that file and version independently of Radarr."
+      },
+      "92268767921bddd1625c6acb80b704464b5feb0a": {
+        "subject": "Bump MailKit to 4.16.0",
+        "month": "2026-04",
+        "disposition": "have",
+        "reason": "Whisparr.Core.csproj is on MailKit 4.17.0, ahead of upstream's 4.16.0."
+      },
+      "ece044e2701d0269e36e458572f48816e5293654": {
+        "subject": "Log media info title used to augment quality",
+        "month": "2026-04",
+        "disposition": "adapt",
+        "reason": "Took the debug log and the single null-safe Trim in AugmentQualityFromMediaInfo. Our version of the file has far more resolution tiers (8K, 6K RED, 6K Blackmagic, 5K) than upstream's, so only the title handling was portable."
+      },
+      "7dd5365ccd5130b62b98f4bef9bfd69d7721aebc": {
+        "subject": "Fixed: Include quality modifier when augmenting quality from media info",
+        "month": "2026-04",
+        "disposition": "skip",
+        "reason": "Not adaptable: our quality model has no Modifier concept at all. There is no Modifier enum under Qualities/, AugmentQualityResult carries no Modifier property, AggregateQuality tracks no modifier, and QualityFinder.FindBySourceAndResolution takes only (source, resolution). Introducing one would be a quality-matching design change, not a sync - and matching is not somewhere to make drive-by changes."
+      },
+      "0134fdedcaff8eaeb6baaeee95e873a2b4881221": {
+        "subject": "Prevent overflow exception for big numbers in SizeSuffix and Fluent.Round",
+        "month": "2026-04",
+        "disposition": "pick",
+        "reason": "Real crash, not a rounding nit: SizeSuffix(long.MinValue) negated to itself and recursed forever. Reproduced here - the new test case stack-overflows and aborts the whole test run without the fix. Round also floored negatives away from zero."
       }
     },
     "sonarr": {}

--- a/UPSTREAM_SYNC.md
+++ b/UPSTREAM_SYNC.md
@@ -7,26 +7,16 @@ See `.github/upstream/state.json` for the machine state and the `sync-upstream` 
 
 ## radarr — Radarr/Radarr `develop`
 
-Owns: **backend**. High-water mark: `4b85fab05b`.
+Owns: **backend**. High-water mark: `0134fdedca`.
 
-**73 outstanding.**
+**67 outstanding.**
 
 | Month | Total | be | fe | be+fe | chore |
 | --- | ---: | ---: | ---: | ---: | ---: |
-| 2026-04 | 6 | 4 | 0 | 0 | 2 |
 | 2026-05 | 12 | 10 | 0 | 0 | 2 |
 | 2026-06 | 5 | 4 | 0 | 0 | 1 |
 | 2026-07 | 18 | 15 | 0 | 0 | 3 |
 | 2026-08 | 32 | 18 | 8 | 4 | 2 |
-
-### 2026-04
-
-- `chore` [`331ce4579`](https://github.com/Radarr/Radarr/commit/331ce4579ce2f3d7cb06d82c0e62c42148acacb8) Close issues that don't follow issue templates — *Mark McDowall*
-- `chore` [`662324775`](https://github.com/Radarr/Radarr/commit/662324775ed72ea39589a2a8f9d7ffec39bca644) version bump to 6.2.0 — *Auggie*
-- `be   ` [`922687679`](https://github.com/Radarr/Radarr/commit/92268767921bddd1625c6acb80b704464b5feb0a) Bump MailKit to 4.16.0 — *Auggie*
-- `be   ` [`ece044e27`](https://github.com/Radarr/Radarr/commit/ece044e2701d0269e36e458572f48816e5293654) Log media info title used to augment quality — *Bogdan*
-- `be   ` [`7dd5365cc`](https://github.com/Radarr/Radarr/commit/7dd5365ccd5130b62b98f4bef9bfd69d7721aebc) Fixed: Include quality modifier when augmenting quality from media info — *Bogdan*
-- `be   ` [`0134fdedc`](https://github.com/Radarr/Radarr/commit/0134fdedcaff8eaeb6baaeee95e873a2b4881221) Prevent overflow exception for big numbers in SizeSuffix and Fluent.Round — *Bogdan*
 
 ### 2026-05
 
@@ -222,3 +212,9 @@ Commits reviewed and dispositioned. Skips carry their reason.
 | [`f1513ca39`](https://github.com/Radarr/Radarr/commit/f1513ca39e7179030eb84ac3769bdc6e41b9c05b) | Multiple Translations updated by Weblate | `skip` | Weblate-generated translation files. Ours come from our own Weblate project, never from upstream cherry-picks. |
 | [`cf0d6b014`](https://github.com/Radarr/Radarr/commit/cf0d6b014222a6424bae52dbbb55849a6f874d2f) | Chore: Sonar Cloud version bump | `skip` | Touches azure-pipelines.yml only. Our Sonar setup lives in .github/workflows/sonarqube.yml. |
 | [`079e2136e`](https://github.com/Radarr/Radarr/commit/079e2136ee6d3b579329f18deaf2e59ed20d93ee) | version bump to 6.1.2 | `skip` | Touches azure-pipelines.yml only. We do not have that file and version independently of Radarr. |
+| [`331ce4579`](https://github.com/Radarr/Radarr/commit/331ce4579ce2f3d7cb06d82c0e62c42148acacb8) | Close issues that don't follow issue templates | `skip` | Adds .github/workflows/close_invalid_issues.yml, which auto-closes issues that do not follow the templates. Declined deliberately, not for lack of the file: we are not seeing template compliance problems, so the workflow would only add a way to close reporters' issues automatically. Revisit only if that changes. |
+| [`662324775`](https://github.com/Radarr/Radarr/commit/662324775ed72ea39589a2a8f9d7ffec39bca644) | version bump to 6.2.0 | `skip` | Touches azure-pipelines.yml only. We do not have that file and version independently of Radarr. |
+| [`922687679`](https://github.com/Radarr/Radarr/commit/92268767921bddd1625c6acb80b704464b5feb0a) | Bump MailKit to 4.16.0 | `have` | Whisparr.Core.csproj is on MailKit 4.17.0, ahead of upstream's 4.16.0. |
+| [`ece044e27`](https://github.com/Radarr/Radarr/commit/ece044e2701d0269e36e458572f48816e5293654) | Log media info title used to augment quality | `adapt` | Took the debug log and the single null-safe Trim in AugmentQualityFromMediaInfo. Our version of the file has far more resolution tiers (8K, 6K RED, 6K Blackmagic, 5K) than upstream's, so only the title handling was portable. |
+| [`7dd5365cc`](https://github.com/Radarr/Radarr/commit/7dd5365ccd5130b62b98f4bef9bfd69d7721aebc) | Fixed: Include quality modifier when augmenting quality from media info | `skip` | Not adaptable: our quality model has no Modifier concept at all. There is no Modifier enum under Qualities/, AugmentQualityResult carries no Modifier property, AggregateQuality tracks no modifier, and QualityFinder.FindBySourceAndResolution takes only (source, resolution). Introducing one would be a quality-matching design change, not a sync - and matching is not somewhere to make drive-by changes. |
+| [`0134fdedc`](https://github.com/Radarr/Radarr/commit/0134fdedcaff8eaeb6baaeee95e873a2b4881221) | Prevent overflow exception for big numbers in SizeSuffix and Fluent.Round | `pick` | Real crash, not a rounding nit: SizeSuffix(long.MinValue) negated to itself and recursed forever. Reproduced here - the new test case stack-overflows and aborts the whole test run without the fix. Round also floored negatives away from zero. |

--- a/src/NzbDrone.Common.Test/ExtensionTests/NumberExtensionFixture.cs
+++ b/src/NzbDrone.Common.Test/ExtensionTests/NumberExtensionFixture.cs
@@ -17,6 +17,8 @@ namespace NzbDrone.Common.Test.ExtensionTests
         [TestCase(-1000000, "-976.6 KB")]
         [TestCase(-377487360, "-360.0 MB")]
         [TestCase(-1255864686, "-1.2 GB")]
+        [TestCase(long.MinValue, "-8.0 EB")]
+        [TestCase(long.MaxValue, "8.0 EB")]
         public void should_calculate_string_correctly(long bytes, string expected)
         {
             bytes.SizeSuffix().Should().Be(expected);

--- a/src/NzbDrone.Common/Extensions/NumberExtensions.cs
+++ b/src/NzbDrone.Common/Extensions/NumberExtensions.cs
@@ -11,14 +11,19 @@ namespace NzbDrone.Common.Extensions
         {
             const int bytesInKb = 1024;
 
-            if (bytes < 0)
-            {
-                return "-" + SizeSuffix(-bytes);
-            }
-
             if (bytes == 0)
             {
                 return "0 B";
+            }
+
+            if (bytes == long.MinValue)
+            {
+                return "-" + SizeSuffix(long.MaxValue);
+            }
+
+            if (bytes < 0)
+            {
+                return "-" + SizeSuffix(Math.Abs(bytes));
             }
 
             var mag = (int)Math.Log(bytes, bytesInKb);

--- a/src/NzbDrone.Core.Test/FluentTest.cs
+++ b/src/NzbDrone.Core.Test/FluentTest.cs
@@ -175,7 +175,9 @@ namespace NzbDrone.Core.Test
         [TestCase(199, 100, 100)]
         [TestCase(1000, 100, 1000)]
         [TestCase(0, 100, 0)]
-        public void round_to_level(long number, int level, int result)
+        [TestCase(long.MinValue, 1000, -9223372036854775000L)]
+        [TestCase(long.MaxValue, 1000, 9223372036854775000L)]
+        public void round_to_level(long number, int level, long result)
         {
             number.Round(level).Should().Be(result);
         }

--- a/src/NzbDrone.Core/Fluent.cs
+++ b/src/NzbDrone.Core/Fluent.cs
@@ -22,7 +22,9 @@ namespace NzbDrone.Core
 
         public static long Round(this long number, long level)
         {
-            return Convert.ToInt64(Math.Floor((decimal)number / level) * level);
+            return number < 0
+                ? Convert.ToInt64(Math.Ceiling((decimal)number / level) * level)
+                : Convert.ToInt64(Math.Floor((decimal)number / level) * level);
         }
 
         public static string ToBestDateString(this DateTime dateTime)

--- a/src/NzbDrone.Core/MediaFiles/MovieImport/Aggregation/Aggregators/Augmenters/Quality/AugmentQualityFromMediaInfo.cs
+++ b/src/NzbDrone.Core/MediaFiles/MovieImport/Aggregation/Aggregators/Augmenters/Quality/AugmentQualityFromMediaInfo.cs
@@ -55,11 +55,13 @@ namespace NzbDrone.Core.MediaFiles.MovieImport.Aggregation.Aggregators.Augmenter
             var height = localMovie.MediaInfo.Height;
             var source = QualitySource.Unknown;
             var sourceConfidence = Confidence.Default;
-            var title = localMovie.MediaInfo.Title;
+            var title = localMovie.MediaInfo.Title?.Trim();
 
             if (title.IsNotNullOrWhiteSpace())
             {
-                var parsedQuality = QualityParser.ParseQualityName(title.Trim());
+                _logger.Debug("Parsing quality from media info title '{0}'", title);
+
+                var parsedQuality = QualityParser.ParseQualityName(title);
 
                 // Only use the quality if it's not unknown and the source is from the name (which is MediaInfo's title in this case)
                 if (parsedQuality.Quality.Source != QualitySource.Unknown &&


### PR DESCRIPTION
#### Database Migration

NO

#### Description

Radarr `develop` 2026-04: six commits reviewed, one picked, one adapted, one already in our tree, three skipped. High-water mark advances to `0134fdedc` (2026-04-29); Radarr backlog 73 → 67.

**Stop SizeSuffix recursing forever on long.MinValue** (radarr/radarr@0134fdedc). Worse than the upstream subject suggests. `SizeSuffix` handled negatives by recursing on `-bytes`, but `-long.MinValue` overflows straight back to `long.MinValue`, so it recursed until the stack ran out — a process-killing crash, not a formatting bug. The new test case aborts the entire test run without the fix. `Fluent.Round` had a smaller sibling problem, flooring negatives away from zero so `-1` at a level of 1000 gave `-1000` rather than `0`.

Worth noting there is a related commit still ahead of us in 2026-08, "Return maximum long value on overflow getting disk information", which is plausibly the path that reaches this in production.

**Log the media info title quality was parsed from** (radarr/radarr@ece044e27). Trims once into the local and logs the title, which is otherwise invisible when a file imports at an unexpected quality. Only the title handling was portable — our copy of this augmenter carries several resolution tiers upstream does not (8K, 6K RED, 6K Blackmagic, 5K).

**Skipped, with reasons recorded in `state.json`:**

- `7dd5365cc` "Include quality modifier when augmenting quality from media info" — not adaptable. Our quality model has no `Modifier` concept at all: no enum under `Qualities/`, no property on `AugmentQualityResult`, no tracking in `AggregateQuality`, and `QualityFinder.FindBySourceAndResolution` takes only `(source, resolution)`. Introducing one is a quality-matching design change, not a sync.
- `331ce4579` "Close issues that don't follow issue templates" — declined deliberately; we are not seeing template compliance problems.
- `662324775` version bump — `azure-pipelines.yml` only.
- `922687679` MailKit 4.16.0 — we are on 4.17.0.

#### Todos

- [x] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)

Extends the existing `NumberExtensionFixture` and `FluentTest` cases with the `long.MinValue`/`long.MaxValue` boundaries. No new user-facing strings, so no translation keys.

Verified after rebasing onto #564: solution builds with 0 warnings, NumberExtensionFixture 12/12, FluentTest 27/27, Api.Test 28/28.

#### Issues Fixed or Closed by this PR

<!-- none -->
