### PR TITLE
Fix: Route upstream-watch tracking issues to Whisparr/Whisparr

### DIFF
--- a/.github/workflows/upstream-watch.yml
+++ b/.github/workflows/upstream-watch.yml
@@ -39,6 +39,15 @@ jobs:
         with:
           app-id: ${{ secrets.CI_APP_ID }}
           private-key: ${{ secrets.CI_APP_KEY }}
+          # Two repos, because the work is split across two. The PR belongs
+          # here, but issues are disabled on this repo -- the backlog issue
+          # goes to Whisparr/Whisparr, where issues for both are tracked.
+          # Left unset, the token is scoped to this repo alone and every
+          # issue call 404s.
+          owner: ${{ github.repository_owner }}
+          repositories: |
+            Whisparr-Eros
+            Whisparr
 
       - name: Check out
         uses: actions/checkout@v7
@@ -69,6 +78,9 @@ jobs:
         if: fromJSON(steps.attempt.outputs.summary).applied > 0
         env:
           GH_TOKEN: ${{ steps.app.outputs.token }}
+          # Stated rather than inferred from the checkout, so the contrast with
+          # the issue step below is on the page.
+          GH_REPO: ${{ github.repository }}
           BRANCH: ${{ fromJSON(steps.attempt.outputs.summary).branch }}
           UPSTREAM: ${{ matrix.upstream }}
         run: |
@@ -96,6 +108,10 @@ jobs:
       - name: Update the tracking issue
         env:
           GH_TOKEN: ${{ steps.app.outputs.token }}
+          # Issues are disabled on Whisparr-Eros and tracked on Whisparr for
+          # both repos, so every gh call in this step -- label and issue alike
+          # -- has to be aimed off this repo.
+          GH_REPO: Whisparr/Whisparr
           TITLE: ${{ matrix.title }}
           OUTSTANDING: ${{ fromJSON(steps.attempt.outputs.summary).outstanding }}
         run: |

--- a/scripts/upstream-sync.mjs
+++ b/scripts/upstream-sync.mjs
@@ -383,7 +383,8 @@ function renderAttempt(result) {
 
   if (conflicted.length > 0 || gated.length > 0) {
     lines.push(
-      `Left out and tracked on the \`Upstream sync: ${upstream.repo.split('/')[1]} ${upstream.branch}\` issue:`,
+      `Left out and tracked on the \`Upstream sync: ${upstream.repo.split('/')[1]} ${upstream.branch}\` issue`,
+      'on Whisparr/Whisparr, where issues for both repos live:',
       `${conflicted.length} conflicted, ${gated.length} gated.`,
       ''
     );


### PR DESCRIPTION
#### Database Migration

NO

#### Description

`upstream-watch` got past the app-token failure and died on the next step:

```
the 'Whisparr/Whisparr-Eros' repository has disabled issues
Error: Process completed with exit code 1.
```

Issues for both repos are tracked on Whisparr/Whisparr, so the tracking-issue
step is aimed there with `GH_REPO`. One env var covers every `gh` call in the
step — `label create` and `issue list/create/edit/close/reopen` — rather than
six `--repo` flags to keep in sync.

The app token had to widen with it: `create-github-app-token` scopes to the
current repo when `repositories` is unset, so the token could not have written
the issue even once the step was pointed correctly.

The PR step still writes here; `GH_REPO` is now stated rather than inferred from
the checkout so the split reads on the page. No behaviour change there.

`scripts/upstream-sync.mjs` said leftovers are tracked on the `Upstream sync: …`
issue with no repo, which was fine when both lived in one place. It now names
Whisparr/Whisparr.

**Needs checking before the next run:** the app has to be installed on
Whisparr/Whisparr. If it is installed on Whisparr-Eros only, `repositories`
listing a repo outside the installation makes the mint step fail outright — a
working step becomes a broken one. The bot has never opened anything on either
repo, so there is no activity trail to infer from.

Also note the `upstream` label does not exist on Whisparr/Whisparr yet;
`gh label create --force` handles that. There is an unrelated `sonarr upstream`
label there already — no collision, they will just sit next to each other.

#### Todos

- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)

Neither applies: workflow and script-side change, no product code and no user-facing strings. `node scripts/upstream-sync.mjs --check` passes and the workflow YAML parses.
