### PR TITLE
Fix: Stop upstream-watch opening a duplicate tracking issue every run

### DIFF
--- a/.github/workflows/upstream-watch.yml
+++ b/.github/workflows/upstream-watch.yml
@@ -109,9 +109,12 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app.outputs.token }}
           # Issues are disabled on Whisparr-Eros and tracked on Whisparr for
-          # both repos, so every gh call in this step -- label and issue alike
-          # -- has to be aimed off this repo.
-          GH_REPO: Whisparr/Whisparr
+          # both repos, so every gh call in this step has to be aimed off this
+          # repo. Passed as an explicit --repo rather than GH_REPO: gh honours
+          # GH_REPO for `issue`, but `label create` ignored it and made the
+          # label against the checkout's remote instead, which is how the first
+          # two issues were opened unlabelled and then duplicated.
+          ISSUES_REPO: Whisparr/Whisparr
           TITLE: ${{ matrix.title }}
           OUTSTANDING: ${{ fromJSON(steps.attempt.outputs.summary).outstanding }}
         run: |
@@ -119,16 +122,22 @@ jobs:
 
           # Created here rather than by hand so a fresh clone of this repo can
           # run the workflow without setup.
-          gh label create upstream \
+          gh label create upstream --repo "$ISSUES_REPO" \
             --description 'Tracking issue for the upstream sync backlog' \
             --color 'ededed' --force
 
+          # Matched on the title, not the label. The label is applied for
+          # humans, but it is not what identifies the issue: if it ever fails to
+          # stick, a label-filtered lookup silently finds nothing and opens a
+          # second issue every run.
+          #
           # --state all, not open: the issue is closed whenever the backlog
           # empties, and the next upstream commit has to reopen that same issue
           # rather than start a second one.
-          FOUND=$(gh issue list --label upstream --state all --limit 50 \
+          FOUND=$(gh issue list --repo "$ISSUES_REPO" --state all --limit 100 \
+            --search "\"${TITLE}\" in:title" \
             --json number,title,state \
-            --jq "map(select(.title == \"${TITLE}\")) | .[0] // empty")
+            --jq "map(select(.title == \"${TITLE}\")) | sort_by(.number) | .[0] // empty")
 
           NUMBER=$(printf '%s' "$FOUND" | jq -r '.number // empty')
           STATE=$(printf '%s' "$FOUND" | jq -r '.state // empty')
@@ -146,14 +155,17 @@ jobs:
               exit 0
             fi
 
-            gh issue create --title "$TITLE" --label upstream --body-file issue.md
+            gh issue create --repo "$ISSUES_REPO" \
+              --title "$TITLE" --label upstream --body-file issue.md
             exit 0
           fi
 
-          gh issue edit "$NUMBER" --body-file issue.md
+          gh issue edit "$NUMBER" --repo "$ISSUES_REPO" --body-file issue.md
 
           if [ "$OUTSTANDING" -eq 0 ] && [ "$STATE" = "OPEN" ]; then
-            gh issue close "$NUMBER" --comment 'Backlog is empty. Reopened automatically when the next upstream commit lands.'
+            gh issue close "$NUMBER" --repo "$ISSUES_REPO" \
+              --comment 'Backlog is empty. Reopened automatically when the next upstream commit lands.'
           elif [ "$OUTSTANDING" -gt 0 ] && [ "$STATE" = "CLOSED" ]; then
-            gh issue reopen "$NUMBER" --comment "${OUTSTANDING} new upstream commit(s) to disposition."
+            gh issue reopen "$NUMBER" --repo "$ISSUES_REPO" \
+              --comment "${OUTSTANDING} new upstream commit(s) to disposition."
           fi


### PR DESCRIPTION
#### Database Migration

NO

#### Description

`upstream-watch` opened a second tracking issue instead of updating the first —
#1238 and #1239 are the same Radarr backlog.

**Root cause:** `gh` honours `GH_REPO` for `issue`, but **`label create` ignored
it** and created the label against the checkout's remote:

| | |
| --- | --- |
| `upstream` label in `Whisparr/Whisparr` | **404** |
| `upstream` label in `Whisparr-Eros` | exists, with this workflow's exact description and colour |

So the label was made on the repo where issues are *disabled*, and does not exist
on the repo where the issues actually live. `gh issue create --label upstream`
then opened the issue without the label, and the lookup — which filtered on that
label — found nothing and opened a fresh issue on every run. The step exited 0
throughout, which is why nothing surfaced until the duplicate appeared.

**Two changes:**

1. **Every `gh` call passes `--repo "$ISSUES_REPO"` explicitly** rather than
   relying on `GH_REPO` being honoured uniformly. This is what I should have done
   in #581 — I chose the env var to avoid "six flags to keep in sync", and the
   inconsistent honouring is exactly the cost of that.
2. **The lookup no longer depends on the label.** The label is applied for humans,
   but the *title* identifies the issue: a label-filtered lookup fails silently
   and duplicates, which is the failure above. It now searches `in:title` and
   takes the lowest issue number, so an existing issue always wins over anything
   opened since. Limit raised to 100 with a search term, since the tracking issue
   lives in a repo with several hundred issues.

Verified against the live repo — the new lookup returns `{"number":1238,...}`
where the old one returned `[]`.

#### Todos

- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)

Neither applies — workflow only. YAML parses.

**Not a bug, for the record:** the missing *Sonarr* tracking issue is correct
behaviour. That run checked out `eros-develop` before #583 merged, so the Sonarr
backlog was still 0 outstanding. The run since is still in progress — it is
working a 486-commit window — and will open it.

**No cherry-picks in this PR, so squash is fine.**
