### PR TITLE
Radarr 2026-05: fix qBittorrent credential caching and HDR stream selection

### DIFF
--- a/.github/upstream/state.json
+++ b/.github/upstream/state.json
@@ -5,8 +5,8 @@
       "repo": "Radarr/Radarr",
       "branch": "develop",
       "owns": "backend",
-      "highWater": "0134fdedcaff8eaeb6baaeee95e873a2b4881221",
-      "highWaterNote": "2026-04-29 'Prevent overflow exception for big numbers in SizeSuffix and Fluent.Round'. Everything on Radarr develop from 2025-10-01 through this point is dispositioned. Advance only when everything at or before the new mark is settled."
+      "highWater": "520bf4215a13223433ef6c77ad7e822cd8359c94",
+      "highWaterNote": "2026-05-31 'Bump BusyTimeout for SQLite to 1000ms'. Everything on Radarr develop from 2025-10-01 through this point is dispositioned. Advance only when everything at or before the new mark is settled."
     },
     "sonarr": {
       "repo": "Sonarr/Sonarr",
@@ -215,6 +215,78 @@
         "month": "2026-04",
         "disposition": "pick",
         "reason": "Real crash, not a rounding nit: SizeSuffix(long.MinValue) negated to itself and recursed forever. Reproduced here - the new test case stack-overflows and aborts the whole test run without the fix. Round also floored negatives away from zero."
+      },
+      "8ac3e4746a40390c4278e97af034f9dc710992c5": {
+        "subject": "Fixed: Testing qBittorrent after credentials change would always pass tests",
+        "month": "2026-05",
+        "disposition": "adapt",
+        "reason": "Both bugs are ours: the auth cookie cache was keyed on base URL + password only, and the session cookie went into the persistent container where it outlived the settings that made it. Took HttpRequestBuilder.StoreRequestCookie and the username in the cache key, covered by a new QBittorrentProxyV2Fixture (2 of its 6 tests fail without this). Did not take upstream's move of BasicNetworkCredential onto the login request alone - radarr/radarr@4dcc7c78 put it back in BuildRequest in 2026-06, which is where ours already is."
+      },
+      "eec3efdb317bdfc81d1a18c0d3af76d6d10cb096": {
+        "subject": "New: API key support for qBittorrent",
+        "month": "2026-05",
+        "disposition": "have",
+        "reason": "Landed as our own #525: ApiKey setting, Bearer header in BuildRequest, the API-key branch in ProcessRequest, the validator rules forbidding username/password alongside a key, and the ApiKey/Username switch in TestConnection are all present. en.json already carries the reworded DownloadClientValidationAuthenticationFailureDetail."
+      },
+      "b028efbe3eb5c5c9a4f0776627d22b0781e212d9": {
+        "subject": "Fixed: Login with credentials on Qbittorrent 5.2",
+        "month": "2026-05",
+        "disposition": "have",
+        "reason": "This dropped BasicNetworkCredential from the login request, then radarr/radarr@4dcc7c78 restored it for every request in 2026-06. Our BuildRequest already matches that end state, so there is nothing left to take."
+      },
+      "065414211d275a86c7b580d000065f548aafbcb5": {
+        "subject": "Fix qBittorrent priority help text",
+        "month": "2026-05",
+        "disposition": "have",
+        "reason": "Upstream briefly pasted Sonarr's Episode help-text keys into the priority fields and reverted it here. We never had the wrong ones - RecentMoviePriority and OlderMoviePriority already point at DownloadClientSettingsRecentPriorityMovieHelpText and ...OlderPriorityMovieHelpText."
+      },
+      "4e1e87660094752d8f4dca40009ae29cda982e20": {
+        "subject": "Reuse authentification cookies for qBittorrent calls",
+        "month": "2026-05",
+        "disposition": "have",
+        "reason": "Fixes the ordering introduced with API key support, where ProcessRequest built the request before AuthenticateClient set the session cookie on the builder. Our #525 picked the corrected form: the cookie-auth path builds after AuthenticateClient, and the API-key path builds its own request."
+      },
+      "5981aea577db5ae8e27920c50e7c6f23f1806f9c": {
+        "subject": "New: Simkl Anime List integration (#11465)",
+        "month": "2026-05",
+        "disposition": "skip",
+        "reason": "Feature decision, declined. Simkl indexes anime and mainstream film/TV; it has no coverage of the scenes, performers and studios we track, so the list would come back empty here."
+      },
+      "c7c205cafb4487317616aa57bc36e4948d10114c": {
+        "subject": "Fixed: Reduce data transfer when reading video stream from files (#11364)",
+        "month": "2026-05",
+        "disposition": "adapt",
+        "reason": "Real bug here too: -select_streams v:N indexes within the video streams, not the file's absolute stream list, so HDR frame analysis on a file whose video stream is not stream 0 read the wrong stream. Ported onto our older FFProbe.GetFrames(customArguments:) signature - we are not on upstream's GetFrameJson/RawFrameData."
+      },
+      "559a2980c360473a9e017f37669cd5e300657cb8": {
+        "subject": "New: Bump .NET to 8.0.27",
+        "month": "2026-05",
+        "disposition": "skip",
+        "reason": "We are on .NET 10 (global.json pins SDK 10.0.101); a bump to .NET 8.0.27 would be a downgrade."
+      },
+      "16c4ab2b0da866c1a72e14ed747fb0893628a716": {
+        "subject": "New: Postgres Connection String option",
+        "month": "2026-05",
+        "disposition": "skip",
+        "reason": "Feature decision, deferred. Adds PostgresMainDbConnectionString/PostgresLogDbConnectionString as an alternative to the discrete Postgres settings. Worth having for managed-Postgres deployments, but upstream's GetConnectionStringType ships two if-branches testing the identical condition and never rejects main-set-without-log, so it wants rewriting rather than picking. Raise separately if wanted."
+      },
+      "cf3775621be8e39c011cdff63f6939400a108bb5": {
+        "subject": "Bump dessant github actions to fix token issues",
+        "month": "2026-05",
+        "disposition": "have",
+        "reason": "We are already on dessant/label-actions@v5 and dessant/lock-threads@v6, which is what this bumped upstream to."
+      },
+      "3b80076373859a5f866b1d52ddc25aa7613a064a": {
+        "subject": "Bump version to 6.2.1",
+        "month": "2026-05",
+        "disposition": "skip",
+        "reason": "Upstream's own version number in azure-pipelines.yml. We version independently."
+      },
+      "520bf4215a13223433ef6c77ad7e822cd8359c94": {
+        "subject": "Bump BusyTimeout for SQLite to 1000ms",
+        "month": "2026-05",
+        "disposition": "have",
+        "reason": "ConnectionStringFactory already sets BusyTimeout = 1000."
       }
     },
     "sonarr": {}

--- a/UPSTREAM_SYNC.md
+++ b/UPSTREAM_SYNC.md
@@ -7,31 +7,15 @@ See `.github/upstream/state.json` for the machine state and the `sync-upstream` 
 
 ## radarr — Radarr/Radarr `develop`
 
-Owns: **backend**. High-water mark: `0134fdedca`.
+Owns: **backend**. High-water mark: `520bf4215a`.
 
-**67 outstanding.**
+**55 outstanding.**
 
 | Month | Total | be | fe | be+fe | chore |
 | --- | ---: | ---: | ---: | ---: | ---: |
-| 2026-05 | 12 | 10 | 0 | 0 | 2 |
 | 2026-06 | 5 | 4 | 0 | 0 | 1 |
 | 2026-07 | 18 | 15 | 0 | 0 | 3 |
 | 2026-08 | 32 | 18 | 8 | 4 | 2 |
-
-### 2026-05
-
-- `be   ` [`8ac3e4746`](https://github.com/Radarr/Radarr/commit/8ac3e4746a40390c4278e97af034f9dc710992c5) Fixed: Testing qBittorrent after credentials change would always pass tests — *Mark McDowall*
-- `be   ` [`b028efbe3`](https://github.com/Radarr/Radarr/commit/b028efbe3eb5c5c9a4f0776627d22b0781e212d9) Fixed: Login with credentials on Qbittorrent 5.2 — *Bogdan*
-- `be   ` [`eec3efdb3`](https://github.com/Radarr/Radarr/commit/eec3efdb317bdfc81d1a18c0d3af76d6d10cb096) New: API key support for qBittorrent — *Bogdan*
-- `be   ` [`065414211`](https://github.com/Radarr/Radarr/commit/065414211d275a86c7b580d000065f548aafbcb5) Fix qBittorrent priority help text — *Auggie*
-- `be   ` [`5981aea57`](https://github.com/Radarr/Radarr/commit/5981aea577db5ae8e27920c50e7c6f23f1806f9c) New: Simkl Anime List integration (#11465) — *Bogdan*
-- `be   ` [`c7c205caf`](https://github.com/Radarr/Radarr/commit/c7c205cafb4487317616aa57bc36e4948d10114c) Fixed: Reduce data transfer when reading video stream from files (#11364) — *realzombee*
-- `be   ` [`559a2980c`](https://github.com/Radarr/Radarr/commit/559a2980c360473a9e017f37669cd5e300657cb8) New: Bump .NET to 8.0.27 — *Bogdan*
-- `be   ` [`16c4ab2b0`](https://github.com/Radarr/Radarr/commit/16c4ab2b0da866c1a72e14ed747fb0893628a716) New: Postgres Connection String option — *solidDoWant*
-- `be   ` [`4e1e87660`](https://github.com/Radarr/Radarr/commit/4e1e87660094752d8f4dca40009ae29cda982e20) Reuse authentification cookies for qBittorrent calls — *Bogdan*
-- `chore` [`cf3775621`](https://github.com/Radarr/Radarr/commit/cf3775621be8e39c011cdff63f6939400a108bb5) Bump dessant github actions to fix token issues — *Bogdan*
-- `chore` [`3b8007637`](https://github.com/Radarr/Radarr/commit/3b80076373859a5f866b1d52ddc25aa7613a064a) Bump version to 6.2.1 — *Auggie*
-- `be   ` [`520bf4215`](https://github.com/Radarr/Radarr/commit/520bf4215a13223433ef6c77ad7e822cd8359c94) Bump BusyTimeout for SQLite to 1000ms — *Bogdan*
 
 ### 2026-06
 
@@ -218,3 +202,15 @@ Commits reviewed and dispositioned. Skips carry their reason.
 | [`ece044e27`](https://github.com/Radarr/Radarr/commit/ece044e2701d0269e36e458572f48816e5293654) | Log media info title used to augment quality | `adapt` | Took the debug log and the single null-safe Trim in AugmentQualityFromMediaInfo. Our version of the file has far more resolution tiers (8K, 6K RED, 6K Blackmagic, 5K) than upstream's, so only the title handling was portable. |
 | [`7dd5365cc`](https://github.com/Radarr/Radarr/commit/7dd5365ccd5130b62b98f4bef9bfd69d7721aebc) | Fixed: Include quality modifier when augmenting quality from media info | `skip` | Not adaptable: our quality model has no Modifier concept at all. There is no Modifier enum under Qualities/, AugmentQualityResult carries no Modifier property, AggregateQuality tracks no modifier, and QualityFinder.FindBySourceAndResolution takes only (source, resolution). Introducing one would be a quality-matching design change, not a sync - and matching is not somewhere to make drive-by changes. |
 | [`0134fdedc`](https://github.com/Radarr/Radarr/commit/0134fdedcaff8eaeb6baaeee95e873a2b4881221) | Prevent overflow exception for big numbers in SizeSuffix and Fluent.Round | `pick` | Real crash, not a rounding nit: SizeSuffix(long.MinValue) negated to itself and recursed forever. Reproduced here - the new test case stack-overflows and aborts the whole test run without the fix. Round also floored negatives away from zero. |
+| [`8ac3e4746`](https://github.com/Radarr/Radarr/commit/8ac3e4746a40390c4278e97af034f9dc710992c5) | Fixed: Testing qBittorrent after credentials change would always pass tests | `adapt` | Both bugs are ours: the auth cookie cache was keyed on base URL + password only, and the session cookie went into the persistent container where it outlived the settings that made it. Took HttpRequestBuilder.StoreRequestCookie and the username in the cache key, covered by a new QBittorrentProxyV2Fixture (2 of its 6 tests fail without this). Did not take upstream's move of BasicNetworkCredential onto the login request alone - radarr/radarr@4dcc7c78 put it back in BuildRequest in 2026-06, which is where ours already is. |
+| [`eec3efdb3`](https://github.com/Radarr/Radarr/commit/eec3efdb317bdfc81d1a18c0d3af76d6d10cb096) | New: API key support for qBittorrent | `have` | Landed as our own #525: ApiKey setting, Bearer header in BuildRequest, the API-key branch in ProcessRequest, the validator rules forbidding username/password alongside a key, and the ApiKey/Username switch in TestConnection are all present. en.json already carries the reworded DownloadClientValidationAuthenticationFailureDetail. |
+| [`b028efbe3`](https://github.com/Radarr/Radarr/commit/b028efbe3eb5c5c9a4f0776627d22b0781e212d9) | Fixed: Login with credentials on Qbittorrent 5.2 | `have` | This dropped BasicNetworkCredential from the login request, then radarr/radarr@4dcc7c78 restored it for every request in 2026-06. Our BuildRequest already matches that end state, so there is nothing left to take. |
+| [`065414211`](https://github.com/Radarr/Radarr/commit/065414211d275a86c7b580d000065f548aafbcb5) | Fix qBittorrent priority help text | `have` | Upstream briefly pasted Sonarr's Episode help-text keys into the priority fields and reverted it here. We never had the wrong ones - RecentMoviePriority and OlderMoviePriority already point at DownloadClientSettingsRecentPriorityMovieHelpText and ...OlderPriorityMovieHelpText. |
+| [`4e1e87660`](https://github.com/Radarr/Radarr/commit/4e1e87660094752d8f4dca40009ae29cda982e20) | Reuse authentification cookies for qBittorrent calls | `have` | Fixes the ordering introduced with API key support, where ProcessRequest built the request before AuthenticateClient set the session cookie on the builder. Our #525 picked the corrected form: the cookie-auth path builds after AuthenticateClient, and the API-key path builds its own request. |
+| [`5981aea57`](https://github.com/Radarr/Radarr/commit/5981aea577db5ae8e27920c50e7c6f23f1806f9c) | New: Simkl Anime List integration (#11465) | `skip` | Feature decision, declined. Simkl indexes anime and mainstream film/TV; it has no coverage of the scenes, performers and studios we track, so the list would come back empty here. |
+| [`c7c205caf`](https://github.com/Radarr/Radarr/commit/c7c205cafb4487317616aa57bc36e4948d10114c) | Fixed: Reduce data transfer when reading video stream from files (#11364) | `adapt` | Real bug here too: -select_streams v:N indexes within the video streams, not the file's absolute stream list, so HDR frame analysis on a file whose video stream is not stream 0 read the wrong stream. Ported onto our older FFProbe.GetFrames(customArguments:) signature - we are not on upstream's GetFrameJson/RawFrameData. |
+| [`559a2980c`](https://github.com/Radarr/Radarr/commit/559a2980c360473a9e017f37669cd5e300657cb8) | New: Bump .NET to 8.0.27 | `skip` | We are on .NET 10 (global.json pins SDK 10.0.101); a bump to .NET 8.0.27 would be a downgrade. |
+| [`16c4ab2b0`](https://github.com/Radarr/Radarr/commit/16c4ab2b0da866c1a72e14ed747fb0893628a716) | New: Postgres Connection String option | `skip` | Feature decision, deferred. Adds PostgresMainDbConnectionString/PostgresLogDbConnectionString as an alternative to the discrete Postgres settings. Worth having for managed-Postgres deployments, but upstream's GetConnectionStringType ships two if-branches testing the identical condition and never rejects main-set-without-log, so it wants rewriting rather than picking. Raise separately if wanted. |
+| [`cf3775621`](https://github.com/Radarr/Radarr/commit/cf3775621be8e39c011cdff63f6939400a108bb5) | Bump dessant github actions to fix token issues | `have` | We are already on dessant/label-actions@v5 and dessant/lock-threads@v6, which is what this bumped upstream to. |
+| [`3b8007637`](https://github.com/Radarr/Radarr/commit/3b80076373859a5f866b1d52ddc25aa7613a064a) | Bump version to 6.2.1 | `skip` | Upstream's own version number in azure-pipelines.yml. We version independently. |
+| [`520bf4215`](https://github.com/Radarr/Radarr/commit/520bf4215a13223433ef6c77ad7e822cd8359c94) | Bump BusyTimeout for SQLite to 1000ms | `have` | ConnectionStringFactory already sets BusyTimeout = 1000. |

--- a/src/NzbDrone.Common/Http/HttpRequestBuilder.cs
+++ b/src/NzbDrone.Common/Http/HttpRequestBuilder.cs
@@ -28,6 +28,7 @@ namespace NzbDrone.Common.Http
         public TimeSpan RateLimit { get; set; }
         public bool LogResponseContent { get; set; }
         public ICredentials NetworkCredential { get; set; }
+        public bool StoreRequestCookie { get; set; }
         public Dictionary<string, string> Cookies { get; private set; }
         public List<HttpFormData> FormData { get; private set; }
         public Action<HttpRequest> PostProcess { get; set; }
@@ -44,6 +45,7 @@ namespace NzbDrone.Common.Http
             Cookies = new Dictionary<string, string>();
             FormData = new List<HttpFormData>();
             LogHttpError = true;
+            StoreRequestCookie = true;
         }
 
         public HttpRequestBuilder(bool useHttps, string host, int port, string urlBase = null)
@@ -111,6 +113,7 @@ namespace NzbDrone.Common.Http
             request.RateLimit = RateLimit;
             request.LogResponseContent = LogResponseContent;
             request.Credentials = NetworkCredential;
+            request.StoreRequestCookie = StoreRequestCookie;
 
             foreach (var header in Headers)
             {

--- a/src/NzbDrone.Core.Test/Download/DownloadClientTests/QBittorrentTests/QBittorrentProxyV2Fixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientTests/QBittorrentTests/QBittorrentProxyV2Fixture.cs
@@ -1,0 +1,115 @@
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+using NzbDrone.Common.Cache;
+using NzbDrone.Common.Http;
+using NzbDrone.Core.Download.Clients.QBittorrent;
+using NzbDrone.Core.Test.Framework;
+
+namespace NzbDrone.Core.Test.Download.DownloadClientTests.QBittorrentTests
+{
+    [TestFixture]
+    public class QBittorrentProxyV2Fixture : CoreTest<QBittorrentProxyV2>
+    {
+        private List<HttpRequest> _requests;
+
+        [SetUp]
+        public void Setup()
+        {
+            _requests = new List<HttpRequest>();
+
+            Mocker.SetConstant<ICacheManager>(Mocker.Resolve<CacheManager>());
+
+            Mocker.GetMock<IHttpClient>()
+                  .Setup(s => s.Execute(It.IsAny<HttpRequest>()))
+                  .Returns<HttpRequest>(r =>
+                  {
+                      _requests.Add(r);
+
+                      if (r.Url.Path.EndsWith("/auth/login"))
+                      {
+                          var headers = new HttpHeader();
+                          headers.Add("Set-Cookie", "SID=abc123; path=/");
+
+                          return new HttpResponse(r, headers, "Ok.");
+                      }
+
+                      return new HttpResponse(r, new HttpHeader(), "[]");
+                  });
+        }
+
+        private static QBittorrentSettings GivenSettings(string username, string password)
+        {
+            return new QBittorrentSettings
+            {
+                Host = "127.0.0.1",
+                Port = 2222,
+                Username = username,
+                Password = password
+            };
+        }
+
+        private int LoginCount => _requests.Count(r => r.Url.Path.EndsWith("/auth/login"));
+
+        [Test]
+        public void should_reuse_the_auth_cookie_for_unchanged_credentials()
+        {
+            Subject.GetTorrents(GivenSettings("admin", "pass"));
+            Subject.GetTorrents(GivenSettings("admin", "pass"));
+
+            LoginCount.Should().Be(1);
+        }
+
+        [Test]
+        public void should_reauthenticate_when_the_username_changes()
+        {
+            Subject.GetTorrents(GivenSettings("admin", "pass"));
+            Subject.GetTorrents(GivenSettings("someone-else", "pass"));
+
+            LoginCount.Should().Be(2);
+        }
+
+        [Test]
+        public void should_reauthenticate_when_the_password_changes()
+        {
+            Subject.GetTorrents(GivenSettings("admin", "pass"));
+            Subject.GetTorrents(GivenSettings("admin", "different"));
+
+            LoginCount.Should().Be(2);
+        }
+
+        [Test]
+        public void should_not_persist_the_auth_cookie_beyond_the_request()
+        {
+            Subject.GetTorrents(GivenSettings("admin", "pass"));
+
+            _requests.Should().NotBeEmpty();
+            _requests.Should().OnlyContain(r => r.StoreRequestCookie == false);
+        }
+
+        [Test]
+        public void should_send_the_auth_cookie_on_subsequent_requests()
+        {
+            Subject.GetTorrents(GivenSettings("admin", "pass"));
+
+            var torrentsRequest = _requests.Last();
+
+            torrentsRequest.Url.Path.Should().EndWith("/torrents/info");
+            torrentsRequest.Cookies.Should().Contain(new KeyValuePair<string, string>("SID", "abc123"));
+        }
+
+        [Test]
+        public void should_use_the_api_key_header_and_skip_login_when_an_api_key_is_set()
+        {
+            var settings = GivenSettings(null, null);
+            settings.ApiKey = "some-api-key";
+
+            Subject.GetTorrents(settings);
+
+            LoginCount.Should().Be(0);
+            _requests.Should().OnlyContain(r => r.Headers["Authorization"] == "Bearer some-api-key");
+        }
+    }
+}

--- a/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentProxyV2.cs
+++ b/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentProxyV2.cs
@@ -360,7 +360,8 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
         {
             var requestBuilder = new HttpRequestBuilder(settings.UseSsl, settings.Host, settings.Port, settings.UrlBase)
             {
-                LogResponseContent = true
+                LogResponseContent = true,
+                StoreRequestCookie = false
             };
 
             if (settings.ApiKey.IsNotNullOrWhiteSpace())
@@ -458,7 +459,7 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
                 return;
             }
 
-            var authKey = string.Format("{0}:{1}", requestBuilder.BaseUrl, settings.Password);
+            var authKey = $"{requestBuilder.BaseUrl}:{settings.Username}:{settings.Password}";
 
             var cookies = _authCookieCache.Find(authKey);
 

--- a/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentSettings.cs
+++ b/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentSettings.cs
@@ -56,16 +56,16 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
         [FieldDefinition(6, Label = "Password", Type = FieldType.Password, Privacy = PrivacyLevel.Password)]
         public string Password { get; set; }
 
-        [FieldDefinition(6, Label = "Category", Type = FieldType.Textbox, HelpText = "DownloadClientSettingsCategoryHelpText")]
+        [FieldDefinition(7, Label = "Category", Type = FieldType.Textbox, HelpText = "DownloadClientSettingsCategoryHelpText")]
         public string MovieCategory { get; set; }
 
-        [FieldDefinition(7, Label = "PostImportCategory", Type = FieldType.Textbox, Advanced = true, HelpText = "DownloadClientSettingsPostImportCategoryHelpText")]
+        [FieldDefinition(8, Label = "PostImportCategory", Type = FieldType.Textbox, Advanced = true, HelpText = "DownloadClientSettingsPostImportCategoryHelpText")]
         public string MovieImportedCategory { get; set; }
 
-        [FieldDefinition(8, Label = "DownloadClientSettingsRecentPriority", Type = FieldType.Select, SelectOptions = typeof(QBittorrentPriority), HelpText = "DownloadClientSettingsRecentPriorityMovieHelpText")]
+        [FieldDefinition(9, Label = "DownloadClientSettingsRecentPriority", Type = FieldType.Select, SelectOptions = typeof(QBittorrentPriority), HelpText = "DownloadClientSettingsRecentPriorityMovieHelpText")]
         public int RecentMoviePriority { get; set; }
 
-        [FieldDefinition(9, Label = "DownloadClientSettingsOlderPriority", Type = FieldType.Select, SelectOptions = typeof(QBittorrentPriority), HelpText = "DownloadClientSettingsOlderPriorityMovieHelpText")]
+        [FieldDefinition(10, Label = "DownloadClientSettingsOlderPriority", Type = FieldType.Select, SelectOptions = typeof(QBittorrentPriority), HelpText = "DownloadClientSettingsOlderPriorityMovieHelpText")]
         public int OlderMoviePriority { get; set; }
 
         [FieldDefinition(11, Label = "DownloadClientSettingsInitialState", Type = FieldType.Select, SelectOptions = typeof(QBittorrentState), HelpText = "DownloadClientQbittorrentSettingsInitialStateHelpText")]

--- a/src/NzbDrone.Core/MediaFiles/MediaInfo/VideoFileInfoReader.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaInfo/VideoFileInfoReader.cs
@@ -112,7 +112,9 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
                 // if it looks like PQ10 or similar HDR, do a frame analysis to figure out which type it is
                 if (PqTransferFunctions.Contains(mediaInfoModel.VideoTransferCharacteristics))
                 {
-                    frames = FFProbe.GetFrames(filename, customArguments: $"-read_intervals \"%+#1\" -select_streams v:{primaryVideoStream?.Index ?? 0}");
+                    var videoStreamIndex = analysis.VideoStreams.FindIndex(stream => stream.Index == primaryVideoStream?.Index);
+
+                    frames = FFProbe.GetFrames(filename, customArguments: $"-read_intervals \"%+#1\" -select_streams v:{(videoStreamIndex == -1 ? 0 : videoStreamIndex)}");
                 }
 
                 var streamSideData = primaryVideoStream?.SideData ?? new();


### PR DESCRIPTION
#### Database Migration

NO

#### Description

Radarr `develop` for 2026-05, twelve commits. Two adapted, six we already have, four skipped.

**Adapted**

- **qBittorrent credential test always passing** (radarr/radarr@8ac3e474). The auth cookie cache was keyed on base URL + password only, so changing just the username reused the old session. The cookie also went into the *persistent* container, where it outlived the settings that created it — so a test with bad credentials could succeed on the back of an earlier good login. Adds `StoreRequestCookie` to `HttpRequestBuilder` and puts the username in the cache key. New `QBittorrentProxyV2Fixture`; 2 of its 6 tests fail without the fix.
  Not taken: upstream moved `BasicNetworkCredential` onto the login request alone, then put it back in `BuildRequest` two months later (radarr/radarr@4dcc7c78). Ours is already at that end state.
- **HDR frame analysis reading the wrong stream** (radarr/radarr@c7c205ca). `-select_streams v:N` indexes within the video streams, not the file's absolute stream list. Ported onto our older `FFProbe.GetFrames(customArguments:)` signature.

Also renumbers the qBittorrent field ordinals, which `#525` left with a duplicate 6 and an unused 10. The schema builder renumbers densely after sorting so the client sees no change today — this is to stop the next insert landing somewhere surprising.

**Already present** — API key support and its two follow-ups (all in `#525`), the priority help-text revert (we never had the wrong keys), the dessant action bumps, and the SQLite `BusyTimeout` bump.

**Skipped** — Simkl anime list (no coverage of scenes, performers or studios); .NET 8.0.27 (we're on 10); upstream's version bump. Also skipped **Postgres connection string support** (radarr/radarr@16c4ab2b): worth having for managed-Postgres deployments, but upstream's `GetConnectionStringType` ships two `if` branches testing the identical condition and never rejects main-set-without-log. Wants rewriting rather than picking — say the word and it gets its own PR.

Reasons for all twelve are in `.github/upstream/state.json`. High-water advances to radarr/radarr@520bf421; 55 Radarr commits remain.

#### Screenshot(s) (if UI related)

<details>
</details>

#### Todos

- [x] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)

#### Verification

`dotnet build` 0 warnings. Full `Whisparr.Core.Test` 4076/4076 and `Whisparr.Common.Test` 572/572 green. `upstream-sync --check` passes.

#### Issues Fixed or Closed by this PR

<!-- If multiple, put each on a separate line -->
