### PR TITLE
Chore: Track the repo's Claude skills, keep local settings ignored

### DIFF
--- a/.claude/skills/review-eros/SKILL.md
+++ b/.claude/skills/review-eros/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: review-eros
+description: Review a GitHub PR against Whisparr/Whisparr-Eros:eros-develop with this repo's conventions (branch target, commit prefixes, 80% new-code coverage, en.json translation keys, DB-migration note, NUnit *Fixture tests, ParserTests scrutiny). Produces a structured terminal review, then offers to post it. Use when reviewing an Eros PR.
+argument-hint: "[PR number or URL]"
+user-invocable: true
+allowed-tools: Bash, Read, Grep, Glob, Agent, AskUserQuestion, TodoWrite
+---
+
+# Review an Eros PR
+
+Review a pull request against `Whisparr/Whisparr-Eros:eros-develop` the same way
+every time. The repo is `Whisparr/Whisparr-Eros` (remote here). Issues for both
+`Whisparr/Whisparr` and `Whisparr/Whisparr-Eros` are tracked on
+`Whisparr/Whisparr`, so linked issues use `Fixes whisparr/whisparr#NNNN`.
+
+Output rule: **produce the full review in the terminal first, then ask** whether
+to post it. Never auto-post. Never add an AI-attribution footer to anything
+posted (per global rules).
+
+Run the phases in order. Track them with TodoWrite if the review is non-trivial.
+
+## 1. Resolve the PR
+
+- The argument is a PR number or URL. If omitted, infer from the current branch
+  (`gh pr view --json number` on the checked-out branch) or ask which PR.
+- Gather everything up front:
+  ```
+  gh pr view <n> --repo Whisparr/Whisparr-Eros \
+    --json number,title,body,baseRefName,headRefName,author,files,commits,url,isDraft
+  gh pr diff <n> --repo Whisparr/Whisparr-Eros
+  ```
+- Note: title, body, **base branch**, head branch, changed files, full diff,
+  commit list, linked issues, draft status.
+
+## 2. Gate checks — conventions & PR template (always run)
+
+Flag every miss. Sources: `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`,
+`.editorconfig`, `src/stylecop.json`.
+
+- **Base branch MUST be `eros-develop`** (never `eros`). Wrong base = blocking
+  hard fail — PRs to `eros` get closed.
+- Head branch is meaningfully named (`fix-...`/`new-...`), not `patch`/`develop`/
+  `eros-develop`.
+- Commit prefixes: accept **both** Servarr (`New:`/`Fix:`/`Chore:`) and
+  conventional (`feat:`/`fix:`/`chore:`/`refactor:`) — the repo tolerates both.
+- One feature/bug-fix per PR — flag scope creep.
+- PR-template items present in the body:
+  - **DB migration note** (`YES - XXXX` or `NO`). If the diff adds a migration
+    under `src/NzbDrone.Core/Datastore/Migration/`, the note must give its
+    number.
+  - **Tests** checkbox and **Translation Keys** checkbox.
+  - Linked issue as `Fixes whisparr/whisparr#NNNN` (issues live on
+    `Whisparr/Whisparr`).
+- **Localization**: any new user-facing string needs an `en.json` key at
+  `src/NzbDrone.Core/Localization/Core/en.json`. Backend uses
+  `_localizationService.GetLocalizedString("Key")`; frontend uses
+  `translate('Key')`. Log-message translations are not accepted — don't ask for
+  them.
+- **Style** (call out obvious violations only; CI's SonarQube + eslint/stylelint
+  do the real enforcement): 4-space indent, `var` preferred, `_camelCase`
+  private fields with `_` prefix, `System.*` usings first, final newline.
+
+## 3. Test-coverage review (always run)
+
+- New/changed **backend** code needs NUnit tests: `*Fixture.cs` classes named
+  `XxxFixture : CoreTest`, in the sibling `src/NzbDrone.*.Test` project (e.g.
+  `NzbDrone.Core.Test`). Expect ~**80% coverage on new code**.
+- **Parser changes get extra scrutiny.** If the diff touches
+  `src/NzbDrone.Core/Parser/`, require added/updated `[TestCase(...)]` rows in
+  `src/NzbDrone.Core.Test/ParserTests/` — `ParserFixture.cs`,
+  `ParseMovieTitleFixture.cs`, `StudioFixture.cs`, `QualityParserFixture.cs`,
+  etc. — covering the **specific tokens/edge cases** touched. A parser change
+  with no new parser test case is a finding, not a nit. (Parser regressions are
+  a recurring theme in this repo: codec tokens, multi-brand studio parsing.)
+
+## 4. Correctness review (always run)
+
+Read the **changed files in full**, not just the diff hunks, and reason about
+logic errors, missed edge cases, and regressions. Weight parser/token handling
+heavily given repo history. You may delegate the deep correctness pass to the
+built-in `/code-review` skill on the checked-out branch and fold its findings in
+— this skill's job is to wrap that with the Eros-specific gates above.
+
+## 5. Adaptive local verification
+
+Decide from the diff whether to run anything locally:
+
+- **Risky diff** — touches `src/NzbDrone.Core/Parser/`, a DB migration, core
+  release/parsing/decision logic, or security-sensitive code:
+  1. `gh pr checkout <n> --repo Whisparr/Whisparr-Eros`
+  2. Build + run the **targeted** fixtures for the touched area, excluding heavy
+     categories, e.g.:
+     ```
+     dotnet test src/NzbDrone.Core.Test/Whisparr.Core.Test.csproj \
+       --filter "FullyQualifiedName~ParserTests&TestCategory!=IntegrationTest&TestCategory!=AutomationTest&TestCategory!=ManualTest"
+     ```
+     (Adjust the `FullyQualifiedName~` filter to the touched fixtures.)
+  3. Report pass/fail with real output. Restore the original branch afterward.
+- **Low-risk diff** — frontend-only, docs, or a small isolated change: stay
+  static and rely on CI. **State explicitly** that local verification was
+  skipped and why.
+
+Never claim tests passed unless you actually ran them.
+
+## 5b. Read the actual CI result (always run)
+
+The PR's CI has usually already run — read it, don't just predict it:
+
+```
+gh pr checks <n> --repo Whisparr/Whisparr-Eros
+gh pr view <n> --repo Whisparr/Whisparr-Eros --json statusCheckRollup,mergeStateStatus,mergeable
+```
+
+Report the real state of the key gates from `build_v3.yml` and `sonarqube.yml`:
+backend matrix, `frontend`, `unit_test`, `unit_test_postgres`, `integration_test`,
+and SonarQube "Build and Analyze". A failing/red check is a **blocking** finding;
+name the failed job. `deploy / release` and `CodeQL` showing `skipping`/`neutral`
+is normal on a PR.
+
+Distinguish a real failure from a **held** run: this repo only blocks automatic
+Action runs for **new / first-time contributors** (runs sit `pending` awaiting
+maintainer approval — GitHub's fork-PR gate). That is a workflow-approval step,
+not a fault in the PR, and it is **not** a blocking finding — call it out as
+"CI awaiting maintainer approval (new contributor)" and review on the code alone.
+For known contributors and Dependabot, CI runs automatically, so absent/pending
+checks there are worth a second look.
+
+`mergeStateStatus: BLOCKED` with `mergeable: MERGEABLE` and all checks green
+usually just means the PR is awaiting a review approval — not a CI problem.
+
+## 6. Emit the terminal review
+
+Always use this fixed structure:
+
+- **Verdict**: Approve / Approve-with-nits / Request-changes / Blocked.
+- **Blocking** — correctness bugs, wrong base branch, missing required tests.
+  Most severe first, each as `file:line` with a concrete failure scenario.
+- **Should-fix** — coverage gaps, convention/PR-template misses.
+- **Nits** — style, naming.
+- **Checklist** — one pass/fail line each: base branch, commit prefixes,
+  migration note, tests present, `en.json` keys, ~80% coverage, and **actual CI
+  status** (from step 5b — real result of build_v3 + SonarQube, or "awaiting
+  maintainer approval" for a new contributor).
+
+## 7. Offer to post (never auto-post)
+
+After printing the review, use AskUserQuestion to ask whether to post it. Only on
+explicit approval:
+
+- Summary review: `gh pr review <n> --repo Whisparr/Whisparr-Eros --comment --body "..."`
+  (or `--request-changes` / `--approve` to match the verdict).
+- Inline notes: `gh pr comment <n> --repo Whisparr/Whisparr-Eros --body "..."`.
+
+Confirm before this outward-facing step every time. No AI-attribution footer.

--- a/.claude/skills/sync-upstream/SKILL.md
+++ b/.claude/skills/sync-upstream/SKILL.md
@@ -1,0 +1,182 @@
+---
+name: sync-upstream
+description: Work one month-sized chunk of the Radarr or Sonarr upstream backlog for Whisparr Eros. Reads each upstream diff, applies the parser/localization/frontend skip rules, records a disposition with a reason, applies the picks, regenerates UPSTREAM_SYNC.md, and opens the PR. Use when catching up on upstream commits or when the upstream-watch tracking issue lists new work.
+argument-hint: "<radarr|sonarr> <YYYY-MM>"
+user-invocable: true
+allowed-tools: Bash, Read, Grep, Glob, Edit, Write, AskUserQuestion, TodoWrite
+---
+
+# Sync one upstream chunk
+
+Whisparr Eros tracks **two** upstreams on two clocks:
+
+| Tree | Upstream | Why |
+| --- | --- | --- |
+| `frontend/` | `Sonarr/Sonarr:v5-develop` | Our React Query + zustand frontend was ported from Sonarr's completed migration (see `REDUX_MIGRATION.md`). |
+| `src/` and everything else | `Radarr/Radarr:develop` | Our code lineage. The chain is Sonarr → Radarr → us. |
+
+State lives in `.github/upstream/state.json` — high-water SHAs plus a
+`sha → {subject, month, disposition, reason}` map. **That file is the only thing
+you edit by hand, and `UPSTREAM_SYNC.md` is generated from it.** Never edit the
+report directly; `--check` will catch you.
+
+Argument is an upstream and a month: `sync-upstream radarr 2026-04`. If omitted,
+read `UPSTREAM_SYNC.md` and propose the smallest outstanding month.
+
+Run the phases in order. Track them with TodoWrite when the chunk has more than
+a handful of commits.
+
+## 1. Resolve the chunk
+
+```sh
+GITHUB_TOKEN=$(gh auth token) node scripts/upstream-sync.mjs --report
+```
+
+Read the month's section of `UPSTREAM_SYNC.md`. That list is the chunk. Anything
+already in `state.json` has been settled and will not appear.
+
+`upstream-watch` runs weekly and may have got there first: it opens a **draft**
+PR holding the commits that cherry-picked cleanly and cleared the automatable
+gates, and lists the conflicted and gated remainder on the tracking issue. That
+PR is a starting point, not a verdict. Nothing in it is dispositioned, none of
+it has been read against the rules below, and taking it as-is is exactly the
+mistake the gates exist to prevent. Read every diff in it as if you had picked
+it yourself, drop what should not be there, and write the dispositions.
+
+Branch off `eros-develop` — never work on it directly:
+
+```sh
+git switch -c sync-<upstream>-<YYYY-MM> eros-develop
+```
+
+## 2. Read every diff
+
+For each commit:
+
+```sh
+gh api repos/<Radarr/Radarr|Sonarr/Sonarr>/commits/<sha> -q '.files[] | .filename, .patch'
+```
+
+**Never classify from the subject line.** Subjects routinely understate scope
+("Fix syntax" that rewrites a service) or overstate relevance (a "parser fix"
+that only touches a token we do not have).
+
+## 3. Apply the skip rules — these are gates, not guidance
+
+Run these *before* deciding anything. Each exists because following upstream
+here has actively cost us.
+
+### Parser → skip by default
+
+Anything under `src/NzbDrone.Core/Parser/`. Our `Parser.cs` is ~1,100 lines
+against Radarr's ~640; we parse scenes with full dates, performers and studios,
+they parse movies by year or series by season/episode. Upstream regexes are
+tuned to a grammar we do not share.
+
+The **only** way past this gate: write a test against *our* parser that fails
+before the fix. A ported regex plus a ported test proves nothing. If it does not
+reproduce here, record `skip` with that reason.
+
+Be especially wary of anything about absolute episode numbers (no such concept
+here) or date-vs-year precedence (exactly where our grammar deliberately
+differs — a bare `[YYYY]` means a movie, scenes carry full dates).
+
+### Localization → never take an upstream `en.json` hunk
+
+We keep `en.json` sorted case-insensitively; upstream does not (they carry ~70
+out-of-order pairs each, we carry one known one). Shared keys also collide —
+dozens have different text on our side.
+
+So a pick that needs a user-facing string gets **our own key, authored by us, in
+correct case-insensitive sorted position**. Take the code, leave the JSON.
+
+Every `Multiple Translations updated by Weblate` commit is an automatic `skip` —
+those files come from Weblate, not from cherry-picks.
+
+### Generated API docs → skip
+
+Both upstreams regenerate a checked-in `openapi.json` from a bot, several times
+a month. We retired ours along with the workflow that produced it, so those
+commits rewrite a file we do not have — automatic `skip`.
+
+Gated on the files, not the subject: commits with "API docs" in the title are
+often hand-written C# (a resource attribute, a controller change) and still have
+to be read.
+
+### Radarr `frontend/` → skip by default
+
+Our frontend follows Sonarr. Radarr is still mid-conversion to the react-query
+patterns Sonarr finished, so picking their frontend commits re-imports something
+we already moved past. Past the gate only for a genuine bug fix in code we still
+share.
+
+## 4. Classify what survives
+
+One of four, and **every one needs a reason** — `--check` rejects a bare or
+stub reason:
+
+- **`pick`** — applies as-is.
+- **`adapt`** — right idea, wrong entity model. Radarr `Movie`/`Collection` or
+  Sonarr `Series`/`Episode` vs our `Movie`/`Scene`/`Performer`/`Studio`.
+- **`skip`** — upstream-specific, gated out, or not wanted. Say which.
+- **`have`** — already in our tree.
+
+Write each into `.github/upstream/state.json` as you go. "Not applicable to
+Whisparr" is precisely the knowledge that gets lost and re-litigated a year
+later, so the reason has to say *why*.
+
+Anything that is a feature decision rather than a sync decision — a new download
+client, a new list integration — is not yours to wave through. Stop and ask.
+
+## 5. Apply the picks
+
+Keep the trailer convention already used throughout our history:
+
+```
+(cherry picked from commit radarr/radarr@<sha>)
+(cherry picked from commit sonarr/sonarr@<sha>)
+```
+
+The Sonarr form barely exists in our history yet, which is exactly why the
+Sonarr side of the backlog was invisible until someone read `REDUX_MIGRATION.md`
+by hand. Use it.
+
+Commit prefixes: Servarr (`New:`/`Fix:`/`Chore:`) or conventional
+(`feat:`/`fix:`/`chore:`) — the repo tolerates both.
+
+## 6. Verify what you actually touched
+
+- Backend: `./build.sh --backend` and `dotnet test`.
+- Frontend: `yarn build`, plus `tsc` and `eslint` from the repo root. Three
+  `node_modules` errors from tsc is the clean baseline, not a failure.
+- Parser (if anything got past the gate): `dotnet test --filter ParserFixture`
+  and the `NzbDrone.Core.Test/ParserTests/` fixtures. **New** assertions —
+  never modify or delete an existing one to go green.
+- New-code coverage stays at 80%.
+- DB migration → note its number in the PR description.
+- Anything user-visible → run the app on port 6969 and check the live API.
+  Do not infer which surfaces a change reaches from shared code paths.
+
+## 7. Regenerate and open the PR
+
+```sh
+GITHUB_TOKEN=$(gh auth token) node scripts/upstream-sync.mjs --report
+GITHUB_TOKEN=$(gh auth token) node scripts/upstream-sync.mjs --check
+```
+
+Commit the regenerated `UPSTREAM_SYNC.md` and the updated `state.json` together
+with the code.
+
+**Advance the high-water SHA only when every commit at or before it is
+dispositioned.** A pointer that jumps ahead of unreviewed commits hides them —
+that is how a stray October pick concealed seven earlier commits until the
+report was rebuilt.
+
+Open the PR against `eros-develop` (never `eros`) filling in
+`.github/PULL_REQUEST_TEMPLATE.md` — `gh pr create --body` silently bypasses it,
+so pass `--body-file` with the template filled in. Keep the body short: what was
+picked, what was skipped and why, and the verification result. Link issues fully
+qualified as `Fixes Whisparr/Whisparr#123` — a bare `#123` resolves against the
+wrong repo from this remote.
+
+Never add AI attribution to the commit or PR body.

--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,7 @@ src/**/[Oo]bj/
 .vs/
 .continue
 .vscode
-.claude
+.claude/settings.local.json
 CLAUDE.md
 
 # Build results


### PR DESCRIPTION
#### Database Migration

NO

#### Description

`.gitignore` ignored all of `.claude`, so the two skills that encode this repo's
own process lived only on whoever's machine wrote them:

- **`sync-upstream`** — the parser / localization / frontend gates, the four
  dispositions and the rule that every one needs a reason, the cherry-pick
  trailer convention, and the high-water rule that a mark must never jump ahead
  of unreviewed commits.
- **`review-eros`** — the review checklist: branch target, commit prefixes, 80%
  new-code coverage, `en.json` keys, DB-migration note, `*Fixture` tests and the
  CI gates to report on.

That is project documentation, not editor config — most of it exists because
following upstream carelessly has cost us before, and none of it is derivable
from the code. A fresh clone should get it.

Narrowed the rule to `.claude/settings.local.json`, which is genuinely
per-machine — it holds absolute paths outside this repo. Verified it is still
ignored after the change, and that the two skills are the only files the
narrower rule exposes.

`CLAUDE.md` stays ignored — separate call, happy to revisit.

#### Todos

- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)

Neither applies — documentation and ignore rules, no code.

**Merge after #584.** The `sync-upstream` skill here documents the `api-docs`
gate that #584 adds, so landing this first leaves the doc briefly ahead of the
code.
