### PR TITLE
Chore: Prefix the tracking issue titles with [v3]

### DIFF
--- a/.github/workflows/upstream-watch.yml
+++ b/.github/workflows/upstream-watch.yml
@@ -22,11 +22,16 @@ jobs:
       # should not hide the state of the other.
       fail-fast: false
       matrix:
+        # Titles carry a [v3] prefix: the tracking issues live on
+        # Whisparr/Whisparr, which serves both the v2 line and this one, so an
+        # unprefixed 'Upstream sync: ...' reads as ambiguous there. The prefix
+        # is also part of the lookup key -- changing it orphans the existing
+        # issue and opens a new one, so rename the issue with it.
         include:
           - upstream: radarr
-            title: 'Upstream sync: Radarr develop'
+            title: '[v3] Upstream sync: Radarr develop'
           - upstream: sonarr
-            title: 'Upstream sync: Sonarr v5-develop'
+            title: '[v3] Upstream sync: Sonarr v5-develop'
 
     steps:
       # github.token cannot be used to open the PR: GitHub does not start

--- a/scripts/upstream-sync.mjs
+++ b/scripts/upstream-sync.mjs
@@ -435,7 +435,7 @@ function renderAttempt(result) {
 
   if (conflicted.length > 0 || gated.length > 0) {
     lines.push(
-      `Left out and tracked on the \`Upstream sync: ${upstream.repo.split('/')[1]} ${upstream.branch}\` issue`,
+      `Left out and tracked on the \`[v3] Upstream sync: ${upstream.repo.split('/')[1]} ${upstream.branch}\` issue`,
       'on Whisparr/Whisparr, where issues for both repos live:',
       `${conflicted.length} conflicted, ${gated.length} gated.`,
       ''


### PR DESCRIPTION
#### Database Migration

NO

#### Description

The tracking issues live on `Whisparr/Whisparr`, which serves both the v2 line
and this one, so a bare `Upstream sync: Radarr develop` there does not say which
app it belongs to. Titles become:

- `[v3] Upstream sync: Radarr develop`
- `[v3] Upstream sync: Sonarr v5-develop`

Two places build that string: the workflow matrix, and `scripts/upstream-sync.mjs`,
where the draft PR body names the issue the leftovers were tracked on.

#### ⚠️ Needs an issue rename before the next run

#589 made the **title** the lookup key, replacing the label that was silently
failing. So changing the title orphans the existing issues. Merging this and
re-running *without* renaming them opens a third Radarr issue — exactly the
failure #589 just fixed.

Order that works:

1. Merge this
2. Rename `#1238` → `[v3] Upstream sync: Radarr develop`, and the Sonarr issue
   the in-flight run is opening → `[v3] Upstream sync: Sonarr v5-develop`
3. Re-run

`#1239` is the duplicate from before the fix and can be closed at the same time;
leaving it open is harmless either way, since the lookup takes the lowest
matching issue number and it will no longer match the new title.

#### Todos

- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)

Neither applies — workflow and one string in a tooling script. YAML parses,
`node --check` passes.

**No cherry-picks in this PR, so squash is fine.**
