### PR TITLE
Fix: Gate upstream commits that touch .github/workflows/

### DIFF
--- a/scripts/upstream-sync.mjs
+++ b/scripts/upstream-sync.mjs
@@ -318,6 +318,24 @@ function gateFor(name, commit) {
     };
   }
 
+  // A GitHub App token cannot push a commit that touches .github/workflows/
+  // without the `workflows` permission, so one of these in the batch fails the
+  // push and takes every other pick with it. Granting the app that permission
+  // is the wrong trade: it would let an unattended cherry-picker rewrite our
+  // CI. These are held for a human instead -- which is what upstream CI
+  // deserves anyway, being mostly their labels, their release automation and
+  // their bots. We have declined a run of them already, `close_invalid_issues`
+  // among them.
+  if (commit.files.some((f) => f.startsWith('.github/workflows/'))) {
+    return {
+      gate: 'workflows',
+      reason:
+        'Touches .github/workflows/. The app token cannot push workflow changes, and upstream CI ' +
+        'is tuned to their labels, bots and release process, so each one needs reading rather than ' +
+        'replaying.',
+    };
+  }
+
   if (commit.files.some((f) => f.startsWith('src/NzbDrone.Core/Parser/'))) {
     return {
       gate: 'parser',


### PR DESCRIPTION
#### Database Migration

NO

#### Description

The Sonarr attempt failed its push outright, taking every pick with it:

```
! [remote rejected] HEAD -> upstream-auto/sonarr (refusing to allow a GitHub App
to create or update workflow `.github/workflows/close_invalid_issues.yml`
without `workflows` permission)
```

A GitHub App token cannot push a commit touching `.github/workflows/` without
that permission. One such commit in the batch fails the push and takes all
300-odd others down with it — the run had already spent 8½ minutes cherry-picking
by that point.

**Granting the app `workflows` is the wrong trade.** It would let an unattended
cherry-picker rewrite our CI — a lot of reach for a bot whose job is replaying
commits nobody has read yet. Gating is both safer and cheaper.

It also matches what we already decide by hand. `close_invalid_issues.yml` is
the very file Radarr `331ce4579` added, which we declined deliberately — "we are
not seeing template compliance problems, so the workflow would only add a way to
close reporters' issues automatically." Upstream CI is largely their labels,
their autopilot and their release automation.

Gated, not auto-skipped: they land in the gated table with their reason and
still need a disposition, same as `parser` and `localization`. Nothing is
decided on anyone's behalf.

Effect on the current Sonarr backlog (471 outstanding):

| gate | commits |
| --- | ---: |
| *ungated (cherry-pick candidates)* | 321 |
| localization | 44 |
| weblate | 39 |
| parser | 27 |
| api-docs | 24 |
| **workflows** | **16** |

#### Todos

- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)

Neither applies — tooling script. Gates only affect `--attempt`, so
`UPSTREAM_SYNC.md` is unchanged and `--check` is unaffected. `node --check`
passes, and the gate was verified against the real backlog range.

**No cherry-picks in this PR, so squash is fine.**
