### PR TITLE
Chore: Note that Sonarr's v5 API commits are a no-op here

### DIFF
--- a/.claude/skills/sync-upstream/SKILL.md
+++ b/.claude/skills/sync-upstream/SKILL.md
@@ -112,6 +112,29 @@ share.
 
 ## 4. Classify what survives
 
+Before deciding anything, check the file list for `src/Sonarr.Api.V5/`.
+
+Sonarr is building a v5 API surface alongside v3; we have only
+`src/Whisparr.Api.V3/`. Those commits **add files under a directory we do not
+have**, so they cherry-pick with no conflict, no csproj references them, and the
+build stays green. Clean merge plus passing build reads as success, and the
+result is dead files in a tree nobody compiles. The gates do not catch this —
+they look for trouble, and this looks fine.
+
+Two shapes, and the second is the trap:
+
+- **V5-only** — every file under `src/Sonarr.Api.V5/`. Straight `skip`: no
+  counterpart project here.
+- **Mixed** — V5 files *plus* real changes elsewhere. **Do not blanket-skip
+  these.** Take the non-V5 half and drop the V5 files. They include work we
+  actively want: `8f95849e9 Use react-query for interactive search` and
+  `dd84bcd91 Bump Sentry to 5.16.2` both touch V5 incidentally.
+
+It is a quarter of the Sonarr backlog — 120 of 471 outstanding, 68 V5-only and
+52 mixed — so this is not a rare case. Worst in 2025-11 and 2025-12.
+
+
+
 One of four, and **every one needs a reason** — `--check` rejects a bare or
 stub reason:
 


### PR DESCRIPTION
#### Database Migration

NO

#### Description

Sonarr is building a v5 API surface alongside v3; we have only
`src/Whisparr.Api.V3/`. Commits touching `src/Sonarr.Api.V5/` **add files under
a directory we do not have** — so they cherry-pick with no conflict, no csproj
references them, and the build stays green.

That is what makes them worth documenting: a clean merge and a passing build
read as success, while dead files accumulate in a tree nobody compiles. The
gates do not catch it, because gates look for trouble and this looks fine.

It is a quarter of the Sonarr backlog — **120 of 471 outstanding**:

| month | V5 commits |
| --- | ---: |
| 2025-11 | 25 |
| 2025-12 | 23 |
| 2026-05 | 18 |
| 2026-03 | 14 |
| 2026-01 | 12 |
| 2026-04 | 11 |
| 2026-06 / 2026-07 | 6 each |
| 2026-02 | 5 |

**Why this is a reading rule and not a gate:** only 68 are V5-only. The other 52
touch V5 *alongside* changes we want — `8f95849e9 Use react-query for
interactive search` (the Sonarr frontend lineage we deliberately follow) and
`dd84bcd91 Bump Sentry to 5.16.2` among them. A gate on the path would hold all
52 back, so it goes in the classify step instead: check the file list, skip the
V5-only ones, take the non-V5 half of the rest.

Documentation only — the note lands at the top of §4, where the disposition is
actually made.

#### Todos

- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)

Neither applies — a skill document.

**No cherry-picks in this PR, so squash is fine.**
