### PR TITLE
Fix: Fail the build when the base version tag has gone missing

### DIFF
--- a/.github/workflows/build_v3.yml
+++ b/.github/workflows/build_v3.yml
@@ -78,6 +78,20 @@ jobs:
             echo "Base version ${BASE} (from VERSION_FALLBACK; no vX.Y.Z tag reachable)"
           fi
 
+          # Deleting a base tag that CI has already built from walks the version
+          # backwards without failing anything: the next run just resolves the
+          # next tag down and publishes a release that looks like a downgrade to
+          # every updater in the field. Every CI-minted tag records the base it
+          # came from, so compare against the highest of those and stop instead.
+          PUBLISHED=$(git tag --merged HEAD 2>/dev/null \
+            | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+-(develop|release)\.[0-9]+$' \
+            | sed -E 's/^v([0-9]+\.[0-9]+\.[0-9]+)-.*$/\1/' \
+            | sort -V | tail -n1 || true)
+          if [ -n "$PUBLISHED" ] && [ "$(printf '%s\n%s\n' "$BASE" "$PUBLISHED" | sort -V | tail -n1)" != "$BASE" ]; then
+            echo "::error::Base version ${BASE} is behind ${PUBLISHED}, which this branch has already published. The v${PUBLISHED} base tag is missing - restore it with 'git push origin v${PUBLISHED}' before merging."
+            exit 1
+          fi
+
           if [[ "${{ github.ref_name }}" == "eros-develop" ]]; then
             SEMVER_LABEL="develop"
           else


### PR DESCRIPTION
#### Database Migration

NO

#### Description

Build 1401 published `3.3.9-develop` after `3.4.0-release.1387` had already
shipped. The base version is the highest reachable `vX.Y.Z` tag, so once
`v3.4.0` stopped being on the remote the next run quietly resolved `v3.3.9`
instead — a downgrade to every updater in the field, with nothing failing.
Both `eros` and `eros-develop` were affected, so the next promotion would
have shipped a stable 3.3.9 too.

The tag has since been restored. This adds the guard that should have caught
it: every CI-minted tag carries the base it was built from, so the prepare
step compares the resolved base against the highest of those and fails,
naming the tag to restore, rather than walking the version backwards.

#### Verification

Ran the prepare step's logic against clean clones of both branches:

| | before the tag was restored | after |
| --- | --- | --- |
| `eros` | fails, names `v3.4.0` | 3.4.0 |
| `eros-develop` | fails, names `v3.4.0` | 3.4.0 |

#### Todos

- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)

#### Issues Fixed or Closed by this PR

