### PR TITLE
Radarr 2026-08: fix Jellyfin, Trakt and Discord connectors, plus zip slip

### DIFF
--- a/.github/upstream/state.json
+++ b/.github/upstream/state.json
@@ -5,8 +5,8 @@
       "repo": "Radarr/Radarr",
       "branch": "develop",
       "owns": "backend",
-      "highWater": "15369ed5c359c9704783d243ce2b55e59a40a3a3",
-      "highWaterNote": "2026-07-26 'New: RQBit download client'. Everything on Radarr develop from 2025-10-01 through this point is dispositioned. Advance only when everything at or before the new mark is settled."
+      "highWater": "68b93db78cb7a648d61a486d94eae703242e1e36",
+      "highWaterNote": "2026-08-27 'Fixed: Importing single files from Freebox'. Everything on Radarr develop from 2025-10-01 through this point is dispositioned. Advance only when everything at or before the new mark is settled."
     },
     "sonarr": {
       "repo": "Sonarr/Sonarr",
@@ -425,6 +425,222 @@
         "month": "2026-07",
         "disposition": "skip",
         "reason": "Declined on 2026-08-30. A new download client, not a fix: ~950 lines of client, proxy, settings and six response models we would own, unverifiable without running an rqbit instance, and nobody has asked for it."
+      },
+      "598f989ad1163b3ed21ef57880ba8ba4d1b07e51": {
+        "subject": "Bump to 6.4.2",
+        "month": "2026-08",
+        "disposition": "skip",
+        "reason": "Radarr version bump. Our versioning is independent."
+      },
+      "34b0f5450fdc346cc72cf18669e601d68b974250": {
+        "subject": "Fixed: Parse Celdra as release group",
+        "month": "2026-08",
+        "disposition": "skip",
+        "reason": "Parser gate. Adds a release group token to Radarr's grammar; our Parser.cs is a different grammar entirely and the bar to touch it is a failing test against our parser, which this does not produce."
+      },
+      "80bbaa6e413c84dc901b090d33ecc66190e7d83b": {
+        "subject": "Fixed: Parsing quality and languages when manual importing item with multiple movies error",
+        "month": "2026-08",
+        "disposition": "pick",
+        "reason": "Identical shape here. Quality, Languages and Rejections were left null on ManualImportItem, so the multiple-movies path dereferenced them while building the error response."
+      },
+      "d2d9dce33baf969ee5801820ee7cdac25d5b8b89": {
+        "subject": "Fix parsing already imported items from download clients",
+        "month": "2026-08",
+        "disposition": "pick",
+        "reason": "Same ordering problem in our TrackedDownloadService. Once a download has been imported we know its movie id, but the title was still being re-parsed and mapped by name, so a title our parser reads differently lost its movie."
+      },
+      "25062f2d7aec0bcc83551f48e94836fa658c28ef": {
+        "subject": "Fix queue not showing items with issues",
+        "month": "2026-08",
+        "disposition": "pick",
+        "reason": "Returning null dropped the tracked download entirely, so an item we could not parse never reached the queue and the user got no explanation. Now it is tracked with a warning."
+      },
+      "c6fef4309de3ffdd5e0e9607ad30beb12d791333": {
+        "subject": "Return maximum long value on overflow getting disk information",
+        "month": "2026-08",
+        "disposition": "pick",
+        "reason": "Identical ProcMount here. UnixDriveInfo throws OverflowException on filesystems reporting sizes beyond long, which took out disk space checks entirely rather than degrading."
+      },
+      "ca451608dc60c6cec754aba8d96bfa30e9468ed5": {
+        "subject": "Bump sqlite to 3.53.4",
+        "month": "2026-08",
+        "disposition": "have",
+        "reason": "We are already on SourceGear.sqlite3 3.53.4 and System.Data.SQLite 2.0.4 - the exact versions this commit moves Radarr to."
+      },
+      "6bb8edeafdf71829249702f0e85cd8d6c7809a5c": {
+        "subject": "Remove offensive joke about a sensitive topic",
+        "month": "2026-08",
+        "disposition": "skip",
+        "reason": "Radarr frontend gate. Edits a Radarr loading-message string we do not carry."
+      },
+      "6a1c50028457d45712316d06b1c07f5387987835": {
+        "subject": "Fixed: Broken Trakt links",
+        "month": "2026-08",
+        "disposition": "pick",
+        "reason": "Verified live before taking it: https://trakt.tv/search/tmdb/550?id_type=movie now redirects to app.trakt.tv and returns 404, while https://trakt.tv/movies/tt0137523 returns 200. Applied to Gotify and Telegram; our Discord connector links StashDB and TMDb rather than Trakt, and we skipped the frontend half."
+      },
+      "b8a3923bce9d80eccc0abcbc0cbb4ff4091e7999": {
+        "subject": "Fixed: Parsing anime releases that contain year in the movie title",
+        "month": "2026-08",
+        "disposition": "skip",
+        "reason": "Parser gate, and the worst possible collision: it changes year-vs-title precedence, which is exactly where our grammar deliberately differs. A bare [YYYY] means a movie here; scenes carry full dates."
+      },
+      "a598695ecd70c95b38f4f9efcd1dbe12cccd2f49": {
+        "subject": "Multiple Translations updated by Weblate",
+        "month": "2026-08",
+        "disposition": "skip",
+        "reason": "Weblate commit. Our translations come from Weblate directly, never from cherry-picks."
+      },
+      "2c24d9b4aafd00dedea4505119060c242c0963be": {
+        "subject": "Fixed: Trakt OAuth URL",
+        "month": "2026-08",
+        "disposition": "pick",
+        "reason": "One-line const. Both hosts currently 307 to the same /api/auth/oauth2/authorize endpoint, so this is following upstream to Trakt's canonical auth host rather than repairing an observed break."
+      },
+      "25eeec39b5c43422e2e81cae3758a902890d9e40": {
+        "subject": "Query options support for useApiQuery",
+        "month": "2026-08",
+        "disposition": "skip",
+        "reason": "Radarr frontend gate, and specifically Radarr catching up to the react-query patterns Sonarr already finished and we already ported."
+      },
+      "aae657b160787f1f3765d3ba5abbd6adb3a06f47": {
+        "subject": "Convert getLanguageName to hook",
+        "month": "2026-08",
+        "disposition": "skip",
+        "reason": "Radarr frontend gate. Same react-query catch-up we moved past with the Sonarr port."
+      },
+      "109f88d7b50a4ba9b1a8430dfafa0b5e0d6fc451": {
+        "subject": "New: Use translations for days of week",
+        "month": "2026-08",
+        "disposition": "skip",
+        "reason": "Frontend plus an en.json hunk. Our frontend follows Sonarr and we never take an upstream en.json diff."
+      },
+      "3287f8e14ae5204604fb12d8fc1101b77903d35a": {
+        "subject": "New: Search movies by original title from page header",
+        "month": "2026-08",
+        "disposition": "skip",
+        "reason": "Radarr frontend gate. Original-title search is a Radarr movie concept and the component is Radarr-shaped."
+      },
+      "c53ccacbce65ed6c61e802038213413d720e0bc6": {
+        "subject": "Bump swiper to 14.1.0",
+        "month": "2026-08",
+        "disposition": "skip",
+        "reason": "Radarr frontend gate; a dependency bump in their package.json, not ours."
+      },
+      "fd8eb4d1593f05b3025b17a61265cbc6593d8e91": {
+        "subject": "Fixed: Don't allow pushed releases to bypass pending releases that recently expired",
+        "month": "2026-08",
+        "disposition": "skip",
+        "reason": "Wanted, but deferred to its own PR by decision on 2026-08-30. Real bug, but the new PendingSpecification needs to know a release was pushed, so it changes IDownloadDecisionEngineSpecification from (RemoteMovie, SearchCriteria) to (RemoteMovie, ReleaseDecisionInformation) across ~25 specifications and ~25 fixtures. 65 files wants its own review."
+      },
+      "dbcb327a1134d26d2feb9b4589ee8c7b2dafb1ae": {
+        "subject": "New: Include External IDs for movies with links",
+        "month": "2026-08",
+        "disposition": "skip",
+        "reason": "Radarr frontend gate. External id links are built around Radarr's movie link groups."
+      },
+      "f62cb92c105b761c142cedfef2e3eed024f6e922": {
+        "subject": "Display external ID only for main movie link group",
+        "month": "2026-08",
+        "disposition": "skip",
+        "reason": "Radarr frontend gate, and a follow-up to dbcb327a1 which we are not taking."
+      },
+      "a11778302bc04e9d60b7d1d0c640c423272deb0b": {
+        "subject": "Bump FluentAssertions to 7.2.2",
+        "month": "2026-08",
+        "disposition": "have",
+        "reason": "We are on FluentAssertions 8.10.0, ahead of the version this moves Radarr to."
+      },
+      "94ef97b1f1187aeeca20d658a747620df8980238": {
+        "subject": "Improve zip extraction",
+        "month": "2026-08",
+        "disposition": "pick",
+        "reason": "Zip slip. Our ArchiveService had no path check either, so an archive naming an entry ../../x could write anywhere the process can reach. Same fix as Sonarr f089df054."
+      },
+      "72ae0c011dc3297b6b5b9feb8971da28977f510c": {
+        "subject": "Add reason to health check",
+        "month": "2026-08",
+        "disposition": "skip",
+        "reason": "Deferred to its own PR by decision on 2026-08-30. A diagnostics feature rather than a fix, touching all 36 health checks plus the HealthCheck model."
+      },
+      "91c6dc4eac9883e8389145ff4728858442502212": {
+        "subject": "New: Add hostname validation",
+        "month": "2026-08",
+        "disposition": "skip",
+        "reason": "Taking Sonarr's original instead, by decision on 2026-08-30. Radarr's is a pick of sonarr/sonarr@1579a8bb7f89803d0850369f3ff7980d6edaf31d, which the Sonarr 2026-08 chunk covers. Keeps one source for the security code rather than importing Radarr's re-spin plus its Radarr-shaped frontend."
+      },
+      "387d43d7aecc3dfa63f780bf93a72e0966aab319": {
+        "subject": "New: Add Trusted Networks setting",
+        "month": "2026-08",
+        "disposition": "skip",
+        "reason": "Taking Sonarr's original instead, by decision on 2026-08-30. Radarr's is a pick of sonarr/sonarr@022f69e14bc333588bc775b9cab98f5e8f12df0c, which the Sonarr 2026-08 chunk covers."
+      },
+      "c3f0654984994145deeb6bfbdd77654653fd2224": {
+        "subject": "Fix allowed hosts check check on config file changes",
+        "month": "2026-08",
+        "disposition": "skip",
+        "reason": "Follow-up to the AllowedHostsCheck that 91c6dc4ea introduces. We have no such check yet; it rides along when we take the hostname validation from Sonarr."
+      },
+      "e575ec5e5e856ebbfeef1c4c1f9b55a86e0d1641": {
+        "subject": "Add isSaving to createSettingsSectionSelector",
+        "month": "2026-08",
+        "disposition": "skip",
+        "reason": "Radarr frontend gate, and specifically a Redux selector - we removed Redux in #549."
+      },
+      "fb908fd5f4861a529e6d60e12ee0a214e24c80ef": {
+        "subject": "Remove configuring as service duplicated PostgresOptions",
+        "month": "2026-08",
+        "disposition": "have",
+        "reason": "Our Bootstrap registers PostgresOptions once in each of the two host builders; there is no duplicated line to remove."
+      },
+      "02ef5f56d54aaf46216b6718fd3591ad253548e5": {
+        "subject": "Bump to 6.4.3",
+        "month": "2026-08",
+        "disposition": "skip",
+        "reason": "Radarr version bump. Our versioning is independent."
+      },
+      "1906cfb3819b6e9f603642020c6a7d689c8e5352": {
+        "subject": "Fixed: Format of timestamps for Discord notifications from some systems",
+        "month": "2026-08",
+        "disposition": "pick",
+        "reason": "Reproduced the premise before taking it: a custom format string renders the year in the current culture's calendar, so th-TH produced 2569 and ar-SA produced 1448. \"O\" is culture-invariant. Seven call sites here."
+      },
+      "bdd5a726071630f408c85fe1b716c5bef108d513": {
+        "subject": "Multiple Translations updated by Weblate",
+        "month": "2026-08",
+        "disposition": "skip",
+        "reason": "Weblate commit. Our translations come from Weblate directly, never from cherry-picks."
+      },
+      "40bb746c5e3f5929f09e0edb9350c721e7670065": {
+        "subject": "Fixed: Connecting to Jellyfin 12+",
+        "month": "2026-08",
+        "disposition": "pick",
+        "reason": "Jellyfin 12 dropped the X-MediaBrowser-Token header in favour of the Authorization: MediaBrowser Token=\"...\" scheme, so the connector stops working outright. Also splits Test into a real connection check plus an optional notification, which is what made a Jellyfin test fail on the notification endpoint rather than the connection."
+      },
+      "2cfc781f85c6fb0355f4c37da5c68d86616e7bdf": {
+        "subject": "Fixed: Ignore invalid languages during Manual Import",
+        "month": "2026-08",
+        "disposition": "pick",
+        "reason": "Adds Language.IsValid and stops a manual import overwriting the aggregated languages with a bad client payload. Adapted the lookup: Radarr has a Lookup dictionary, we search All by id."
+      },
+      "9910767f58b0d9beb3b7fa671ed4695487d917d3": {
+        "subject": "Fixed: Unexpected languages stored in DB will be treated as Unknown",
+        "month": "2026-08",
+        "disposition": "pick",
+        "reason": "Identical converter here. A null language column made GetInt32 throw, so one bad row took down whatever was deserializing it instead of degrading to Unknown."
+      },
+      "45da623c777c2451bff5684718832952925f2be3": {
+        "subject": "Fixed: Re-grabbing a torrent that was already imported should re-import",
+        "month": "2026-08",
+        "disposition": "pick",
+        "reason": "Same gap here: nothing evicted a tracked download on a new grab, so re-grabbing a release we had already imported kept the old terminal state and the new download was never imported."
+      },
+      "68b93db78cb7a648d61a486d94eae703242e1e36": {
+        "subject": "Fixed: Importing single files from Freebox",
+        "month": "2026-08",
+        "disposition": "pick",
+        "reason": "Freebox drops a single-file torrent straight into the download root, so there is no folder to identify it by and the import matched the wrong thing. Now each task gets its own folder named for the release. Updated the three existing fixture assertions, which encoded the old paths - that path change is the fix, not a workaround."
       }
     },
     "sonarr": {}

--- a/UPSTREAM_SYNC.md
+++ b/UPSTREAM_SYNC.md
@@ -7,52 +7,9 @@ See `.github/upstream/state.json` for the machine state and the `sync-upstream` 
 
 ## radarr — Radarr/Radarr `develop`
 
-Owns: **backend**. High-water mark: `15369ed5c3`.
+Owns: **backend**. High-water mark: `68b93db78c`.
 
-**36 outstanding.**
-
-| Month | Total | be | fe | be+fe | chore |
-| --- | ---: | ---: | ---: | ---: | ---: |
-| 2026-08 | 36 | 22 | 8 | 4 | 2 |
-
-### 2026-08
-
-- `chore` [`598f989ad`](https://github.com/Radarr/Radarr/commit/598f989ad1163b3ed21ef57880ba8ba4d1b07e51) Bump to 6.4.2 — *Auggie*
-- `be   ` [`34b0f5450`](https://github.com/Radarr/Radarr/commit/34b0f5450fdc346cc72cf18669e601d68b974250) Fixed: Parse Celdra as release group — *Bogdan*
-- `be   ` [`80bbaa6e4`](https://github.com/Radarr/Radarr/commit/80bbaa6e413c84dc901b090d33ecc66190e7d83b) Fixed: Parsing quality and languages when manual importing item with multiple movies error — *Bogdan*
-- `be   ` [`d2d9dce33`](https://github.com/Radarr/Radarr/commit/d2d9dce33baf969ee5801820ee7cdac25d5b8b89) Fix parsing already imported items from download clients — *Bogdan*
-- `be   ` [`25062f2d7`](https://github.com/Radarr/Radarr/commit/25062f2d7aec0bcc83551f48e94836fa658c28ef) Fix queue not showing items with issues — *Bogdan*
-- `be   ` [`c6fef4309`](https://github.com/Radarr/Radarr/commit/c6fef4309de3ffdd5e0e9607ad30beb12d791333) Return maximum long value on overflow getting disk information — *Mark McDowall*
-- `be   ` [`ca451608d`](https://github.com/Radarr/Radarr/commit/ca451608dc60c6cec754aba8d96bfa30e9468ed5) Bump sqlite to 3.53.4 — *Bogdan*
-- `fe   ` [`6bb8edeaf`](https://github.com/Radarr/Radarr/commit/6bb8edeafdf71829249702f0e85cd8d6c7809a5c) Remove offensive joke about a sensitive topic — *Corgo*
-- `be+fe` [`6a1c50028`](https://github.com/Radarr/Radarr/commit/6a1c50028457d45712316d06b1c07f5387987835) Fixed: Broken Trakt links — *Joshua Higgins*
-- `be   ` [`b8a3923bc`](https://github.com/Radarr/Radarr/commit/b8a3923bce9d80eccc0abcbc0cbb4ff4091e7999) Fixed: Parsing anime releases that contain year in the movie title — *Camillo Positano*
-- `be   ` [`a598695ec`](https://github.com/Radarr/Radarr/commit/a598695ecd70c95b38f4f9efcd1dbe12cccd2f49) Multiple Translations updated by Weblate — *Weblate*
-- `be   ` [`2c24d9b4a`](https://github.com/Radarr/Radarr/commit/2c24d9b4aafd00dedea4505119060c242c0963be) Fixed: Trakt OAuth URL — *RobinDadswell*
-- `fe   ` [`25eeec39b`](https://github.com/Radarr/Radarr/commit/25eeec39b5c43422e2e81cae3758a902890d9e40) Query options support for useApiQuery — *Mark McDowall*
-- `fe   ` [`aae657b16`](https://github.com/Radarr/Radarr/commit/aae657b160787f1f3765d3ba5abbd6adb3a06f47) Convert getLanguageName to hook — *Mark McDowall*
-- `be+fe` [`109f88d7b`](https://github.com/Radarr/Radarr/commit/109f88d7b50a4ba9b1a8430dfafa0b5e0d6fc451) New: Use translations for days of week — *Mark McDowall*
-- `fe   ` [`3287f8e14`](https://github.com/Radarr/Radarr/commit/3287f8e14ae5204604fb12d8fc1101b77903d35a) New: Search movies by original title from page header — *Bogdan*
-- `fe   ` [`c53ccacbc`](https://github.com/Radarr/Radarr/commit/c53ccacbce65ed6c61e802038213413d720e0bc6) Bump swiper to 14.1.0 — *Bogdan*
-- `be   ` [`fd8eb4d15`](https://github.com/Radarr/Radarr/commit/fd8eb4d1593f05b3025b17a61265cbc6593d8e91) Fixed: Don't allow pushed releases to bypass pending releases that recently expired — *Mark McDowall*
-- `fe   ` [`dbcb327a1`](https://github.com/Radarr/Radarr/commit/dbcb327a1134d26d2feb9b4589ee8c7b2dafb1ae) New: Include External IDs for movies with links — *Yashizzle*
-- `fe   ` [`f62cb92c1`](https://github.com/Radarr/Radarr/commit/f62cb92c105b761c142cedfef2e3eed024f6e922) Display external ID only for main movie link group — *Bogdan*
-- `be   ` [`a11778302`](https://github.com/Radarr/Radarr/commit/a11778302bc04e9d60b7d1d0c640c423272deb0b) Bump FluentAssertions to 7.2.2 — *Bogdan*
-- `be   ` [`94ef97b1f`](https://github.com/Radarr/Radarr/commit/94ef97b1f1187aeeca20d658a747620df8980238) Improve zip extraction — *Mark McDowall*
-- `be   ` [`72ae0c011`](https://github.com/Radarr/Radarr/commit/72ae0c011dc3297b6b5b9feb8971da28977f510c) Add reason to health check — *Mark McDowall*
-- `be+fe` [`91c6dc4ea`](https://github.com/Radarr/Radarr/commit/91c6dc4eac9883e8389145ff4728858442502212) New: Add hostname validation — *Mark McDowall*
-- `be+fe` [`387d43d7a`](https://github.com/Radarr/Radarr/commit/387d43d7aecc3dfa63f780bf93a72e0966aab319) New: Add Trusted Networks setting — *Mark McDowall*
-- `be   ` [`c3f065498`](https://github.com/Radarr/Radarr/commit/c3f0654984994145deeb6bfbdd77654653fd2224) Fix allowed hosts check check on config file changes — *Bogdan*
-- `fe   ` [`e575ec5e5`](https://github.com/Radarr/Radarr/commit/e575ec5e5e856ebbfeef1c4c1f9b55a86e0d1641) Add isSaving to createSettingsSectionSelector — *Bogdan*
-- `be   ` [`fb908fd5f`](https://github.com/Radarr/Radarr/commit/fb908fd5f4861a529e6d60e12ee0a214e24c80ef) Remove configuring as service duplicated PostgresOptions — *Bogdan*
-- `chore` [`02ef5f56d`](https://github.com/Radarr/Radarr/commit/02ef5f56d54aaf46216b6718fd3591ad253548e5) Bump to 6.4.3 — *Auggie*
-- `be   ` [`1906cfb38`](https://github.com/Radarr/Radarr/commit/1906cfb3819b6e9f603642020c6a7d689c8e5352) Fixed: Format of timestamps for Discord notifications from some systems — *Alexander*
-- `be   ` [`bdd5a7260`](https://github.com/Radarr/Radarr/commit/bdd5a726071630f408c85fe1b716c5bef108d513) Multiple Translations updated by Weblate — *Weblate*
-- `be   ` [`40bb746c5`](https://github.com/Radarr/Radarr/commit/40bb746c5e3f5929f09e0edb9350c721e7670065) Fixed: Connecting to Jellyfin 12+ (#11663) — *Auggie*
-- `be   ` [`2cfc781f8`](https://github.com/Radarr/Radarr/commit/2cfc781f85c6fb0355f4c37da5c68d86616e7bdf) Fixed: Ignore invalid languages during Manual Import — *Bogdan*
-- `be   ` [`9910767f5`](https://github.com/Radarr/Radarr/commit/9910767f58b0d9beb3b7fa671ed4695487d917d3) Fixed: Unexpected languages stored in DB will be treated as Unknown — *Mark McDowall*
-- `be   ` [`45da623c7`](https://github.com/Radarr/Radarr/commit/45da623c777c2451bff5684718832952925f2be3) Fixed: Re-grabbing a torrent that was already imported should re-import — *Mark McDowall*
-- `be   ` [`68b93db78`](https://github.com/Radarr/Radarr/commit/68b93db78cb7a648d61a486d94eae703242e1e36) Fixed: Importing single files from Freebox — *Bogdan*
+Caught up — nothing outstanding.
 
 ## sonarr — Sonarr/Sonarr `v5-develop`
 
@@ -210,3 +167,39 @@ Commits reviewed and dispositioned. Skips carry their reason.
 | [`0c78421d5`](https://github.com/Radarr/Radarr/commit/0c78421d553f8395fee14171892da60650123c97) | Fix disposing of the HttpRequestMessage | `pick` | Identical code in our ManagedHttpDispatcher. HttpRequestMessage and its ByteArrayContent were never disposed on any request. Also unwraps the stray block left behind when SendAsync moved to a using declaration. |
 | [`9f0328d31`](https://github.com/Radarr/Radarr/commit/9f0328d31781b488659fa33119b5a0fd5419da1d) | Update major version to 6.4.1 | `skip` | Radarr version bump. Our versioning is independent. |
 | [`15369ed5c`](https://github.com/Radarr/Radarr/commit/15369ed5c359c9704783d243ce2b55e59a40a3a3) | New: RQBit download client | `skip` | Declined on 2026-08-30. A new download client, not a fix: ~950 lines of client, proxy, settings and six response models we would own, unverifiable without running an rqbit instance, and nobody has asked for it. |
+| [`598f989ad`](https://github.com/Radarr/Radarr/commit/598f989ad1163b3ed21ef57880ba8ba4d1b07e51) | Bump to 6.4.2 | `skip` | Radarr version bump. Our versioning is independent. |
+| [`34b0f5450`](https://github.com/Radarr/Radarr/commit/34b0f5450fdc346cc72cf18669e601d68b974250) | Fixed: Parse Celdra as release group | `skip` | Parser gate. Adds a release group token to Radarr's grammar; our Parser.cs is a different grammar entirely and the bar to touch it is a failing test against our parser, which this does not produce. |
+| [`80bbaa6e4`](https://github.com/Radarr/Radarr/commit/80bbaa6e413c84dc901b090d33ecc66190e7d83b) | Fixed: Parsing quality and languages when manual importing item with multiple movies error | `pick` | Identical shape here. Quality, Languages and Rejections were left null on ManualImportItem, so the multiple-movies path dereferenced them while building the error response. |
+| [`d2d9dce33`](https://github.com/Radarr/Radarr/commit/d2d9dce33baf969ee5801820ee7cdac25d5b8b89) | Fix parsing already imported items from download clients | `pick` | Same ordering problem in our TrackedDownloadService. Once a download has been imported we know its movie id, but the title was still being re-parsed and mapped by name, so a title our parser reads differently lost its movie. |
+| [`25062f2d7`](https://github.com/Radarr/Radarr/commit/25062f2d7aec0bcc83551f48e94836fa658c28ef) | Fix queue not showing items with issues | `pick` | Returning null dropped the tracked download entirely, so an item we could not parse never reached the queue and the user got no explanation. Now it is tracked with a warning. |
+| [`c6fef4309`](https://github.com/Radarr/Radarr/commit/c6fef4309de3ffdd5e0e9607ad30beb12d791333) | Return maximum long value on overflow getting disk information | `pick` | Identical ProcMount here. UnixDriveInfo throws OverflowException on filesystems reporting sizes beyond long, which took out disk space checks entirely rather than degrading. |
+| [`ca451608d`](https://github.com/Radarr/Radarr/commit/ca451608dc60c6cec754aba8d96bfa30e9468ed5) | Bump sqlite to 3.53.4 | `have` | We are already on SourceGear.sqlite3 3.53.4 and System.Data.SQLite 2.0.4 - the exact versions this commit moves Radarr to. |
+| [`6bb8edeaf`](https://github.com/Radarr/Radarr/commit/6bb8edeafdf71829249702f0e85cd8d6c7809a5c) | Remove offensive joke about a sensitive topic | `skip` | Radarr frontend gate. Edits a Radarr loading-message string we do not carry. |
+| [`6a1c50028`](https://github.com/Radarr/Radarr/commit/6a1c50028457d45712316d06b1c07f5387987835) | Fixed: Broken Trakt links | `pick` | Verified live before taking it: https://trakt.tv/search/tmdb/550?id_type=movie now redirects to app.trakt.tv and returns 404, while https://trakt.tv/movies/tt0137523 returns 200. Applied to Gotify and Telegram; our Discord connector links StashDB and TMDb rather than Trakt, and we skipped the frontend half. |
+| [`b8a3923bc`](https://github.com/Radarr/Radarr/commit/b8a3923bce9d80eccc0abcbc0cbb4ff4091e7999) | Fixed: Parsing anime releases that contain year in the movie title | `skip` | Parser gate, and the worst possible collision: it changes year-vs-title precedence, which is exactly where our grammar deliberately differs. A bare [YYYY] means a movie here; scenes carry full dates. |
+| [`a598695ec`](https://github.com/Radarr/Radarr/commit/a598695ecd70c95b38f4f9efcd1dbe12cccd2f49) | Multiple Translations updated by Weblate | `skip` | Weblate commit. Our translations come from Weblate directly, never from cherry-picks. |
+| [`2c24d9b4a`](https://github.com/Radarr/Radarr/commit/2c24d9b4aafd00dedea4505119060c242c0963be) | Fixed: Trakt OAuth URL | `pick` | One-line const. Both hosts currently 307 to the same /api/auth/oauth2/authorize endpoint, so this is following upstream to Trakt's canonical auth host rather than repairing an observed break. |
+| [`25eeec39b`](https://github.com/Radarr/Radarr/commit/25eeec39b5c43422e2e81cae3758a902890d9e40) | Query options support for useApiQuery | `skip` | Radarr frontend gate, and specifically Radarr catching up to the react-query patterns Sonarr already finished and we already ported. |
+| [`aae657b16`](https://github.com/Radarr/Radarr/commit/aae657b160787f1f3765d3ba5abbd6adb3a06f47) | Convert getLanguageName to hook | `skip` | Radarr frontend gate. Same react-query catch-up we moved past with the Sonarr port. |
+| [`109f88d7b`](https://github.com/Radarr/Radarr/commit/109f88d7b50a4ba9b1a8430dfafa0b5e0d6fc451) | New: Use translations for days of week | `skip` | Frontend plus an en.json hunk. Our frontend follows Sonarr and we never take an upstream en.json diff. |
+| [`3287f8e14`](https://github.com/Radarr/Radarr/commit/3287f8e14ae5204604fb12d8fc1101b77903d35a) | New: Search movies by original title from page header | `skip` | Radarr frontend gate. Original-title search is a Radarr movie concept and the component is Radarr-shaped. |
+| [`c53ccacbc`](https://github.com/Radarr/Radarr/commit/c53ccacbce65ed6c61e802038213413d720e0bc6) | Bump swiper to 14.1.0 | `skip` | Radarr frontend gate; a dependency bump in their package.json, not ours. |
+| [`fd8eb4d15`](https://github.com/Radarr/Radarr/commit/fd8eb4d1593f05b3025b17a61265cbc6593d8e91) | Fixed: Don't allow pushed releases to bypass pending releases that recently expired | `skip` | Wanted, but deferred to its own PR by decision on 2026-08-30. Real bug, but the new PendingSpecification needs to know a release was pushed, so it changes IDownloadDecisionEngineSpecification from (RemoteMovie, SearchCriteria) to (RemoteMovie, ReleaseDecisionInformation) across ~25 specifications and ~25 fixtures. 65 files wants its own review. |
+| [`dbcb327a1`](https://github.com/Radarr/Radarr/commit/dbcb327a1134d26d2feb9b4589ee8c7b2dafb1ae) | New: Include External IDs for movies with links | `skip` | Radarr frontend gate. External id links are built around Radarr's movie link groups. |
+| [`f62cb92c1`](https://github.com/Radarr/Radarr/commit/f62cb92c105b761c142cedfef2e3eed024f6e922) | Display external ID only for main movie link group | `skip` | Radarr frontend gate, and a follow-up to dbcb327a1 which we are not taking. |
+| [`a11778302`](https://github.com/Radarr/Radarr/commit/a11778302bc04e9d60b7d1d0c640c423272deb0b) | Bump FluentAssertions to 7.2.2 | `have` | We are on FluentAssertions 8.10.0, ahead of the version this moves Radarr to. |
+| [`94ef97b1f`](https://github.com/Radarr/Radarr/commit/94ef97b1f1187aeeca20d658a747620df8980238) | Improve zip extraction | `pick` | Zip slip. Our ArchiveService had no path check either, so an archive naming an entry ../../x could write anywhere the process can reach. Same fix as Sonarr f089df054. |
+| [`72ae0c011`](https://github.com/Radarr/Radarr/commit/72ae0c011dc3297b6b5b9feb8971da28977f510c) | Add reason to health check | `skip` | Deferred to its own PR by decision on 2026-08-30. A diagnostics feature rather than a fix, touching all 36 health checks plus the HealthCheck model. |
+| [`91c6dc4ea`](https://github.com/Radarr/Radarr/commit/91c6dc4eac9883e8389145ff4728858442502212) | New: Add hostname validation | `skip` | Taking Sonarr's original instead, by decision on 2026-08-30. Radarr's is a pick of sonarr/sonarr@1579a8bb7f89803d0850369f3ff7980d6edaf31d, which the Sonarr 2026-08 chunk covers. Keeps one source for the security code rather than importing Radarr's re-spin plus its Radarr-shaped frontend. |
+| [`387d43d7a`](https://github.com/Radarr/Radarr/commit/387d43d7aecc3dfa63f780bf93a72e0966aab319) | New: Add Trusted Networks setting | `skip` | Taking Sonarr's original instead, by decision on 2026-08-30. Radarr's is a pick of sonarr/sonarr@022f69e14bc333588bc775b9cab98f5e8f12df0c, which the Sonarr 2026-08 chunk covers. |
+| [`c3f065498`](https://github.com/Radarr/Radarr/commit/c3f0654984994145deeb6bfbdd77654653fd2224) | Fix allowed hosts check check on config file changes | `skip` | Follow-up to the AllowedHostsCheck that 91c6dc4ea introduces. We have no such check yet; it rides along when we take the hostname validation from Sonarr. |
+| [`e575ec5e5`](https://github.com/Radarr/Radarr/commit/e575ec5e5e856ebbfeef1c4c1f9b55a86e0d1641) | Add isSaving to createSettingsSectionSelector | `skip` | Radarr frontend gate, and specifically a Redux selector - we removed Redux in #549. |
+| [`fb908fd5f`](https://github.com/Radarr/Radarr/commit/fb908fd5f4861a529e6d60e12ee0a214e24c80ef) | Remove configuring as service duplicated PostgresOptions | `have` | Our Bootstrap registers PostgresOptions once in each of the two host builders; there is no duplicated line to remove. |
+| [`02ef5f56d`](https://github.com/Radarr/Radarr/commit/02ef5f56d54aaf46216b6718fd3591ad253548e5) | Bump to 6.4.3 | `skip` | Radarr version bump. Our versioning is independent. |
+| [`1906cfb38`](https://github.com/Radarr/Radarr/commit/1906cfb3819b6e9f603642020c6a7d689c8e5352) | Fixed: Format of timestamps for Discord notifications from some systems | `pick` | Reproduced the premise before taking it: a custom format string renders the year in the current culture's calendar, so th-TH produced 2569 and ar-SA produced 1448. "O" is culture-invariant. Seven call sites here. |
+| [`bdd5a7260`](https://github.com/Radarr/Radarr/commit/bdd5a726071630f408c85fe1b716c5bef108d513) | Multiple Translations updated by Weblate | `skip` | Weblate commit. Our translations come from Weblate directly, never from cherry-picks. |
+| [`40bb746c5`](https://github.com/Radarr/Radarr/commit/40bb746c5e3f5929f09e0edb9350c721e7670065) | Fixed: Connecting to Jellyfin 12+ | `pick` | Jellyfin 12 dropped the X-MediaBrowser-Token header in favour of the Authorization: MediaBrowser Token="..." scheme, so the connector stops working outright. Also splits Test into a real connection check plus an optional notification, which is what made a Jellyfin test fail on the notification endpoint rather than the connection. |
+| [`2cfc781f8`](https://github.com/Radarr/Radarr/commit/2cfc781f85c6fb0355f4c37da5c68d86616e7bdf) | Fixed: Ignore invalid languages during Manual Import | `pick` | Adds Language.IsValid and stops a manual import overwriting the aggregated languages with a bad client payload. Adapted the lookup: Radarr has a Lookup dictionary, we search All by id. |
+| [`9910767f5`](https://github.com/Radarr/Radarr/commit/9910767f58b0d9beb3b7fa671ed4695487d917d3) | Fixed: Unexpected languages stored in DB will be treated as Unknown | `pick` | Identical converter here. A null language column made GetInt32 throw, so one bad row took down whatever was deserializing it instead of degrading to Unknown. |
+| [`45da623c7`](https://github.com/Radarr/Radarr/commit/45da623c777c2451bff5684718832952925f2be3) | Fixed: Re-grabbing a torrent that was already imported should re-import | `pick` | Same gap here: nothing evicted a tracked download on a new grab, so re-grabbing a release we had already imported kept the old terminal state and the new download was never imported. |
+| [`68b93db78`](https://github.com/Radarr/Radarr/commit/68b93db78cb7a648d61a486d94eae703242e1e36) | Fixed: Importing single files from Freebox | `pick` | Freebox drops a single-file torrent straight into the download root, so there is no folder to identify it by and the import matched the wrong thing. Now each task gets its own folder named for the release. Updated the three existing fixture assertions, which encoded the old paths - that path change is the fix, not a workaround. |

--- a/src/NzbDrone.Common/ArchiveService.cs
+++ b/src/NzbDrone.Common/ArchiveService.cs
@@ -86,6 +86,13 @@ namespace NzbDrone.Common
 
                     // Manipulate the output filename here as desired.
                     var fullZipToPath = Path.Combine(destination, entryFileName);
+
+                    // Ensure the destination path is within the target directory
+                    if (!Path.GetFullPath(fullZipToPath).StartsWith(Path.GetFullPath(destination).TrimEnd(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar))
+                    {
+                        throw new IOException($"Entry is outside the target dir: {entryFileName}");
+                    }
+
                     var directoryName = Path.GetDirectoryName(fullZipToPath);
                     if (directoryName.Length > 0)
                     {

--- a/src/NzbDrone.Core.Test/Datastore/Converters/LanguageIntConverterFixture.cs
+++ b/src/NzbDrone.Core.Test/Datastore/Converters/LanguageIntConverterFixture.cs
@@ -1,0 +1,41 @@
+using System.Text.Json;
+using FluentAssertions;
+using NUnit.Framework;
+using NzbDrone.Core.Languages;
+using NzbDrone.Core.Test.Framework;
+
+namespace NzbDrone.Core.Test.Datastore.Converters
+{
+    [TestFixture]
+    public class LanguageIntConverterFixture : CoreTest
+    {
+        private JsonSerializerOptions _options;
+
+        [SetUp]
+        public void Setup()
+        {
+            _options = new JsonSerializerOptions();
+            _options.Converters.Add(new NzbDrone.Core.Datastore.Converters.LanguageIntConverter());
+        }
+
+        [Test]
+        public void should_read_language_id()
+        {
+            JsonSerializer.Deserialize<Language>("1", _options).Should().Be(Language.English);
+        }
+
+        [Test]
+        public void should_read_null_as_unknown()
+        {
+            // A null language stored in the DB threw on GetInt32 instead of falling back, so a
+            // single bad row took down whatever was deserializing it.
+            JsonSerializer.Deserialize<Language>("null", _options).Should().Be(Language.Unknown);
+        }
+
+        [Test]
+        public void should_write_language_id()
+        {
+            JsonSerializer.Serialize(Language.English, _options).Should().Be("1");
+        }
+    }
+}

--- a/src/NzbDrone.Core.Test/Download/DownloadClientTests/FreeboxDownloadTests/TorrentFreeboxDownloadFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientTests/FreeboxDownloadTests/TorrentFreeboxDownloadFixture.cs
@@ -25,11 +25,8 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.FreeboxDownloadTests
         protected FreeboxDownloadTask _task;
 
         protected string _defaultDestination = @"/some/path";
-        protected string _encodedDefaultDestination = "L3NvbWUvcGF0aA==";
         protected string _category = "somecat";
-        protected string _encodedDefaultDestinationAndCategory = "L3NvbWUvcGF0aC9zb21lY2F0";
         protected string _destinationDirectory = @"/path/to/media";
-        protected string _encodedDestinationDirectory = "L3BhdGgvdG8vbWVkaWE=";
         protected OsPath _physicalPath = new OsPath("/mnt/sdb1/mydata");
         protected string _downloadURL => "magnet:?xt=urn:btih:5dee65101db281ac9c46344cd6b175cdcad53426&dn=download";
 
@@ -51,7 +48,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.FreeboxDownloadTests
 
             _downloadConfiguration = new FreeboxDownloadConfiguration()
             {
-                DownloadDirectory = _encodedDefaultDestination
+                DownloadDirectory = _defaultDestination.EncodeBase64()
             };
 
             _task = new FreeboxDownloadTask()
@@ -157,7 +154,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.FreeboxDownloadTests
             await Subject.Download(remoteMovie, CreateIndexer());
 
             Mocker.GetMock<IFreeboxDownloadProxy>()
-                  .Verify(v => v.AddTaskFromUrl(It.IsAny<string>(), _encodedDestinationDirectory, It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<double?>(), It.IsAny<FreeboxDownloadSettings>()), Times.Once());
+                  .Verify(v => v.AddTaskFromUrl(It.IsAny<string>(), $"{_destinationDirectory}/{_title}".EncodeBase64(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<double?>(), It.IsAny<FreeboxDownloadSettings>()), Times.Once());
         }
 
         [Test]
@@ -172,7 +169,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.FreeboxDownloadTests
             await Subject.Download(remoteMovie, CreateIndexer());
 
             Mocker.GetMock<IFreeboxDownloadProxy>()
-                  .Verify(v => v.AddTaskFromUrl(It.IsAny<string>(), _encodedDefaultDestinationAndCategory, It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<double?>(), It.IsAny<FreeboxDownloadSettings>()), Times.Once());
+                  .Verify(v => v.AddTaskFromUrl(It.IsAny<string>(), $"{_defaultDestination}/{_category}/{_title}".EncodeBase64(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<double?>(), It.IsAny<FreeboxDownloadSettings>()), Times.Once());
         }
 
         [Test]
@@ -186,7 +183,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.FreeboxDownloadTests
             await Subject.Download(remoteMovie, CreateIndexer());
 
             Mocker.GetMock<IFreeboxDownloadProxy>()
-                  .Verify(v => v.AddTaskFromUrl(It.IsAny<string>(), _encodedDefaultDestination, It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<double?>(), It.IsAny<FreeboxDownloadSettings>()), Times.Once());
+                  .Verify(v => v.AddTaskFromUrl(It.IsAny<string>(), $"{_defaultDestination}/{_title}".EncodeBase64(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<double?>(), It.IsAny<FreeboxDownloadSettings>()), Times.Once());
         }
 
         [TestCase(false, false)]

--- a/src/NzbDrone.Core.Test/Download/TrackedDownloads/TrackedDownloadServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/TrackedDownloads/TrackedDownloadServiceFixture.cs
@@ -4,6 +4,7 @@ using FluentAssertions;
 using Moq;
 using NUnit.Framework;
 using NzbDrone.Core.Download;
+using NzbDrone.Core.Download.History;
 using NzbDrone.Core.Download.TrackedDownloads;
 using NzbDrone.Core.History;
 using NzbDrone.Core.Indexers;
@@ -196,6 +197,136 @@ namespace NzbDrone.Core.Test.Download.TrackedDownloads
             var trackedDownloads = Subject.GetTrackedDownloads();
             trackedDownloads.Should().HaveCount(1);
             trackedDownloads.First().RemoteMovie.Should().BeNull();
+        }
+
+        [Test]
+        public void should_map_to_the_imported_movie_when_the_download_was_already_imported()
+        {
+            // Parsing the client title on its own goes looking for a movie by name. Once we have
+            // already imported this download we know which movie it was, so use that instead of
+            // re-deriving it and risking a miss.
+            GivenDownloadHistory();
+
+            Mocker.GetMock<IDownloadHistoryService>()
+                .Setup(s => s.GetLatestDownloadHistoryItem(It.IsAny<string>()))
+                .Returns(new DownloadHistory
+                {
+                    DownloadId = "35238",
+                    EventType = DownloadHistoryEventType.DownloadImported,
+                    MovieId = 3
+                });
+
+            var remoteMovie = new RemoteMovie
+            {
+                Movie = new Movie { Id = 3 },
+                ParsedMovieInfo = new ParsedMovieInfo
+                {
+                    MovieTitles = new List<string> { "A Movie" },
+                    Year = 1998
+                }
+            };
+
+            Mocker.GetMock<IParsingService>()
+                .Setup(s => s.Map(It.IsAny<ParsedMovieInfo>(), 3))
+                .Returns(remoteMovie);
+
+            var trackedDownload = Subject.TrackDownload(GivenClient(), GivenItem("35238"));
+
+            trackedDownload.RemoteMovie.Movie.Id.Should().Be(3);
+
+            Mocker.GetMock<IParsingService>()
+                .Verify(s => s.Map(It.IsAny<ParsedMovieInfo>(), 3), Times.Once());
+
+            Mocker.GetMock<IParsingService>()
+                .Verify(s => s.Map(It.IsAny<ParsedMovieInfo>(), It.IsAny<string>(), It.IsAny<int>(), null), Times.Never());
+        }
+
+        [Test]
+        public void should_keep_tracking_the_item_when_the_movie_cannot_be_found()
+        {
+            // Returning null here dropped the item entirely, so a download that failed to parse
+            // never appeared in the queue and there was nothing to tell the user why.
+            Mocker.GetMock<IHistoryService>()
+                .Setup(s => s.FindByDownloadId(It.IsAny<string>()))
+                .Throws(new System.InvalidOperationException("boom"));
+
+            var trackedDownload = Subject.TrackDownload(GivenClient(), GivenItem("12345"));
+
+            trackedDownload.Should().NotBeNull();
+            trackedDownload.Status.Should().Be(TrackedDownloadStatus.Warning);
+            trackedDownload.StatusMessages.Should().ContainSingle(m => m.Messages.Contains("Unable to parse movie from title"));
+
+            Subject.GetTrackedDownloads().Should().HaveCount(1);
+        }
+
+        [TestCase(TrackedDownloadState.Imported)]
+        [TestCase(TrackedDownloadState.Failed)]
+        [TestCase(TrackedDownloadState.Ignored)]
+        public void should_stop_tracking_a_finished_download_that_is_grabbed_again(TrackedDownloadState state)
+        {
+            // Re-grabbing the same release is a fresh attempt. Keeping the old terminal state
+            // around made the new download look already handled, so it never imported.
+            GivenTrackedDownload("12345", state);
+
+            Subject.Handle(new MovieGrabbedEvent(new RemoteMovie()) { DownloadId = "12345" });
+
+            Subject.Find("12345").Should().BeNull();
+        }
+
+        [TestCase(TrackedDownloadState.Downloading)]
+        [TestCase(TrackedDownloadState.ImportBlocked)]
+        public void should_keep_tracking_an_unfinished_download_that_is_grabbed_again(TrackedDownloadState state)
+        {
+            GivenTrackedDownload("12345", state);
+
+            Subject.Handle(new MovieGrabbedEvent(new RemoteMovie()) { DownloadId = "12345" });
+
+            Subject.Find("12345").Should().NotBeNull();
+        }
+
+        [Test]
+        public void should_ignore_a_grab_without_a_download_id()
+        {
+            GivenTrackedDownload("12345", TrackedDownloadState.Imported);
+
+            Subject.Handle(new MovieGrabbedEvent(new RemoteMovie()) { DownloadId = null });
+
+            Subject.Find("12345").Should().NotBeNull();
+        }
+
+        private void GivenTrackedDownload(string downloadId, TrackedDownloadState state)
+        {
+            Mocker.GetMock<IHistoryService>()
+                .Setup(s => s.FindByDownloadId(It.IsAny<string>()))
+                .Returns(new List<MovieHistory>());
+
+            Subject.TrackDownload(GivenClient(), GivenItem(downloadId));
+            Subject.Find(downloadId).State = state;
+        }
+
+        private static DownloadClientDefinition GivenClient()
+        {
+            return new DownloadClientDefinition
+            {
+                Id = 1,
+                Protocol = DownloadProtocol.Torrent
+            };
+        }
+
+        private static DownloadClientItem GivenItem(string downloadId)
+        {
+            return new DownloadClientItem
+            {
+                Title = "A Movie 1998",
+                DownloadId = downloadId,
+                DownloadClientInfo = new DownloadClientItemClientInfo
+                {
+                    Id = 1,
+                    Type = "Blackhole",
+                    Name = "Blackhole Client",
+                    Protocol = DownloadProtocol.Torrent
+                }
+            };
         }
     }
 }

--- a/src/NzbDrone.Core.Test/Languages/LanguageFixture.cs
+++ b/src/NzbDrone.Core.Test/Languages/LanguageFixture.cs
@@ -1,3 +1,4 @@
+using System;
 using FluentAssertions;
 using NUnit.Framework;
 using NzbDrone.Core.Languages;
@@ -150,6 +151,28 @@ namespace NzbDrone.Core.Test.Languages
         {
             var i = (int)source;
             i.Should().Be(expected);
+        }
+
+        [Test]
+        public void should_report_a_known_language_as_valid()
+        {
+            Language.English.IsValid().Should().BeTrue();
+        }
+
+        [Test]
+        public void should_report_an_unknown_id_as_invalid()
+        {
+            // A language id can reach us from a client payload or an old DB row without ever
+            // going through FindById, so the object exists but names nothing.
+            new Language { Id = 9999, Name = "Klingon" }.IsValid(false).Should().BeFalse();
+        }
+
+        [Test]
+        public void should_throw_on_an_unknown_id_by_default()
+        {
+            var language = new Language { Id = 9999, Name = "Klingon" };
+
+            Assert.Throws<InvalidOperationException>(() => language.IsValid());
         }
     }
 }

--- a/src/NzbDrone.Core.Test/NotificationTests/DiscordTests/DiscordFixture.cs
+++ b/src/NzbDrone.Core.Test/NotificationTests/DiscordTests/DiscordFixture.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Globalization;
+using System.Threading;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+using NzbDrone.Core.Notifications;
+using NzbDrone.Core.Notifications.Discord;
+using NzbDrone.Core.Notifications.Discord.Payloads;
+using NzbDrone.Core.Test.Framework;
+
+namespace NzbDrone.Core.Test.NotificationTests.DiscordTests
+{
+    [TestFixture]
+    public class DiscordFixture : CoreTest<Discord>
+    {
+        private DiscordPayload _payload;
+
+        [SetUp]
+        public void Setup()
+        {
+            Subject.Definition = new NotificationDefinition { Settings = new DiscordSettings() };
+
+            Mocker.GetMock<IDiscordProxy>()
+                .Setup(s => s.SendPayload(It.IsAny<DiscordPayload>(), It.IsAny<DiscordSettings>()))
+                .Callback<DiscordPayload, DiscordSettings>((payload, _) => _payload = payload);
+        }
+
+        // Custom format strings render the year in the current culture's calendar, so a host set
+        // to a non-Gregorian locale sent Discord a year like 2569 (Buddhist) or 1448 (Hijri) and
+        // Discord rejected or misrendered the embed. "O" is culture-invariant.
+        [TestCase("en-US")]
+        [TestCase("th-TH")]
+        [TestCase("ar-SA")]
+        public void should_send_a_gregorian_timestamp_regardless_of_culture(string culture)
+        {
+            var originalCulture = Thread.CurrentThread.CurrentCulture;
+
+            try
+            {
+                Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfo(culture);
+
+                Subject.OnApplicationUpdate(new ApplicationUpdateMessage
+                {
+                    Message = "Updated",
+                    PreviousVersion = new Version(3, 4, 0),
+                    NewVersion = new Version(3, 5, 0)
+                });
+
+                var timestamp = _payload.Embeds[0].Timestamp;
+
+                DateTime.TryParse(timestamp, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var parsed)
+                    .Should().BeTrue();
+
+                parsed.Year.Should().Be(DateTime.UtcNow.Year);
+            }
+            finally
+            {
+                Thread.CurrentThread.CurrentCulture = originalCulture;
+            }
+        }
+    }
+}

--- a/src/NzbDrone.Core.Test/ProviderTests/DiskProviderTests/ArchiveProviderFixture.cs
+++ b/src/NzbDrone.Core.Test/ProviderTests/DiskProviderTests/ArchiveProviderFixture.cs
@@ -1,5 +1,6 @@
 ﻿using System.IO;
 using FluentAssertions;
+using ICSharpCode.SharpZipLib.Zip;
 using NUnit.Framework;
 using NzbDrone.Common;
 using NzbDrone.Common.EnvironmentInfo;
@@ -22,6 +23,29 @@ namespace NzbDrone.Core.Test.ProviderTests.DiskProviderTests
             destinationFolder.GetDirectories().Should().HaveCount(1);
             destinationFolder.GetDirectories("*", SearchOption.AllDirectories).Should().HaveCount(3);
             destinationFolder.GetFiles("*.*", SearchOption.AllDirectories).Should().HaveCount(6);
+        }
+
+        [Test]
+        public void should_refuse_a_zip_entry_that_escapes_the_destination()
+        {
+            // Zip slip: an archive can name an entry ../../evil.txt and write anywhere the
+            // process can reach. Nothing stopped that before.
+            var destinationFolder = new DirectoryInfo(GetTempFilePath());
+            var archivePath = Path.Combine(GetTempFilePath(), "traversal.zip");
+
+            Directory.CreateDirectory(Path.GetDirectoryName(archivePath));
+
+            using (var zipStream = new ZipOutputStream(File.Create(archivePath)))
+            {
+                zipStream.PutNextEntry(new ZipEntry("../../escaped.txt"));
+                zipStream.Write(new byte[] { 1, 2, 3 }, 0, 3);
+                zipStream.CloseEntry();
+            }
+
+            Assert.Throws<IOException>(() => Subject.Extract(archivePath, destinationFolder.FullName));
+
+            var escaped = Path.GetFullPath(Path.Combine(destinationFolder.FullName, "../../escaped.txt"));
+            File.Exists(escaped).Should().BeFalse();
         }
     }
 }

--- a/src/NzbDrone.Core/Datastore/Converters/LanguageIntConverter.cs
+++ b/src/NzbDrone.Core/Datastore/Converters/LanguageIntConverter.cs
@@ -34,8 +34,15 @@ namespace NzbDrone.Core.Datastore.Converters
 
     public class LanguageIntConverter : JsonConverter<Language>
     {
+        public override bool HandleNull => true;
+
         public override Language Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
+            if (reader.TokenType == JsonTokenType.Null)
+            {
+                return Language.Unknown;
+            }
+
             var item = reader.GetInt32();
             return (Language)item;
         }

--- a/src/NzbDrone.Core/Download/Clients/FreeboxDownload/TorrentFreeboxDownload.cs
+++ b/src/NzbDrone.Core/Download/Clients/FreeboxDownload/TorrentFreeboxDownload.cs
@@ -11,6 +11,7 @@ using NzbDrone.Core.Configuration;
 using NzbDrone.Core.Download.Clients.FreeboxDownload.Responses;
 using NzbDrone.Core.Localization;
 using NzbDrone.Core.MediaFiles.TorrentInfo;
+using NzbDrone.Core.Organizer;
 using NzbDrone.Core.Parser.Model;
 using NzbDrone.Core.RemotePathMappings;
 
@@ -130,7 +131,7 @@ namespace NzbDrone.Core.Download.Clients.FreeboxDownload
         protected override string AddFromMagnetLink(RemoteMovie remoteMovie, string hash, string magnetLink)
         {
             return _proxy.AddTaskFromUrl(magnetLink,
-                                         GetDownloadDirectory().EncodeBase64(),
+                                         GetDownloadDirectory(remoteMovie).EncodeBase64(),
                                          ToBePaused(),
                                          ToBeQueuedFirst(remoteMovie),
                                          GetSeedRatio(remoteMovie),
@@ -141,7 +142,7 @@ namespace NzbDrone.Core.Download.Clients.FreeboxDownload
         {
             return _proxy.AddTaskFromFile(filename,
                                           fileContent,
-                                          GetDownloadDirectory().EncodeBase64(),
+                                          GetDownloadDirectory(remoteMovie).EncodeBase64(),
                                           ToBePaused(),
                                           ToBeQueuedFirst(remoteMovie),
                                           GetSeedRatio(remoteMovie),
@@ -186,18 +187,28 @@ namespace NzbDrone.Core.Download.Clients.FreeboxDownload
             }
         }
 
-        private string GetDownloadDirectory()
+        private string GetDownloadDirectory(RemoteMovie remoteMovie = null)
         {
+            string destDir;
+
             if (Settings.DestinationDirectory.IsNotNullOrWhiteSpace())
             {
-                return Settings.DestinationDirectory.TrimEnd('/');
+                destDir = Settings.DestinationDirectory.TrimEnd('/');
+            }
+            else
+            {
+                destDir = _proxy.GetDownloadConfiguration(Settings).DecodedDownloadDirectory.TrimEnd('/');
+
+                if (Settings.Category.IsNotNullOrWhiteSpace())
+                {
+                    destDir = $"{destDir}/{Settings.Category}";
+                }
             }
 
-            var destDir = _proxy.GetDownloadConfiguration(Settings).DecodedDownloadDirectory.TrimEnd('/');
-
-            if (Settings.Category.IsNotNullOrWhiteSpace())
+            if (remoteMovie?.Release?.Title.IsNotNullOrWhiteSpace() ?? false)
             {
-                destDir = $"{destDir}/{Settings.Category}";
+                var folderName = FileNameBuilder.CleanFileName(remoteMovie.Release.Title);
+                destDir = $"{destDir}/{folderName}";
             }
 
             return destDir;

--- a/src/NzbDrone.Core/Download/TrackedDownloads/TrackedDownloadService.cs
+++ b/src/NzbDrone.Core/Download/TrackedDownloads/TrackedDownloadService.cs
@@ -28,6 +28,7 @@ namespace NzbDrone.Core.Download.TrackedDownloads
     }
 
     public class TrackedDownloadService : ITrackedDownloadService,
+                                          IHandle<MovieGrabbedEvent>,
                                           IHandle<MovieAddedEvent>,
                                           IHandleAsync<MovieEditedEvent>,
                                           IHandleAsync<MoviesBulkEditedEvent>,
@@ -117,19 +118,6 @@ namespace NzbDrone.Core.Download.TrackedDownloads
 
             try
             {
-                var historyItems = _historyService.FindByDownloadId(downloadItem.DownloadId)
-                    .OrderByDescending(h => h.Date)
-                    .ToList();
-
-                var parsedMovieInfo = Parser.Parser.ParseMovieTitle(trackedDownload.DownloadItem.Title);
-
-                if (parsedMovieInfo != null)
-                {
-                    trackedDownload.RemoteMovie = _parsingService.Map(parsedMovieInfo, "", 0, null);
-
-                    _aggregationService.Augment(trackedDownload.RemoteMovie);
-                }
-
                 var downloadHistory = _downloadHistoryService.GetLatestDownloadHistoryItem(downloadItem.DownloadId);
 
                 if (downloadHistory != null)
@@ -137,6 +125,21 @@ namespace NzbDrone.Core.Download.TrackedDownloads
                     var state = GetStateFromHistory(downloadHistory.EventType);
                     trackedDownload.State = state;
                 }
+
+                var parsedMovieInfo = Parser.Parser.ParseMovieTitle(trackedDownload.DownloadItem.Title);
+
+                if (parsedMovieInfo != null)
+                {
+                    trackedDownload.RemoteMovie = downloadHistory is { EventType: DownloadHistoryEventType.DownloadImported }
+                        ? _parsingService.Map(parsedMovieInfo, downloadHistory.MovieId)
+                        : _parsingService.Map(parsedMovieInfo, "", 0, null);
+
+                    _aggregationService.Augment(trackedDownload.RemoteMovie);
+                }
+
+                var historyItems = _historyService.FindByDownloadId(downloadItem.DownloadId)
+                    .OrderByDescending(h => h.Date)
+                    .ToList();
 
                 if (historyItems.Any())
                 {
@@ -198,7 +201,8 @@ namespace NzbDrone.Core.Download.TrackedDownloads
             catch (Exception e)
             {
                 _logger.Debug(e, "Failed to find movie for " + downloadItem.Title);
-                return null;
+
+                trackedDownload.Warn("Unable to parse movie from title");
             }
 
             LogItemChange(trackedDownload, existingItem?.DownloadItem, trackedDownload.DownloadItem);
@@ -261,6 +265,25 @@ namespace NzbDrone.Core.Download.TrackedDownloads
                     trackedDownload.State,
                     trackedDownload.RemoteMovie?.ParsedMovieInfo,
                     downloadItem.OutputPath);
+            }
+        }
+
+        public void Handle(MovieGrabbedEvent message)
+        {
+            if (message.DownloadId.IsNullOrWhiteSpace())
+            {
+                return;
+            }
+
+            var trackedDownload = Find(message.DownloadId);
+
+            // A finished download being grabbed again is a fresh attempt, so drop the old
+            // tracking rather than letting its terminal state suppress the new import.
+            if (trackedDownload is { State: TrackedDownloadState.Imported or
+                                            TrackedDownloadState.Failed or
+                                            TrackedDownloadState.Ignored })
+            {
+                _cache.Remove(message.DownloadId);
             }
         }
 

--- a/src/NzbDrone.Core/Languages/Language.cs
+++ b/src/NzbDrone.Core/Languages/Language.cs
@@ -239,5 +239,15 @@ namespace NzbDrone.Core.Languages
 
             return language;
         }
+
+        public bool IsValid(bool throwOnMissing = true)
+        {
+            return All.Any(v => v.Id == Id) switch
+            {
+                false when throwOnMissing => throw new InvalidOperationException("ID does not match a known language"),
+                false => false,
+                _ => true
+            };
+        }
     }
 }

--- a/src/NzbDrone.Core/MediaFiles/MovieImport/Manual/ManualImportFile.cs
+++ b/src/NzbDrone.Core/MediaFiles/MovieImport/Manual/ManualImportFile.cs
@@ -10,8 +10,8 @@ namespace NzbDrone.Core.MediaFiles.MovieImport.Manual
     {
         public string Path { get; set; }
         public string FolderName { get; set; }
-        public QualityModel Quality { get; set; }
-        public List<Language> Languages { get; set; }
+        public QualityModel Quality { get; set; } = new();
+        public List<Language> Languages { get; set; } = new();
         public string ReleaseGroup { get; set; }
         public int IndexerFlags { get; set; }
         public string DownloadId { get; set; }

--- a/src/NzbDrone.Core/MediaFiles/MovieImport/Manual/ManualImportItem.cs
+++ b/src/NzbDrone.Core/MediaFiles/MovieImport/Manual/ManualImportItem.cs
@@ -15,18 +15,13 @@ namespace NzbDrone.Core.MediaFiles.MovieImport.Manual
         public long Size { get; set; }
         public Movie Movie { get; set; }
         public int? MovieFileId { get; set; }
-        public QualityModel Quality { get; set; }
-        public List<Language> Languages { get; set; }
+        public QualityModel Quality { get; set; } = new();
+        public List<Language> Languages { get; set; } = new();
         public string ReleaseGroup { get; set; }
         public string DownloadId { get; set; }
-        public List<CustomFormat> CustomFormats { get; set; }
+        public List<CustomFormat> CustomFormats { get; set; } = new();
         public int CustomFormatScore { get; set; }
         public int IndexerFlags { get; set; }
-        public IEnumerable<ImportRejection> Rejections { get; set; }
-
-        public ManualImportItem()
-        {
-            CustomFormats = new List<CustomFormat>();
-        }
+        public IEnumerable<ImportRejection> Rejections { get; set; } = new List<ImportRejection>();
     }
 }

--- a/src/NzbDrone.Core/MediaFiles/MovieImport/Manual/ManualImportService.cs
+++ b/src/NzbDrone.Core/MediaFiles/MovieImport/Manual/ManualImportService.cs
@@ -498,8 +498,12 @@ namespace NzbDrone.Core.MediaFiles.MovieImport.Manual
                     localMovie.Movie = movie;
                     localMovie.ReleaseGroup = file.ReleaseGroup;
                     localMovie.Quality = file.Quality;
-                    localMovie.Languages = file.Languages;
                     localMovie.IndexerFlags = (IndexerFlags)file.IndexerFlags;
+
+                    if (file.Languages is { Count: > 0 } && file.Languages.All(l => l is not null && l.IsValid()))
+                    {
+                        localMovie.Languages = file.Languages;
+                    }
 
                     localMovie.CustomFormats = _formatCalculator.ParseCustomFormat(localMovie);
                     localMovie.CustomFormatScore = localMovie.Movie.QualityProfile?.CalculateCustomFormatScore(localMovie.CustomFormats) ?? 0;

--- a/src/NzbDrone.Core/Notifications/Discord/Discord.cs
+++ b/src/NzbDrone.Core/Notifications/Discord/Discord.cs
@@ -48,7 +48,7 @@ namespace NzbDrone.Core.Notifications.Discord
                 Title = GetTitle(message.Movie),
                 Color = (int)DiscordColors.Standard,
                 Fields = new List<DiscordField>(),
-                Timestamp = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss.fffZ")
+                Timestamp = DateTime.UtcNow.ToString("O")
             };
 
             if (Settings.GrabFields.Contains((int)DiscordGrabFieldType.Poster))
@@ -152,7 +152,7 @@ namespace NzbDrone.Core.Notifications.Discord
                 Title = GetTitle(message.Movie),
                 Color = isUpgrade ? (int)DiscordColors.Upgrade : (int)DiscordColors.Success,
                 Fields = new List<DiscordField>(),
-                Timestamp = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss.fffZ")
+                Timestamp = DateTime.UtcNow.ToString("O")
             };
 
             if (Settings.ImportFields.Contains((int)DiscordImportFieldType.Poster))
@@ -369,7 +369,7 @@ namespace NzbDrone.Core.Notifications.Discord
                     new () { Name = "Reason", Value = reason.ToString() },
                     new () { Name = "File name", Value = string.Format("```{0}```", deletedFile) }
                 },
-                Timestamp = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss.fffZ"),
+                Timestamp = DateTime.UtcNow.ToString("O"),
             };
 
             var payload = CreatePayload(null, new List<Embed> { embed });
@@ -388,7 +388,7 @@ namespace NzbDrone.Core.Notifications.Discord
                 },
                 Title = healthCheck.Source.Name,
                 Description = healthCheck.Message,
-                Timestamp = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss.fffZ"),
+                Timestamp = DateTime.UtcNow.ToString("O"),
                 Color = healthCheck.Type == HealthCheck.HealthCheckResult.Warning ? (int)DiscordColors.Warning : (int)DiscordColors.Danger
             };
 
@@ -408,7 +408,7 @@ namespace NzbDrone.Core.Notifications.Discord
                 },
                 Title = "Health Issue Resolved: " + previousCheck.Source.Name,
                 Description = $"The following issue is now resolved: {previousCheck.Message}",
-                Timestamp = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss.fffZ"),
+                Timestamp = DateTime.UtcNow.ToString("O"),
                 Color = (int)DiscordColors.Success
             };
 
@@ -427,7 +427,7 @@ namespace NzbDrone.Core.Notifications.Discord
                     IconUrl = "https://raw.githubusercontent.com/Whisparr/Whisparr/eros/Logo/256.png"
                 },
                 Title = APPLICATION_UPDATE_TITLE,
-                Timestamp = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss.fffZ"),
+                Timestamp = DateTime.UtcNow.ToString("O"),
                 Color = (int)DiscordColors.Standard,
                 Fields = new List<DiscordField>
                 {
@@ -465,7 +465,7 @@ namespace NzbDrone.Core.Notifications.Discord
                 Title = GetTitle(movie),
                 Color = (int)DiscordColors.Standard,
                 Fields = new List<DiscordField>(),
-                Timestamp = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss.fffZ")
+                Timestamp = DateTime.UtcNow.ToString("O")
             };
 
             if (Settings.ManualInteractionFields.Contains((int)DiscordManualInteractionFieldType.Poster))

--- a/src/NzbDrone.Core/Notifications/Gotify/Gotify.cs
+++ b/src/NzbDrone.Core/Notifications/Gotify/Gotify.cs
@@ -172,10 +172,10 @@ namespace NzbDrone.Core.Notifications.Gotify
                             linkUrl = $"https://www.imdb.com/title/{movie.ImdbId}";
                         }
 
-                        if (linkType == MetadataLinkType.Trakt && movie.TmdbId > 0)
+                        if (linkType == MetadataLinkType.Trakt && movie.ImdbId.IsNotNullOrWhiteSpace())
                         {
                             linkText = "Trakt";
-                            linkUrl = $"https://trakt.tv/search/tmdb/{movie.TmdbId}?id_type=movie";
+                            linkUrl = $"https://trakt.tv/movies/{movie.ImdbId}";
                         }
 
                         sb.AppendLine($"[{linkText}]({linkUrl})");

--- a/src/NzbDrone.Core/Notifications/MediaBrowser/MediaBrowserProxy.cs
+++ b/src/NzbDrone.Core/Notifications/MediaBrowser/MediaBrowserProxy.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net;
 using NLog;
 using NzbDrone.Common.Http;
 using NzbDrone.Common.Serializer;
@@ -20,10 +19,19 @@ namespace NzbDrone.Core.Notifications.Emby
             _logger = logger;
         }
 
+        public void TestConnection(MediaBrowserSettings settings)
+        {
+            var path = "/System/Configuration";
+            var request = BuildRequest(path, settings).Build();
+
+            var response = _httpClient.Get(request);
+            _logger.Trace("Response: {0}", response.Content);
+        }
+
         public void Notify(MediaBrowserSettings settings, string title, string message)
         {
             var path = "/Notifications/Admin";
-            var request = BuildRequest(path, settings);
+            var request = BuildRequest(path, settings).Build();
             request.Headers.ContentType = "application/json";
             request.LogHttpError = false;
 
@@ -34,31 +42,15 @@ namespace NzbDrone.Core.Notifications.Emby
                 ImageUrl = "https://raw.github.com/Whisparr/Whisparr/develop/Logo/64.png"
             }.ToJson());
 
-            try
-            {
-                ProcessRequest(request, settings);
-            }
-            catch (HttpException e)
-            {
-                if (e.Response.StatusCode == HttpStatusCode.NotFound)
-                {
-                    _logger.Warn("Unable to send notification to Emby. If you're using Jellyfin disable 'Send Notifications'");
-                }
-                else
-                {
-                    throw;
-                }
-            }
+            ProcessRequest(request);
         }
 
         public HashSet<string> GetPaths(MediaBrowserSettings settings, Movie movie)
         {
             var path = "/Items";
-            var url = GetUrl(settings);
 
             // NameStartsWith uses the sort title, which is not the movie title
-            var request = new HttpRequestBuilder(url)
-                .Resource(path)
+            var request = BuildRequest(path, settings)
                 .AddQueryParam("recursive", "true")
                 .AddQueryParam("includeItemTypes", "Movie")
                 .AddQueryParam("fields", "Path,ProviderIds")
@@ -67,7 +59,7 @@ namespace NzbDrone.Core.Notifications.Emby
 
             try
             {
-                var paths = ProcessGetRequest<MediaBrowserItems>(request, settings).Items.GroupBy(item =>
+                var paths = ProcessGetRequest<MediaBrowserItems>(request).Items.GroupBy(item =>
                 {
                     if (item is { ProviderIds.Tmdb: int tmdbid } && tmdbid != 0 && tmdbid == movie.TmdbId)
                     {
@@ -109,7 +101,7 @@ namespace NzbDrone.Core.Notifications.Emby
         public void Update(MediaBrowserSettings settings, string moviePath, string updateType)
         {
             var path = "/Library/Media/Updated";
-            var request = BuildRequest(path, settings);
+            var request = BuildRequest(path, settings).Build();
             request.Headers.ContentType = "application/json";
 
             request.SetContent(new
@@ -124,14 +116,12 @@ namespace NzbDrone.Core.Notifications.Emby
                 }
             }.ToJson());
 
-            ProcessRequest(request, settings);
+            ProcessRequest(request);
         }
 
-        private T ProcessGetRequest<T>(HttpRequest request, MediaBrowserSettings settings)
+        private T ProcessGetRequest<T>(HttpRequest request)
             where T : new()
         {
-            request.Headers.Add("X-MediaBrowser-Token", settings.ApiKey);
-
             var response = _httpClient.Get<T>(request);
             _logger.Trace("Response: {0}", response.Content);
 
@@ -140,10 +130,8 @@ namespace NzbDrone.Core.Notifications.Emby
             return response.Resource;
         }
 
-        private string ProcessRequest(HttpRequest request, MediaBrowserSettings settings)
+        private string ProcessRequest(HttpRequest request)
         {
-            request.Headers.Add("X-MediaBrowser-Token", settings.ApiKey);
-
             var response = _httpClient.Post(request);
             _logger.Trace("Response: {0}", response.Content);
 
@@ -158,11 +146,15 @@ namespace NzbDrone.Core.Notifications.Emby
             return $@"{scheme}://{settings.Address}";
         }
 
-        private HttpRequest BuildRequest(string path, MediaBrowserSettings settings)
+        private HttpRequestBuilder BuildRequest(string path, MediaBrowserSettings settings)
         {
             var url = GetUrl(settings);
+            var request = new HttpRequestBuilder(url).Resource(path);
 
-            return new HttpRequestBuilder(url).Resource(path).Build();
+            request.Headers.Add("X-MediaBrowser-Token", settings.ApiKey);
+            request.Headers.Add("Authorization", $"MediaBrowser Token=\"{settings.ApiKey}\"");
+
+            return request;
         }
 
         private void CheckForError(HttpResponse response)

--- a/src/NzbDrone.Core/Notifications/MediaBrowser/MediaBrowserService.cs
+++ b/src/NzbDrone.Core/Notifications/MediaBrowser/MediaBrowserService.cs
@@ -60,8 +60,7 @@ namespace NzbDrone.Core.Notifications.Emby
             try
             {
                 _logger.Debug("Testing connection to Emby/Jellyfin : {0}", settings.Address);
-
-                Notify(settings, "Test from Whisparr", "Success! MediaBrowser has been successfully configured!");
+                _proxy.TestConnection(settings);
             }
             catch (HttpException ex)
             {
@@ -69,11 +68,31 @@ namespace NzbDrone.Core.Notifications.Emby
                 {
                     return new ValidationFailure("ApiKey", _localizationService.GetLocalizedString("NotificationsValidationInvalidApiKey"));
                 }
+
+                _logger.Trace(ex, "Error when connecting to Emby/Jellyfin");
+                return new ValidationFailure("Host", _localizationService.GetLocalizedString("NotificationsValidationUnableToSendTestMessage", new Dictionary<string, object> { { "exceptionMessage", ex.Message } }));
             }
             catch (Exception ex)
             {
                 _logger.Error(ex, "Unable to send test message");
                 return new ValidationFailure("Host", _localizationService.GetLocalizedString("NotificationsValidationUnableToSendTestMessage", new Dictionary<string, object> { { "exceptionMessage", ex.Message } }));
+            }
+
+            if (settings.Notify)
+            {
+                try
+                {
+                    Notify(settings, "Test from Whisparr", "Success! MediaBrowser has been successfully configured!");
+                }
+                catch (HttpException ex)
+                {
+                    if (ex.Response.StatusCode == HttpStatusCode.NotFound)
+                    {
+                        return new ValidationFailure("Notify", "Unable to send notification to Emby. If you're using Jellyfin disable 'Send Notifications'");
+                    }
+
+                    throw;
+                }
             }
 
             return null;

--- a/src/NzbDrone.Core/Notifications/Telegram/Telegram.cs
+++ b/src/NzbDrone.Core/Notifications/Telegram/Telegram.cs
@@ -141,9 +141,9 @@ namespace NzbDrone.Core.Notifications.Telegram
                     links.Add(new TelegramLink("IMDb", $"https://www.imdb.com/title/{movie.ImdbId}"));
                 }
 
-                if (linkType == MetadataLinkType.Trakt && movie.TmdbId > 0)
+                if (linkType == MetadataLinkType.Trakt && movie.ImdbId.IsNotNullOrWhiteSpace())
                 {
-                    links.Add(new TelegramLink("Trakt", $"https://trakt.tv/search/tmdb/{movie.TmdbId}?id_type=movie"));
+                    links.Add(new TelegramLink("Trakt", $"https://trakt.tv/movies/{movie.ImdbId}"));
                 }
             }
 

--- a/src/NzbDrone.Core/Notifications/Trakt/TraktProxy.cs
+++ b/src/NzbDrone.Core/Notifications/Trakt/TraktProxy.cs
@@ -21,7 +21,7 @@ namespace NzbDrone.Core.Notifications.Trakt
     public class TraktProxy : ITraktProxy
     {
         private const string URL = "https://api.trakt.tv";
-        private const string OAuthUrl = "https://trakt.tv/oauth/authorize";
+        private const string OAuthUrl = "https://auth.trakt.tv/oauth/authorize";
         private const string RedirectUri = "https://auth.servarr.com/v1/trakt/auth";
         private const string RenewUri = "https://auth.servarr.com/v1/trakt/renew";
         private const string ClientId = "64508a8bf370cee550dde4806469922fd7cd70afb2d5690e3ee7f75ae784b70e";

--- a/src/NzbDrone.Mono/Disk/ProcMount.cs
+++ b/src/NzbDrone.Mono/Disk/ProcMount.cs
@@ -1,12 +1,16 @@
+using System;
 using System.IO;
 using Mono.Unix;
+using NLog;
 using NzbDrone.Common.Disk;
 using NzbDrone.Common.Extensions;
+using NzbDrone.Common.Instrumentation;
 
 namespace NzbDrone.Mono.Disk
 {
     public class ProcMount : IMount
     {
+        private static readonly Logger Logger = NzbDroneLogger.GetLogger(typeof(ProcMount));
         private readonly UnixDriveInfo _unixDriveInfo;
 
         public ProcMount(DriveType driveType, string name, string mount, string type, MountOptions mountOptions)
@@ -34,9 +38,37 @@ namespace NzbDrone.Mono.Disk
 
         public string RootDirectory { get; private set; }
 
-        public long TotalFreeSpace => _unixDriveInfo.TotalFreeSpace;
+        public long TotalFreeSpace
+        {
+            get
+            {
+                try
+                {
+                    return _unixDriveInfo.TotalFreeSpace;
+                }
+                catch (OverflowException ex)
+                {
+                    Logger.Warn(ex, "Failed to get total free space");
+                    return long.MaxValue;
+                }
+            }
+        }
 
-        public long TotalSize => _unixDriveInfo.TotalSize;
+        public long TotalSize
+        {
+            get
+            {
+                try
+                {
+                    return _unixDriveInfo.TotalSize;
+                }
+                catch (OverflowException ex)
+                {
+                    Logger.Warn(ex, "Failed to get total size");
+                    return long.MaxValue;
+                }
+            }
+        }
 
         public string VolumeLabel => _unixDriveInfo.VolumeLabel;
 


### PR DESCRIPTION
#### Database Migration

NO

#### Description

Radarr `develop` for 2026-08 — 36 commits reviewed, 13 picked, 3 already covered, 20 skipped with reasons in `.github/upstream/state.json`. **This clears the Radarr backlog**; the high-water mark moves to `68b93db78c` and only Sonarr `v5-develop` remains.

Three connectors were broken outright:

- **Jellyfin 12+** dropped `X-MediaBrowser-Token` for the `Authorization: MediaBrowser Token="..."` scheme. Also splits `Test` into a real connection check plus an optional notification, so testing against Jellyfin no longer fails on the notification endpoint rather than the connection.
- **Trakt links** — verified live: `trakt.tv/search/tmdb/550?id_type=movie` now 404s, `trakt.tv/movies/tt0137523` returns 200.
- **Discord timestamps** rendered the year in the host's calendar. Reproduced before fixing: `th-TH` produced 2569, `ar-SA` produced 1448.

Plus a **zip slip** guard (an archive naming `../../x` could write anywhere the process could reach), three `TrackedDownloadService` fixes (unidentifiable downloads vanished from the queue instead of showing a warning; an already-imported download was re-mapped by name; a re-grab of an imported release never re-imported), Freebox single-file imports, manual import null and unknown-language handling, an overflow reading disk info, and a null language column no longer taking down deserialization.

Deferred to their own PRs by decision: `fd8eb4d15` (pending-release spec — a real fix, but it changes `IDownloadDecisionEngineSpecification` across 65 files) and `72ae0c011` (health check reasons, 36 files, no bug behind it). **Hostname validation and Trusted Networks are skipped here on purpose** — Radarr's are picks of Sonarr `1579a8bb7f` and `022f69e14b`, and the Sonarr chunk takes the originals.

#### Screenshot(s) (if UI related)

<details>
</details>

#### Todos

- [x] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json) — no new user-facing strings

15 tests added across five fixtures, all 15 verified failing with their fix reverted. `Discord` and `LanguageIntConverter` had no coverage before. The three Freebox assertions were updated rather than added: the destination path change *is* the fix, and upstream moved the same three.

`Whisparr.Core.Test` 4113 passed / 34 skipped, build clean at 0 warnings. `Whisparr.Common.Test` 571/39 with one pre-existing failure (a missing local `Whisparr.Mono.dll`, identical on a clean tree).

#### Issues Fixed or Closed by this PR
