### PR TITLE
Chore: Note the merge-commit rule for PRs carrying cherry-picks

### DIFF
--- a/.claude/skills/sync-upstream/SKILL.md
+++ b/.claude/skills/sync-upstream/SKILL.md
@@ -172,6 +172,21 @@ dispositioned.** A pointer that jumps ahead of unreviewed commits hides them —
 that is how a stray October pick concealed seven earlier commits until the
 report was rebuilt.
 
+**If any commit carries a cherry-pick trailer, say so in the handoff and ask for
+a merge commit rather than a squash.** This repo squashes by default, and its
+`squash_merge_commit_message` is `BLANK` — a squash keeps only the PR title and
+discards every commit body, trailers included. #586 squashed to the single line
+`Chore: Sync Sonarr 2025-10 (#586)` and both `sonarr/sonarr@` trailers left the
+history with it. `state.json` still held the dispositions, so the knowledge
+survived, but a trailer grep now reports those picks as absent — the same
+blindness that hid the Sonarr backlog to begin with.
+
+Check before handing over, and mention the count if it hits:
+
+```sh
+git log eros-develop..HEAD --format=%b | grep -c 'cherry picked from'
+```
+
 Open the PR against `eros-develop` (never `eros`) filling in
 `.github/PULL_REQUEST_TEMPLATE.md` — `gh pr create --body` silently bypasses it,
 so pass `--body-file` with the template filled in. Keep the body short: what was


### PR DESCRIPTION
#### Database Migration

NO

#### Description

Follow-up to #586. That PR carried two `(cherry picked from commit
sonarr/sonarr@...)` trailers; squashing it produced the single line
`Chore: Sync Sonarr 2025-10 (#586)` and both trailers left the history.

The cause is a repo setting, not the merge choice: `squash_merge_commit_message`
is `BLANK` and `squash_merge_commit_title` is `PR_TITLE`, so a squash keeps the
PR title and discards every commit body.

Nothing was actually lost — `state.json` records both as `adapt` with their
reasons, and that is the authoritative record. But the sync skill asks for the
trailer convention specifically because their absence is what hid the Sonarr
backlog, and a squash defeats it silently. So the skill now says to check for
trailers before handing a sync PR over and to ask for a merge commit when there
are any.

Documentation only — no code, and no change to the repo's default merge
strategy. Squash stays right for the PRs that carry no trailers, which is most
of them.

#### Todos

- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)

Neither applies — a skill document.

**This PR has no cherry-picks, so squash is fine.**
