### PR TITLE
Chore: Route studio, performer, add-movie, and backup hooks through useApiMutation

### DIFF
--- a/frontend/src/AddMovie/AddNewMovie/useAddNewMovie.ts
+++ b/frontend/src/AddMovie/AddNewMovie/useAddNewMovie.ts
@@ -1,4 +1,3 @@
-import { useMutation } from '@tanstack/react-query';
 import React, {
   useCallback,
   useEffect,
@@ -11,6 +10,7 @@ import { useAppDimension, useAppDimensions } from 'App/appStore';
 import { queryClient } from 'App/queryClient';
 import { useSafeForWorkMode } from 'App/safeForWorkStore';
 import { ValidationMessage } from 'Components/Form/FormInputGroup';
+import useApiMutation from 'Helpers/Hooks/useApiMutation';
 import useApiQuery from 'Helpers/Hooks/useApiQuery';
 import selectSettings from 'Helpers/selectSettings';
 import { MovieStats } from 'Movie/Index/useMovieStats';
@@ -20,8 +20,6 @@ import { useSystemStatusData } from 'System/Status/useSystemStatus';
 import { InputChanged } from 'typings/inputs';
 import MovieCredit from 'typings/MovieCredit';
 import { ValidationError, ValidationWarning } from 'typings/pending';
-import fetchJson, { ApiError } from 'Utilities/Fetch/fetchJson';
-import getQueryPath from 'Utilities/Fetch/getQueryPath';
 import getNewMovie from 'Utilities/Movie/getNewMovie';
 import parseUrl from 'Utilities/String/parseUrl';
 import {
@@ -80,20 +78,6 @@ interface AddMovieSettings {
   qualityProfileId: SettingValue<number>;
   searchForMovie: SettingValue<boolean>;
   tags: SettingValue<number[]>;
-}
-
-const AUTH_HEADERS = {
-  'X-Api-Key': window.Whisparr.apiKey,
-  'X-Whisparr-Client': 'Whisparr',
-};
-
-function apiPost<T, TBody>(path: string, body: TBody): Promise<T> {
-  return fetchJson<T, TBody>({
-    path: getQueryPath(path),
-    method: 'POST',
-    body,
-    headers: AUTH_HEADERS,
-  });
 }
 
 // Hook for the AddNewMovie and AddNewScene pages
@@ -193,15 +177,16 @@ export function useAddMovieMutation(
 
   const defaults = useAddMovieDefaults();
 
-  const mutation = useMutation<Movie, ApiError, MovieLookupResult>({
-    mutationFn: (movieToAdd: MovieLookupResult) => {
-      return apiPost<Movie, MovieLookupResult>('/movie', movieToAdd);
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['/movie/paged'] });
-      queryClient.invalidateQueries({ queryKey: ['/movie/stats'] });
-      queryClient.invalidateQueries({ queryKey: ['/movie/lookup'] });
-      onSuccess?.();
+  const mutation = useApiMutation<Movie, MovieLookupResult>({
+    method: 'POST',
+    path: '/movie',
+    mutationOptions: {
+      onSuccess: () => {
+        queryClient.invalidateQueries({ queryKey: ['/movie/paged'] });
+        queryClient.invalidateQueries({ queryKey: ['/movie/stats'] });
+        queryClient.invalidateQueries({ queryKey: ['/movie/lookup'] });
+        onSuccess?.();
+      },
     },
   });
 

--- a/frontend/src/Helpers/Hooks/useApiMutation.ts
+++ b/frontend/src/Helpers/Hooks/useApiMutation.ts
@@ -12,12 +12,16 @@ import fetchJson, {
 import getQueryPath from 'Utilities/Fetch/getQueryPath';
 import getQueryString, { QueryParams } from 'Utilities/Fetch/getQueryString';
 
-interface MutationOptions<T, TData> extends Omit<
-  FetchJsonOptions<TData>,
-  'method' | 'path'
+interface MutationOptions<T, TData, TBody = TData> extends Omit<
+  FetchJsonOptions<TBody>,
+  'method' | 'path' | 'body'
 > {
   method: 'POST' | 'PUT' | 'PATCH' | 'DELETE';
   path: string | ((data: TData) => string);
+  // Derives the request body from the mutate() argument. For read-modify-
+  // writes where the caller only holds a partial payload (a monitored flag,
+  // say) and the full entity is loaded from cache before a whole-record PUT.
+  body?: (data: TData) => TBody | Promise<TBody>;
   mutationOptions?: Omit<UseMutationOptions<T, ApiError, TData>, 'mutationFn'>;
   // A function form is for query params the caller can only decide per-call,
   // such as the provider `forceSave` flag, which depends on whether this is a
@@ -25,17 +29,26 @@ interface MutationOptions<T, TData> extends Omit<
   queryParams?: QueryParams | ((data: TData) => QueryParams);
 }
 
-function useApiMutation<T, TData>(options: MutationOptions<T, TData>) {
+function useApiMutation<T, TData, TBody = TData>(
+  options: MutationOptions<T, TData, TBody>
+) {
   return useMutation<T, ApiError, TData>({
     ...options.mutationOptions,
     mutationFn: async (data: TData) => {
-      const { path, queryParams, mutationOptions, ...otherOptions } = options;
+      const { path, queryParams, body, mutationOptions, ...otherOptions } =
+        options;
       const resolvedPath = typeof path === 'function' ? path(data) : path;
 
       const resolvedQueryParams =
         typeof queryParams === 'function' ? queryParams(data) : queryParams;
 
-      return fetchJson<T, TData>({
+      // Without a body function the mutate() argument is the request body --
+      // `TBody` defaults to `TData`, so widening through `unknown` is safe.
+      const resolvedBody: TBody = body
+        ? await body(data)
+        : (data as unknown as TBody);
+
+      return fetchJson<T, TBody>({
         ...otherOptions,
         path: getQueryPath(resolvedPath) + getQueryString(resolvedQueryParams),
         headers: {
@@ -43,7 +56,7 @@ function useApiMutation<T, TData>(options: MutationOptions<T, TData>) {
           'X-Api-Key': window.Whisparr.apiKey,
           'X-Whisparr-Client': 'Whisparr',
         },
-        body: data,
+        body: resolvedBody,
       });
     },
   });

--- a/frontend/src/Performer/usePerformer.ts
+++ b/frontend/src/Performer/usePerformer.ts
@@ -1,15 +1,9 @@
-import { useMutation } from '@tanstack/react-query';
 import { queryClient } from 'App/queryClient';
 import useApiMutation from 'Helpers/Hooks/useApiMutation';
 import useApiQuery from 'Helpers/Hooks/useApiQuery';
 import fetchJson from 'Utilities/Fetch/fetchJson';
 import getQueryPath from 'Utilities/Fetch/getQueryPath';
 import Performer from './Performer';
-
-const AUTH_HEADERS = {
-  'X-Api-Key': globalThis.Whisparr.apiKey,
-  'X-Whisparr-Client': 'Whisparr',
-};
 
 export function usePerformer(foreignId: string | undefined) {
   return useApiQuery<Performer>({
@@ -28,19 +22,22 @@ export function useSavePerformer() {
   });
 }
 
+interface TogglePerformerInput {
+  performerId: number;
+  foreignId: string;
+  monitored: boolean;
+  moviesMonitored: boolean;
+}
+
+// `PUT /performer/{id}` takes the whole performer, but callers only hold the two
+// monitored fields -- read-modify-write against the cached entity. The cache is
+// cold when `usePerformer` was never mounted for this foreign id (movie credit
+// posters), so fall back to a plain read over the same path it would take.
 export function useTogglePerformerMonitored() {
-  return useMutation({
-    mutationFn: async ({
-      performerId,
-      foreignId,
-      monitored,
-      moviesMonitored,
-    }: {
-      performerId: number;
-      foreignId: string;
-      monitored: boolean;
-      moviesMonitored: boolean;
-    }) => {
+  return useApiMutation<Performer, TogglePerformerInput, Performer>({
+    method: 'PUT',
+    path: ({ performerId }) => `/performer/${performerId}`,
+    body: async ({ foreignId, monitored, moviesMonitored }) => {
       const performerPath = `/performer/${foreignId}`;
       // Fetch from cache first; falls back to network if not cached
       const performer = await queryClient.fetchQuery<Performer>({
@@ -48,26 +45,26 @@ export function useTogglePerformerMonitored() {
         queryFn: () =>
           fetchJson<Performer, undefined>({
             path: getQueryPath(performerPath),
-            headers: AUTH_HEADERS,
+            headers: {
+              'X-Api-Key': window.Whisparr.apiKey,
+              'X-Whisparr-Client': 'Whisparr',
+            },
           }),
       });
-      return fetchJson<Performer, Performer>({
-        path: getQueryPath(`/performer/${performerId}`),
-        method: 'PUT',
-        body: { ...performer, monitored, moviesMonitored },
-        headers: AUTH_HEADERS,
-      });
+      return { ...performer, monitored, moviesMonitored };
     },
-    onSuccess: (data) => {
-      if (data?.foreignId) {
-        queryClient.setQueryData(
-          [`/performer/${data.foreignId}`],
-          (old: Performer) => (old ? { ...old, ...data } : data)
-        );
+    mutationOptions: {
+      onSuccess: (data) => {
+        if (data?.foreignId) {
+          queryClient.setQueryData(
+            [`/performer/${data.foreignId}`],
+            (old: Performer) => (old ? { ...old, ...data } : data)
+          );
 
-        // Invalidate credit to handle the toggle on MovieDetails posters
-        queryClient.invalidateQueries({ queryKey: ['/credit'] });
-      }
+          // Invalidate credit to handle the toggle on MovieDetails posters
+          queryClient.invalidateQueries({ queryKey: ['/credit'] });
+        }
+      },
     },
   });
 }

--- a/frontend/src/Studio/useStudio.ts
+++ b/frontend/src/Studio/useStudio.ts
@@ -1,15 +1,9 @@
-import { useMutation } from '@tanstack/react-query';
 import { queryClient } from 'App/queryClient';
 import useApiMutation from 'Helpers/Hooks/useApiMutation';
 import useApiQuery from 'Helpers/Hooks/useApiQuery';
 import fetchJson from 'Utilities/Fetch/fetchJson';
 import getQueryPath from 'Utilities/Fetch/getQueryPath';
 import Studio from './Studio';
-
-const AUTH_HEADERS = {
-  'X-Api-Key': globalThis.Whisparr.apiKey,
-  'X-Whisparr-Client': 'Whisparr',
-};
 
 export function useStudio(foreignId: string | undefined) {
   return useApiQuery<Studio>({
@@ -31,19 +25,22 @@ export function useSaveStudio() {
   });
 }
 
+interface ToggleStudioInput {
+  studioId: number;
+  foreignId: string;
+  monitored: boolean;
+  moviesMonitored: boolean;
+}
+
+// `PUT /studio/{id}` takes the whole studio, but callers only hold the two
+// monitored fields -- read-modify-write against the cached entity. The cache
+// is cold when `useStudio` was never mounted for this foreign id (movie credit
+// posters), so fall back to a plain read over the same path it would take.
 export function useToggleStudioMonitored() {
-  return useMutation({
-    mutationFn: async ({
-      studioId,
-      foreignId,
-      monitored,
-      moviesMonitored,
-    }: {
-      studioId: number;
-      foreignId: string;
-      monitored: boolean;
-      moviesMonitored: boolean;
-    }) => {
+  return useApiMutation<Studio, ToggleStudioInput, Studio>({
+    method: 'PUT',
+    path: ({ studioId }) => `/studio/${studioId}`,
+    body: async ({ foreignId, monitored, moviesMonitored }) => {
       const studioPath = `/studio/${foreignId}`;
       // Fetch from cache first; falls back to network if not cached
       const studio = await queryClient.fetchQuery<Studio>({
@@ -51,23 +48,23 @@ export function useToggleStudioMonitored() {
         queryFn: () =>
           fetchJson<Studio, undefined>({
             path: getQueryPath(studioPath),
-            headers: AUTH_HEADERS,
+            headers: {
+              'X-Api-Key': window.Whisparr.apiKey,
+              'X-Whisparr-Client': 'Whisparr',
+            },
           }),
       });
-      return fetchJson<Studio, Studio>({
-        path: getQueryPath(`/studio/${studioId}`),
-        method: 'PUT',
-        body: { ...studio, monitored, moviesMonitored },
-        headers: AUTH_HEADERS,
-      });
+      return { ...studio, monitored, moviesMonitored };
     },
-    onSuccess: (data) => {
-      if (data?.foreignId) {
-        queryClient.setQueryData(
-          [`/studio/${data.foreignId}`],
-          (old: Studio) => (old ? { ...old, ...data } : data)
-        );
-      }
+    mutationOptions: {
+      onSuccess: (data) => {
+        if (data?.foreignId) {
+          queryClient.setQueryData(
+            [`/studio/${data.foreignId}`],
+            (old: Studio) => (old ? { ...old, ...data } : data)
+          );
+        }
+      },
     },
   });
 }

--- a/frontend/src/System/Backup/useBackups.ts
+++ b/frontend/src/System/Backup/useBackups.ts
@@ -1,8 +1,7 @@
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useQueryClient } from '@tanstack/react-query';
 import useApiMutation from 'Helpers/Hooks/useApiMutation';
 import useApiQuery from 'Helpers/Hooks/useApiQuery';
 import Backup from 'typings/Backup';
-import getQueryPath from 'Utilities/Fetch/getQueryPath';
 
 const useBackups = () => {
   const result = useApiQuery<Backup[]>({
@@ -67,37 +66,21 @@ export const useRestoreBackup = (id: number) => {
   };
 };
 
-// Multipart upload, so this cannot go through useApiMutation -- fetchJson sets
-// a JSON content type, and the boundary has to be left to the browser.
+// Multipart upload -- `fetchJson` passes FormData through untouched, so the
+// browser keeps setting the boundary and this goes through the shared layer.
 export const useRestoreBackupUpload = () => {
   const queryClient = useQueryClient();
 
-  const { mutate, isPending, error } = useMutation<
+  const { mutate, isPending, error } = useApiMutation<
     RestoreBackupResponse,
-    Error,
     FormData
   >({
-    mutationFn: async (formData: FormData) => {
-      const response = await fetch(
-        getQueryPath('/system/backup/restore/upload'),
-        {
-          method: 'POST',
-          headers: {
-            'X-Api-Key': window.Whisparr.apiKey,
-            'X-Whisparr-Client': 'Whisparr',
-          },
-          body: formData,
-        }
-      );
-
-      if (!response.ok) {
-        throw new Error(`Failed to restore backup: ${response.statusText}`);
-      }
-
-      return response.json();
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['/system/backup'] });
+    method: 'POST',
+    path: '/system/backup/restore/upload',
+    mutationOptions: {
+      onSuccess: () => {
+        queryClient.invalidateQueries({ queryKey: ['/system/backup'] });
+      },
     },
   });
 

--- a/frontend/src/Utilities/Fetch/fetchJson.ts
+++ b/frontend/src/Utilities/Fetch/fetchJson.ts
@@ -51,9 +51,21 @@ async function fetchJson<T, TData>({
     }, timeout);
   }
 
+  // Binary bodies (FormData, Blob) pass through untouched so a multipart upload
+  // keeps the boundary only the browser can set. Everything else is JSON-encoded
+  // and gets a matching content type below.
+  const isBinaryBody = body instanceof FormData || body instanceof Blob;
+
+  let requestBody: BodyInit | undefined = undefined;
+  if (body) {
+    requestBody = isBinaryBody
+      ? (body as unknown as BodyInit)
+      : JSON.stringify(body);
+  }
+
   const response = await fetch(path, {
     ...options,
-    body: body ? JSON.stringify(body) : undefined,
+    body: requestBody,
     headers: {
       ...options.headers,
       Accept: 'application/json',
@@ -61,8 +73,9 @@ async function fetchJson<T, TData>({
       // application/json` is not a CORS-safelisted request header, so setting
       // it unconditionally makes every cross-origin GET preflight -- which the
       // OAuth intermediate request to plex.tv is. Same-origin calls never
-      // noticed, and a body-less request has no content type to declare.
-      ...(body ? { 'Content-Type': 'application/json' } : {}),
+      // noticed, and a body-less request has no content type to declare. A
+      // binary body carries its own (browser-set) multipart content type.
+      ...(body && !isBinaryBody ? { 'Content-Type': 'application/json' } : {}),
     },
     signal: anySignal(abortController.signal, signal),
   });


### PR DESCRIPTION
#### Database Migration

NO

#### Description

Completes the shared-mutation sweep started in Whisparr/Whisparr-Eros#845: the remaining hooks that built raw react-query mutations with local `AUTH_HEADERS` + fetch helpers now go through the shared `useApiMutation` layer.

- Studio/Performer monitored toggles read-modify-write via a function-form request body on `useApiMutation` (cached entity + toggled fields; full-body PUT semantics unchanged).
- Add-movie POST and restore-backup upload go through the same shared layer; multipart restore passes `FormData` bodies straight through `fetchJson` without applying a JSON content-type.
- Adds an optional `TBody` generic to `useApiMutation` so per-call bodies can be derived from the mutate argument — no existing call site needed changes.

No `AUTH_HEADERS`, local `apiPost` helpers, or raw `useMutation(` calls remain in `frontend/src`. Verified with `yarn lint` (clean) and `tsc --noEmit` (only 3 pre-existing node_modules lib errors), plus a live check on localhost:6969 confirming the toggle PUTs to `/studio/{id}` with the cache patched afterwards.

#### Screenshot(s) (if UI related)

<details>
<!-- paste screenshots below here.-->

N/A - behavior-preserving refactor, no visual changes.

<!-- paste screenshots above here.  MAKE SURE THE ARE SFW -->
</details>

#### Todos

- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)

#### Issues Fixed or Closed by this PR

- Fixes Whisparr/Whisparr-Eros#845
