### PR TITLE
Chore: Sync Sonarr 2025-10

### DIFF
--- a/.github/upstream/state.json
+++ b/.github/upstream/state.json
@@ -12,8 +12,8 @@
       "repo": "Sonarr/Sonarr",
       "branch": "v5-develop",
       "owns": "frontend",
-      "highWater": "a4f210855e9a5457546a612a6fca57081d239433",
-      "highWaterNote": "2026-08-27 'New: Parsing file names with ambiguous episode numbering'. Everything on Sonarr v5-develop at or before this point is dispositioned. Advance only when everything at or before the new mark is settled."
+      "highWater": "37dfad11f26301c1d0dbfd944df1e4bdc0d44d89",
+      "highWaterNote": "2025-10-30 'Remove v3 updates from UI'. Everything on Sonarr v5-develop at or before this point is dispositioned. Deliberately stops one short of the end of 2025-10: 550cf8d39 'New: Option to specify timezone for formatting times in the UI' is a feature decision being taken as its own PR, so it stays outstanding rather than being recorded as settled. Advance only when everything at or before the new mark is settled."
     }
   },
   "dispositions": {
@@ -1021,6 +1021,90 @@
         "month": "2026-08",
         "disposition": "pick",
         "reason": "Allowed Hosts lives in the config file, so ConfigFileSavedEvent is the event that follows a change to it; ConfigSavedEvent left the check showing a stale result until the next scheduled run. Applies as-is."
+      },
+      "ca364724cfcf5d22604dd32556e3415ff1fbe566": {
+        "subject": "Automated API Docs update",
+        "month": "2025-10",
+        "disposition": "skip",
+        "reason": "Regenerated openapi.json only. We retired the checked-in spec and the workflow that produced it, so there is no counterpart file here."
+      },
+      "74ce132556557897ef35f4d7cc73dacdb96c36d8": {
+        "subject": "Add v5 History endpoints",
+        "month": "2025-10",
+        "disposition": "skip",
+        "reason": "Adds src/Sonarr.Api.V5/History. Sonarr is building a v5 API surface alongside v3; we only have Whisparr.Api.V3, so there is nothing here to add these to."
+      },
+      "a45b077625e7c20a2421bb61822e3b21805817cb": {
+        "subject": "Use react-query for History UI",
+        "month": "2025-10",
+        "disposition": "have",
+        "reason": "We already ran this migration: frontend/src/Activity/History has historyOptionsStore.ts and useHistory.ts, and the redux historyActions.js this deletes never existed here - there is no frontend/src/Store at all."
+      },
+      "b04b9f900fc72c68df8dafd8980e0db5fcba0e1b": {
+        "subject": "New: Add button to close side bar",
+        "month": "2025-10",
+        "disposition": "adapt",
+        "reason": "Ported. Ours drives visibility through the zustand appStore rather than a redux dispatch, and the logo is logo.png under window.Whisparr, so the small-screen sidebar header was rewritten rather than cherry-picked. Also drops the scroll-tracked sidebar positioning, as upstream did."
+      },
+      "813d7df643fb1b47221201e27a8b8039a4deaaf8": {
+        "subject": "Fixed: Notifications when episode is not available",
+        "month": "2025-10",
+        "disposition": "skip",
+        "reason": "Guards episodes.First() against an empty episode list in the Series/Episode notification builders. Our NotificationService.GetMessage takes a single Movie and no collection, and there is no .First() on an item collection anywhere under Notifications, so the crash path does not exist here."
+      },
+      "5568746ef817b0e09bd30e32e192a574294eb09c": {
+        "subject": "Fixed: Validation for SSL certificate file existence",
+        "month": "2025-10",
+        "disposition": "have",
+        "reason": "Upstream's FileExistsValidator was still the FluentValidation 9 non-generic PropertyValidator, and this migrates its use to construct one with an IDiskProvider. Ours is already the generic FileExistsValidator<T> : PropertyValidator<T, string>, injected and working. We also have no SslKeyPath setting, so that half does not apply."
+      },
+      "79b56c3ff60e2e56e9d9b57a953764d7ef6cdac0": {
+        "subject": "Pin System.Drawing.Common to 8.0.20",
+        "month": "2025-10",
+        "disposition": "have",
+        "reason": "We already pin System.Drawing.Common in Whisparr.Core.csproj, at 10.0.11 - ahead of the 8.0.20 this pins to."
+      },
+      "a1db23353c89c1a20ddb3b39f3b3817583a42616": {
+        "subject": "Fix Queue v5 API resource mapping when no episodes present",
+        "month": "2025-10",
+        "disposition": "skip",
+        "reason": "Fixes src/Sonarr.Api.V5/Queue/QueueResource.cs. We have no Api.V5 project, so there is no resource here to fix."
+      },
+      "52d7f676274df312db7120474119132928690766": {
+        "subject": "Switch to FluentMigrator.Runner.Core to avoid extranous platform runners",
+        "month": "2025-10",
+        "disposition": "have",
+        "reason": "Whisparr.Core.csproj already references FluentMigrator.Runner.Core 8.0.1 alongside the SQLite and Postgres runners, which is what this switches to."
+      },
+      "5a3f41263aa066f64ababcf73756fbf077a54fb3": {
+        "subject": "Fixed: qBittorrent /login API success check",
+        "month": "2025-10",
+        "disposition": "have",
+        "reason": "QBittorrentProxyV2 already has both halves: the catch logs the exception and treats Unauthorized or Forbidden as an auth failure, and the content check is guarded with IsNotNullOrWhiteSpace() so an empty body from older qbit builds is not read as a failed login."
+      },
+      "4fb89252b527b1a34cc0e1133a2acb765360fa13": {
+        "subject": "New: Parse multilang and multilanguage as multi",
+        "month": "2025-10",
+        "disposition": "adapt",
+        "reason": "Same gap, different home: our MultiRegex lives in Indexers/IndexerBase.cs, not under Parser/, and uses \\b word boundaries where upstream used an explicit delimiter class. Widened the alternation to multilanguage|multilang|multi and kept our boundaries, so titles like 'MultiSub' and 'Multiple.Angles' still do not match. Covered by new cases in IndexerBaseFixture, which failed before the change."
+      },
+      "fce8e780cb7567fed9a47c3bbb2dc510f1a461e6": {
+        "subject": "Add v5 log files endpoints",
+        "month": "2025-10",
+        "disposition": "skip",
+        "reason": "Adds src/Sonarr.Api.V5/Logs. Same reason as the other v5 endpoint commits: we have no Api.V5 project."
+      },
+      "ff5e73273b02f90be9ee03307cd6909e8b5fb8bd": {
+        "subject": "Use react-query for Log Files",
+        "month": "2025-10",
+        "disposition": "have",
+        "reason": "We already have frontend/src/System/Logs/useLogFiles.ts and the redux systemActions.js this strips from never existed here."
+      },
+      "37dfad11f26301c1d0dbfd944df1e4bdc0d44d89": {
+        "subject": "Remove v3 updates from UI",
+        "month": "2025-10",
+        "disposition": "have",
+        "reason": "Drops the redux fetchUpdates dispatch in favour of react-query refetch. Our AppUpdatedModalContent already uses useUpdates() with refetch and useAppValues, with no redux anywhere in the tree."
       }
     }
   }

--- a/UPSTREAM_SYNC.md
+++ b/UPSTREAM_SYNC.md
@@ -26,15 +26,15 @@ Owns: **backend**. High-water mark: `68b93db78c`.
 
 ## sonarr — Sonarr/Sonarr `v5-develop`
 
-<!-- outstanding: 486 -->
+<!-- outstanding: 472 -->
 
-Owns: **frontend**. High-water mark: `a4f210855e`.
+Owns: **frontend**. High-water mark: `37dfad11f2`.
 
-**486 outstanding.**
+**472 outstanding.**
 
 | Month | Total | be | fe | be+fe | chore |
 | --- | ---: | ---: | ---: | ---: | ---: |
-| 2025-10 | 15 | 10 | 4 | 1 | 0 |
+| 2025-10 | 1 | 0 | 0 | 1 | 0 |
 | 2025-11 | 73 | 46 | 21 | 6 | 0 |
 | 2025-12 | 74 | 46 | 19 | 7 | 2 |
 | 2026-01 | 62 | 37 | 15 | 10 | 0 |
@@ -47,20 +47,6 @@ Owns: **frontend**. High-water mark: `a4f210855e`.
 
 ### 2025-10
 
-- `be   ` [`ca364724c`](https://github.com/Sonarr/Sonarr/commit/ca364724cfcf5d22604dd32556e3415ff1fbe566) Automated API Docs update — *Sonarr*
-- `be   ` [`74ce13255`](https://github.com/Sonarr/Sonarr/commit/74ce132556557897ef35f4d7cc73dacdb96c36d8) Add v5 History endpoints — *Mark McDowall*
-- `fe   ` [`a45b07762`](https://github.com/Sonarr/Sonarr/commit/a45b077625e7c20a2421bb61822e3b21805817cb) Use react-query for History UI — *Mark McDowall*
-- `fe   ` [`b04b9f900`](https://github.com/Sonarr/Sonarr/commit/b04b9f900fc72c68df8dafd8980e0db5fcba0e1b) New: Add button to close side bar — *Mark McDowall*
-- `be   ` [`813d7df64`](https://github.com/Sonarr/Sonarr/commit/813d7df643fb1b47221201e27a8b8039a4deaaf8) Fixed: Notifications when episode is not available — *Stevie Robinson*
-- `be   ` [`5568746ef`](https://github.com/Sonarr/Sonarr/commit/5568746ef817b0e09bd30e32e192a574294eb09c) Fixed: Validation for SSL certificate file existence — *Bogdan*
-- `be   ` [`79b56c3ff`](https://github.com/Sonarr/Sonarr/commit/79b56c3ff60e2e56e9d9b57a953764d7ef6cdac0) Pin System.Drawing.Common to 8.0.20 — *Bogdan*
-- `be   ` [`a1db23353`](https://github.com/Sonarr/Sonarr/commit/a1db23353c89c1a20ddb3b39f3b3817583a42616) Fix Queue v5 API resource mapping when no episodes present — *Stevie Robinson*
-- `be   ` [`52d7f6762`](https://github.com/Sonarr/Sonarr/commit/52d7f676274df312db7120474119132928690766) Switch to FluentMigrator.Runner.Core to avoid extranous platform runners — *Bogdan*
-- `be   ` [`5a3f41263`](https://github.com/Sonarr/Sonarr/commit/5a3f41263aa066f64ababcf73756fbf077a54fb3) Fixed: qBittorrent /login API success check — *Polgonite*
-- `be   ` [`4fb89252b`](https://github.com/Sonarr/Sonarr/commit/4fb89252b527b1a34cc0e1133a2acb765360fa13) New: Parse multilang and multilanguage as multi — *Stevie Robinson*
-- `be   ` [`fce8e780c`](https://github.com/Sonarr/Sonarr/commit/fce8e780cb7567fed9a47c3bbb2dc510f1a461e6) Add v5 log files endpoints — *Mark McDowall*
-- `fe   ` [`ff5e73273`](https://github.com/Sonarr/Sonarr/commit/ff5e73273b02f90be9ee03307cd6909e8b5fb8bd) Use react-query for Log Files — *Mark McDowall*
-- `fe   ` [`37dfad11f`](https://github.com/Sonarr/Sonarr/commit/37dfad11f26301c1d0dbfd944df1e4bdc0d44d89) Remove v3 updates from UI — *Mark McDowall*
 - `be+fe` [`550cf8d39`](https://github.com/Sonarr/Sonarr/commit/550cf8d39963f30da7273b884c6007ce9da9cdf0) New: Option to specify timezone for formatting times in the UI — *Audionut*
 
 ### 2025-11
@@ -678,6 +664,20 @@ Commits reviewed and dispositioned. Skips carry their reason.
 
 | Commit | Subject | Disposition | Reason |
 | --- | --- | --- | --- |
+| [`ca364724c`](https://github.com/Sonarr/Sonarr/commit/ca364724cfcf5d22604dd32556e3415ff1fbe566) | Automated API Docs update | `skip` | Regenerated openapi.json only. We retired the checked-in spec and the workflow that produced it, so there is no counterpart file here. |
+| [`74ce13255`](https://github.com/Sonarr/Sonarr/commit/74ce132556557897ef35f4d7cc73dacdb96c36d8) | Add v5 History endpoints | `skip` | Adds src/Sonarr.Api.V5/History. Sonarr is building a v5 API surface alongside v3; we only have Whisparr.Api.V3, so there is nothing here to add these to. |
+| [`a45b07762`](https://github.com/Sonarr/Sonarr/commit/a45b077625e7c20a2421bb61822e3b21805817cb) | Use react-query for History UI | `have` | We already ran this migration: frontend/src/Activity/History has historyOptionsStore.ts and useHistory.ts, and the redux historyActions.js this deletes never existed here - there is no frontend/src/Store at all. |
+| [`b04b9f900`](https://github.com/Sonarr/Sonarr/commit/b04b9f900fc72c68df8dafd8980e0db5fcba0e1b) | New: Add button to close side bar | `adapt` | Ported. Ours drives visibility through the zustand appStore rather than a redux dispatch, and the logo is logo.png under window.Whisparr, so the small-screen sidebar header was rewritten rather than cherry-picked. Also drops the scroll-tracked sidebar positioning, as upstream did. |
+| [`813d7df64`](https://github.com/Sonarr/Sonarr/commit/813d7df643fb1b47221201e27a8b8039a4deaaf8) | Fixed: Notifications when episode is not available | `skip` | Guards episodes.First() against an empty episode list in the Series/Episode notification builders. Our NotificationService.GetMessage takes a single Movie and no collection, and there is no .First() on an item collection anywhere under Notifications, so the crash path does not exist here. |
+| [`5568746ef`](https://github.com/Sonarr/Sonarr/commit/5568746ef817b0e09bd30e32e192a574294eb09c) | Fixed: Validation for SSL certificate file existence | `have` | Upstream's FileExistsValidator was still the FluentValidation 9 non-generic PropertyValidator, and this migrates its use to construct one with an IDiskProvider. Ours is already the generic FileExistsValidator<T> : PropertyValidator<T, string>, injected and working. We also have no SslKeyPath setting, so that half does not apply. |
+| [`79b56c3ff`](https://github.com/Sonarr/Sonarr/commit/79b56c3ff60e2e56e9d9b57a953764d7ef6cdac0) | Pin System.Drawing.Common to 8.0.20 | `have` | We already pin System.Drawing.Common in Whisparr.Core.csproj, at 10.0.11 - ahead of the 8.0.20 this pins to. |
+| [`a1db23353`](https://github.com/Sonarr/Sonarr/commit/a1db23353c89c1a20ddb3b39f3b3817583a42616) | Fix Queue v5 API resource mapping when no episodes present | `skip` | Fixes src/Sonarr.Api.V5/Queue/QueueResource.cs. We have no Api.V5 project, so there is no resource here to fix. |
+| [`52d7f6762`](https://github.com/Sonarr/Sonarr/commit/52d7f676274df312db7120474119132928690766) | Switch to FluentMigrator.Runner.Core to avoid extranous platform runners | `have` | Whisparr.Core.csproj already references FluentMigrator.Runner.Core 8.0.1 alongside the SQLite and Postgres runners, which is what this switches to. |
+| [`5a3f41263`](https://github.com/Sonarr/Sonarr/commit/5a3f41263aa066f64ababcf73756fbf077a54fb3) | Fixed: qBittorrent /login API success check | `have` | QBittorrentProxyV2 already has both halves: the catch logs the exception and treats Unauthorized or Forbidden as an auth failure, and the content check is guarded with IsNotNullOrWhiteSpace() so an empty body from older qbit builds is not read as a failed login. |
+| [`4fb89252b`](https://github.com/Sonarr/Sonarr/commit/4fb89252b527b1a34cc0e1133a2acb765360fa13) | New: Parse multilang and multilanguage as multi | `adapt` | Same gap, different home: our MultiRegex lives in Indexers/IndexerBase.cs, not under Parser/, and uses \b word boundaries where upstream used an explicit delimiter class. Widened the alternation to multilanguage|multilang|multi and kept our boundaries, so titles like 'MultiSub' and 'Multiple.Angles' still do not match. Covered by new cases in IndexerBaseFixture, which failed before the change. |
+| [`fce8e780c`](https://github.com/Sonarr/Sonarr/commit/fce8e780cb7567fed9a47c3bbb2dc510f1a461e6) | Add v5 log files endpoints | `skip` | Adds src/Sonarr.Api.V5/Logs. Same reason as the other v5 endpoint commits: we have no Api.V5 project. |
+| [`ff5e73273`](https://github.com/Sonarr/Sonarr/commit/ff5e73273b02f90be9ee03307cd6909e8b5fb8bd) | Use react-query for Log Files | `have` | We already have frontend/src/System/Logs/useLogFiles.ts and the redux systemActions.js this strips from never existed here. |
+| [`37dfad11f`](https://github.com/Sonarr/Sonarr/commit/37dfad11f26301c1d0dbfd944df1e4bdc0d44d89) | Remove v3 updates from UI | `have` | Drops the redux fetchUpdates dispatch in favour of react-query refetch. Our AppUpdatedModalContent already uses useUpdates() with refetch and useAppValues, with no redux anywhere in the tree. |
 | [`2fbeff438`](https://github.com/Sonarr/Sonarr/commit/2fbeff4383af3ced58aac72d2470b90572a27da0) | Multiple Translations updated by Weblate | `skip` | Weblate commit. Our translations come from Weblate directly, never from cherry-picks. |
 | [`8112b536a`](https://github.com/Sonarr/Sonarr/commit/8112b536a23b16c27900aca05437b5ff9661b5e9) | Improve accessibility of series status indicators | `adapt` | Applied to MovieStatusCell and SceneStatusCell, our equivalents of SeriesStatusCell. Also brought in Components/StatusIndicator, which upstream added in 71d9a5d57 (2026-07-12, behind our high-water mark) and we never ported. Verified on 6969: all 40 status icons on the movie table now carry announced text. |
 | [`650a452bf`](https://github.com/Sonarr/Sonarr/commit/650a452bf0aa7a1f93aec5a1528c8e08d19b29cf) | New: Sorting Blocklist, History and Queue by Quality | `skip` | Deferred to its own PR by decision on 2026-08-30, not skipped on merit. 21 files: a QualityProfileQualityRank table, repository and service, a DB migration (233 there, 242 here) and rank joins added to the Blocklist, History and Episode repositories. A schema change belongs in its own review, not in a 15-commit sync chunk. |

--- a/frontend/src/Components/Page/Header/PageHeader.css
+++ b/frontend/src/Components/Page/Header/PageHeader.css
@@ -1,5 +1,4 @@
 .header {
-  z-index: 3;
   display: flex;
   align-items: center;
   flex: 0 0 auto;

--- a/frontend/src/Components/Page/Sidebar/PageSidebar.css
+++ b/frontend/src/Components/Page/Sidebar/PageSidebar.css
@@ -7,6 +7,38 @@
   transform: translateX(0);
 }
 
+.sidebarHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: $headerHeight;
+}
+
+.logoContainer {
+  display: flex;
+  align-items: center;
+  padding-left: 20px;
+}
+
+.logoLink {
+  line-height: 0;
+}
+
+.logo {
+  display: block;
+  width: auto;
+  height: 32px;
+  vertical-align: middle;
+}
+
+.sidebarCloseButton {
+  composes: button from '~Components/Link/IconButton.css';
+
+  margin-right: 15px;
+  color: var(--white);
+  text-align: center;
+}
+
 .sidebar {
   display: flex;
   flex-direction: column;

--- a/frontend/src/Components/Page/Sidebar/PageSidebar.css.d.ts
+++ b/frontend/src/Components/Page/Sidebar/PageSidebar.css.d.ts
@@ -1,7 +1,12 @@
 declare namespace PageSidebarCssNamespace {
   export interface IPageSidebarCss {
+    logo: string;
+    logoContainer: string;
+    logoLink: string;
     sidebar: string;
+    sidebarCloseButton: string;
     sidebarContainer: string;
+    sidebarHeader: string;
   }
 }
 

--- a/frontend/src/Components/Page/Sidebar/PageSidebar.tsx
+++ b/frontend/src/Components/Page/Sidebar/PageSidebar.tsx
@@ -1,4 +1,3 @@
-import classNames from 'classnames';
 import React, {
   useCallback,
   useEffect,
@@ -10,6 +9,8 @@ import { useLocation } from 'react-router';
 import QueueStatus from 'Activity/Queue/Status/QueueStatus';
 import { setIsSidebarVisible } from 'App/appStore';
 import { IconName } from 'Components/Icon';
+import IconButton from 'Components/Link/IconButton';
+import Link from 'Components/Link/Link';
 import OverlayScroller from 'Components/Scroller/OverlayScroller';
 import Scroller from 'Components/Scroller/Scroller';
 import usePrevious from 'Helpers/Hooks/usePrevious';
@@ -23,7 +24,6 @@ import Messages from './Messages/Messages';
 import PageSidebarItem from './PageSidebarItem';
 import styles from './PageSidebar.css';
 
-const HEADER_HEIGHT = Number.parseInt(dimensions.headerHeight, 10);
 const SIDEBAR_WIDTH = Number.parseInt(dimensions.sidebarWidth, 10);
 
 interface SidebarItem {
@@ -269,11 +269,6 @@ function PageSidebar({ isSidebarVisible, isSmallScreen }: PageSidebarProps) {
     transition: 'none',
     transform: isSidebarVisible ? 0 : SIDEBAR_WIDTH * -1,
   });
-  const [sidebarStyle, setSidebarStyle] = useState({
-    top: dimensions.headerHeight,
-    height: `${window.innerHeight - HEADER_HEIGHT}px`,
-  });
-
   const { data: generalSettings } = useGeneralSettings();
 
   if (generalSettings.whisparrMovieMetadataSource?.toLowerCase() === 'none') {
@@ -370,21 +365,9 @@ function PageSidebar({ isSidebarVisible, isSmallScreen }: PageSidebarProps) {
     setIsSidebarVisible({ isSidebarVisible: false });
   }, []);
 
-  const handleWindowScroll = useCallback(() => {
-    const windowScroll =
-      window.scrollY == null
-        ? document.documentElement.scrollTop
-        : window.scrollY;
-    const sidebarTop = Math.max(HEADER_HEIGHT - windowScroll, 0);
-    const sidebarHeight = window.innerHeight - sidebarTop;
-
-    if (isSmallScreen) {
-      setSidebarStyle({
-        top: `${sidebarTop}px`,
-        height: `${sidebarHeight}px`,
-      });
-    }
-  }, [isSmallScreen]);
+  const handleSidebarClosePress = useCallback(() => {
+    setIsSidebarVisible({ isSidebarVisible: false });
+  }, []);
 
   const handleTouchStart = useCallback(
     (event: TouchEvent) => {
@@ -470,7 +453,6 @@ function PageSidebar({ isSidebarVisible, isSmallScreen }: PageSidebarProps) {
   useEffect(() => {
     if (isSmallScreen) {
       window.addEventListener('click', handleWindowClick, { capture: true });
-      window.addEventListener('scroll', handleWindowScroll);
       window.addEventListener('touchstart', handleTouchStart);
       window.addEventListener('touchmove', handleTouchMove);
       window.addEventListener('touchend', handleTouchEnd);
@@ -479,7 +461,6 @@ function PageSidebar({ isSidebarVisible, isSmallScreen }: PageSidebarProps) {
 
     return () => {
       window.removeEventListener('click', handleWindowClick, { capture: true });
-      window.removeEventListener('scroll', handleWindowScroll);
       window.removeEventListener('touchstart', handleTouchStart);
       window.removeEventListener('touchmove', handleTouchMove);
       window.removeEventListener('touchend', handleTouchEnd);
@@ -488,7 +469,6 @@ function PageSidebar({ isSidebarVisible, isSmallScreen }: PageSidebarProps) {
   }, [
     isSmallScreen,
     handleWindowClick,
-    handleWindowScroll,
     handleTouchStart,
     handleTouchMove,
     handleTouchEnd,
@@ -527,13 +507,33 @@ function PageSidebar({ isSidebarVisible, isSmallScreen }: PageSidebarProps) {
   return (
     <div
       ref={sidebarRef}
-      className={classNames(styles.sidebarContainer)}
+      className={styles.sidebarContainer}
       style={containerStyle}
     >
+      {isSmallScreen ? (
+        <div className={styles.sidebarHeader}>
+          <div className={styles.logoContainer}>
+            <Link className={styles.logoLink} to="/">
+              <img
+                className={styles.logo}
+                src={`${window.Whisparr.urlBase}/Content/Images/logo.png`}
+                alt="Whisparr Logo"
+              />
+            </Link>
+          </div>
+
+          <IconButton
+            className={styles.sidebarCloseButton}
+            name={icons.CLOSE}
+            aria-label={translate('Close')}
+            onPress={handleSidebarClosePress}
+          />
+        </div>
+      ) : null}
+
       <ScrollerComponent
         className={styles.sidebar}
         scrollDirection={VERTICAL}
-        style={sidebarStyle}
         autoHide={true}
         autoScroll={false}
       >

--- a/src/NzbDrone.Core.Test/IndexerTests/IndexerBaseFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerTests/IndexerBaseFixture.cs
@@ -39,11 +39,23 @@ public class IndexerBaseFixture : CoreTest<IndexerBase<TestIndexerSettings>>
     }
 
     [TestCase("The.Movie.Name.2016.Multi.DTS.720p.BluRay.x264-RlsGrp")]
+    [TestCase("The.Movie.Name.2016.MultiLang.DTS.720p.BluRay.x264-RlsGrp")]
+    [TestCase("The.Movie.Name.2016.MULTILANGUAGE.DTS.720p.BluRay.x264-RlsGrp")]
+    [TestCase("The Movie Name (2016) [1080p H265 EAC3 MultiLang MultiSub][RlsGrp]")]
+    [TestCase("Studio.Name.16.01.15.Performer.Name.MULTILANG.1080p.MP4-RlsGrp")]
     public void should_parse_multi_language(string postTitle)
     {
         var result = _indexer.CleanupReleases(new ReleaseInfo[] { new () { Title = postTitle, Languages = new List<Language>() } });
         result.Single().Languages.Count.Should().Be(2);
         result.Single().Languages.Should().Contain(Language.German);
         result.Single().Languages.Should().Contain(Language.English);
+    }
+
+    [TestCase("The.Movie.Name.2016.MultiSub.DTS.720p.BluRay.x264-RlsGrp")]
+    [TestCase("Studio.Name.16.01.15.Performer.Name.Multiple.Angles.1080p.MP4-RlsGrp")]
+    public void should_not_parse_multi_language_when_multi_is_part_of_another_word(string postTitle)
+    {
+        var result = _indexer.CleanupReleases(new ReleaseInfo[] { new () { Title = postTitle, Languages = new List<Language>() } });
+        result.Single().Languages.Should().BeEmpty();
     }
 }

--- a/src/NzbDrone.Core/Indexers/IndexerBase.cs
+++ b/src/NzbDrone.Core/Indexers/IndexerBase.cs
@@ -19,7 +19,7 @@ namespace NzbDrone.Core.Indexers
     public abstract class IndexerBase<TSettings> : IIndexer
         where TSettings : IIndexerSettings, new()
     {
-        private static readonly Regex MultiRegex = new (@"\b(?<multi>multi)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private static readonly Regex MultiRegex = new (@"\b(?<multi>multilanguage|multilang|multi)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         protected readonly IIndexerStatusService _indexerStatusService;
         protected readonly IConfigService _configService;


### PR DESCRIPTION
#### Database Migration

NO

#### Description

First month of the Sonarr baseline sweep. Fifteen commits read diff by diff;
fourteen dispositioned, two applied.

**Applied (2, both adapted):**

- `4fb89252b` **Parse multilang and multilanguage as multi.** Titles saying
  `MultiLang` or `MULTILANGUAGE` never matched, so an indexer's configured
  multi-languages were not applied to them. Upstream's `MultiRegex` lives in
  `Parser.cs`; ours is in `Indexers/IndexerBase.cs` and uses `\b` boundaries
  where theirs uses an explicit delimiter class. Taking theirs verbatim would
  have *narrowed* ours, so only the alternation was widened.
- `b04b9f900` **Add button to close side bar.** Ours drives visibility through
  the zustand `appStore`, not a redux dispatch, and the logo is `logo.png` under
  `window.Whisparr`, so the sidebar header was rewritten rather than picked.
  Also drops the scroll-tracked positioning as upstream did, which takes the
  `PageHeader` `z-index` with it.

**Already here (6):** `a45b07762`, `ff5e73273`, `37dfad11f` — the react-query
migration our frontend ran *ahead* of Sonarr; `5568746ef` — upstream catching up
to the generic `FileExistsValidator<T>` we already use; `79b56c3ff` (we pin
System.Drawing.Common at 10.0.11); `52d7f6762`; `5a3f41263`.

**Not applicable (5):** `74ce13255`, `a1db23353`, `fce8e780c` add endpoints under
`src/Sonarr.Api.V5`, which has no counterpart here. `ca364724c` regenerates the
retired OpenAPI spec. `813d7df64` guards `episodes.First()` against an empty
list; our `NotificationService.GetMessage` takes a single `Movie` and no
collection.

**The mark advances to `37dfad11f`, one commit short of the end of the month.**
`550cf8d39` (timezone option) pulls in `moment-timezone`, a settings field and a
config key — a feature decision, being taken as its own PR rather than recorded
as settled here. Outstanding drops 486 → 472.

#### Todos

- [x] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)

The close button reuses the existing `Close` key; no new strings.

Five cases added to `IndexerBaseFixture` for the regex, **four of which failed
before the change**, plus two negative cases pinning that `MultiSub` and
`Multiple.Angles` still do not match. Core suite 4166 passed / 0 failed. `tsc`
at the three-`node_modules`-error baseline, `eslint` clean, `yarn build` green,
`--check` passes.

Sidebar verified live on 6969 at a 420px viewport: opens to `translateX(0)`,
close button returns it to `-210px`.
