### PR TITLE
New: Custom Filters for Wanted Missing and Cutoff Unmet

### DIFF
--- a/frontend/src/Utilities/Fetch/getQueryString.ts
+++ b/frontend/src/Utilities/Fetch/getQueryString.ts
@@ -30,7 +30,14 @@ const getQueryString = (queryParams?: QueryParams) => {
       if (Array.isArray(value)) {
         if (typeof value[0] === 'object') {
           (value as PropertyFilter[]).forEach((filter) => {
-            acc.append(filter.key, String(filter.value));
+            // A filter whose value is a list (tags, quality profiles, movie ids)
+            // has to become one query parameter per entry, so the controller
+            // binds it as a List<int> rather than a single comma-joined string.
+            if (Array.isArray(filter.value)) {
+              filter.value.forEach((v) => acc.append(filter.key, String(v)));
+            } else {
+              acc.append(filter.key, String(filter.value));
+            }
           });
         } else {
           value.forEach((item) => {

--- a/frontend/src/Wanted/CutoffUnmet/CutoffUnmet.tsx
+++ b/frontend/src/Wanted/CutoffUnmet/CutoffUnmet.tsx
@@ -16,6 +16,7 @@ import TableBody from 'Components/Table/TableBody';
 import TableOptionsModalWrapper from 'Components/Table/TableOptions/TableOptionsModalWrapper';
 import TablePager from 'Components/Table/TablePager';
 import { Filter as AppStateFilter } from 'Filters/Filter';
+import { useCustomFiltersList } from 'Filters/useCustomFilters';
 import useSelectState from 'Helpers/Hooks/useSelectState';
 import { align, icons, kinds } from 'Helpers/Props';
 import { SortDirection } from 'Helpers/Props/sortDirections';
@@ -25,7 +26,9 @@ import { TableOptionsChangePayload } from 'typings/Table';
 import translate from 'Utilities/String/translate';
 import getSelectedIds from 'Utilities/Table/getSelectedIds';
 import getMonitoredValue from 'Wanted/getMonitoredValue';
+import toWantedSearchCommandBody from 'Wanted/toWantedSearchCommandBody';
 import useToggleMoviesMonitored from 'Wanted/useToggleMoviesMonitored';
+import CutoffUnmetFilterModal from './CutoffUnmetFilterModal';
 import {
   setCutoffUnmetOption,
   setCutoffUnmetOptions,
@@ -37,6 +40,7 @@ import useCutoffUnmet, { FILTERS } from './useCutoffUnmet';
 
 function CutoffUnmet() {
   const executeCommand = useExecuteCommand();
+  const customFilters = useCustomFiltersList('wanted.cutoffUnmet');
 
   const { columns, pageSize, selectedFilterKey, sortKey, sortDirection } =
     useCutoffUnmetOptions();
@@ -119,14 +123,17 @@ function CutoffUnmet() {
 
   const handleSearchAllCutoffUnmetConfirmed = useCallback(() => {
     executeCommand({
-      name: commandNames.CUTOFF_UNMET_MOVIES_SEARCH,
+      ...toWantedSearchCommandBody(
+        commandNames.CUTOFF_UNMET_MOVIES_SEARCH,
+        filters
+      ),
       commandFinished: () => {
         refetch();
       },
     });
 
     setIsConfirmSearchAllModalOpen(false);
-  }, [refetch, executeCommand]);
+  }, [filters, refetch, executeCommand]);
 
   const handleToggleSelectedPress = useCallback(() => {
     toggleMoviesMonitored({
@@ -226,7 +233,8 @@ function CutoffUnmet() {
             alignMenu={align.RIGHT}
             selectedFilterKey={selectedFilterKey}
             filters={FILTERS as unknown as AppStateFilter[]}
-            customFilters={[]}
+            customFilters={customFilters}
+            filterModalConnectorComponent={CutoffUnmetFilterModal}
             onFilterSelect={handleFilterSelect}
           />
         </PageToolbarSection>

--- a/frontend/src/Wanted/CutoffUnmet/CutoffUnmetFilterModal.tsx
+++ b/frontend/src/Wanted/CutoffUnmet/CutoffUnmetFilterModal.tsx
@@ -1,0 +1,34 @@
+import React, { useCallback } from 'react';
+import FilterModal, {
+  FilterModalPassthroughProps,
+} from 'Components/Filter/FilterModal';
+import { CUTOFF_UNMET_FILTER_BUILDER_PROPS } from 'Wanted/wantedFilterBuilderProps';
+import { setCutoffUnmetOption } from './cutoffUnmetOptionsStore';
+import useCutoffUnmet from './useCutoffUnmet';
+
+type CutoffUnmetFilterModalProps = FilterModalPassthroughProps;
+
+export default function CutoffUnmetFilterModal(
+  props: Readonly<CutoffUnmetFilterModalProps>
+) {
+  // Feeds the builder's value suggestions off the page already on screen, the
+  // same way MovieIndexFilterModal does.
+  const { records } = useCutoffUnmet();
+
+  const dispatchSetFilter = useCallback(
+    ({ selectedFilterKey }: { selectedFilterKey: string | number }) => {
+      setCutoffUnmetOption('selectedFilterKey', selectedFilterKey);
+    },
+    []
+  );
+
+  return (
+    <FilterModal
+      {...props}
+      sectionItems={records}
+      filterBuilderProps={CUTOFF_UNMET_FILTER_BUILDER_PROPS}
+      customFilterType="wanted.cutoffUnmet"
+      dispatchSetFilter={dispatchSetFilter}
+    />
+  );
+}

--- a/frontend/src/Wanted/CutoffUnmet/useCutoffUnmet.ts
+++ b/frontend/src/Wanted/CutoffUnmet/useCutoffUnmet.ts
@@ -1,6 +1,7 @@
 import { keepPreviousData } from '@tanstack/react-query';
 import { useMemo } from 'react';
 import { Filter } from 'Filters/Filter';
+import { useCustomFiltersList } from 'Filters/useCustomFilters';
 import usePage from 'Helpers/Hooks/usePage';
 import usePagedApiQuery from 'Helpers/Hooks/usePagedApiQuery';
 import { filterTypes } from 'Helpers/Props';
@@ -39,11 +40,11 @@ const useCutoffUnmet = () => {
   const { pageSize, selectedFilterKey, sortKey, sortDirection } =
     useCutoffUnmetOptions();
 
-  // Neither wanted page offers custom filters, so there is nothing to merge
-  // into the two built-ins.
+  const customFilters = useCustomFiltersList('wanted.cutoffUnmet');
+
   const filters = useMemo(() => {
-    return findSelectedFilters(selectedFilterKey, FILTERS, []);
-  }, [selectedFilterKey]);
+    return findSelectedFilters(selectedFilterKey, FILTERS, customFilters);
+  }, [selectedFilterKey, customFilters]);
 
   const query = usePagedApiQuery<Movie>({
     path: '/wanted/cutoff',

--- a/frontend/src/Wanted/Missing/Missing.tsx
+++ b/frontend/src/Wanted/Missing/Missing.tsx
@@ -16,6 +16,7 @@ import TableBody from 'Components/Table/TableBody';
 import TableOptionsModalWrapper from 'Components/Table/TableOptions/TableOptionsModalWrapper';
 import TablePager from 'Components/Table/TablePager';
 import { Filter as AppStateFilter } from 'Filters/Filter';
+import { useCustomFiltersList } from 'Filters/useCustomFilters';
 import useSelectState from 'Helpers/Hooks/useSelectState';
 import { align, icons, kinds } from 'Helpers/Props';
 import { SortDirection } from 'Helpers/Props/sortDirections';
@@ -26,7 +27,9 @@ import { TableOptionsChangePayload } from 'typings/Table';
 import translate from 'Utilities/String/translate';
 import getSelectedIds from 'Utilities/Table/getSelectedIds';
 import getMonitoredValue from 'Wanted/getMonitoredValue';
+import toWantedSearchCommandBody from 'Wanted/toWantedSearchCommandBody';
 import useToggleMoviesMonitored from 'Wanted/useToggleMoviesMonitored';
+import MissingFilterModal from './MissingFilterModal';
 import {
   setMissingOption,
   setMissingOptions,
@@ -38,6 +41,7 @@ import useMissing, { FILTERS } from './useMissing';
 
 function Missing() {
   const executeCommand = useExecuteCommand();
+  const customFilters = useCustomFiltersList('wanted.missing');
 
   const { columns, pageSize, selectedFilterKey, sortKey, sortDirection } =
     useMissingOptions();
@@ -123,14 +127,14 @@ function Missing() {
 
   const handleSearchAllMissingConfirmed = useCallback(() => {
     executeCommand({
-      name: commandNames.MISSING_MOVIES_SEARCH,
+      ...toWantedSearchCommandBody(commandNames.MISSING_MOVIES_SEARCH, filters),
       commandFinished: () => {
         refetch();
       },
     });
 
     setIsConfirmSearchAllModalOpen(false);
-  }, [refetch, executeCommand]);
+  }, [filters, refetch, executeCommand]);
 
   const handleToggleSelectedPress = useCallback(() => {
     toggleMoviesMonitored({
@@ -246,7 +250,8 @@ function Missing() {
             alignMenu={align.RIGHT}
             selectedFilterKey={selectedFilterKey}
             filters={FILTERS as unknown as AppStateFilter[]}
-            customFilters={[]}
+            customFilters={customFilters}
+            filterModalConnectorComponent={MissingFilterModal}
             onFilterSelect={handleFilterSelect}
           />
         </PageToolbarSection>

--- a/frontend/src/Wanted/Missing/MissingFilterModal.tsx
+++ b/frontend/src/Wanted/Missing/MissingFilterModal.tsx
@@ -1,0 +1,34 @@
+import React, { useCallback } from 'react';
+import FilterModal, {
+  FilterModalPassthroughProps,
+} from 'Components/Filter/FilterModal';
+import { MISSING_FILTER_BUILDER_PROPS } from 'Wanted/wantedFilterBuilderProps';
+import { setMissingOption } from './missingOptionsStore';
+import useMissing from './useMissing';
+
+type MissingFilterModalProps = FilterModalPassthroughProps;
+
+export default function MissingFilterModal(
+  props: Readonly<MissingFilterModalProps>
+) {
+  // Feeds the builder's value suggestions off the page already on screen, the
+  // same way MovieIndexFilterModal does.
+  const { records } = useMissing();
+
+  const dispatchSetFilter = useCallback(
+    ({ selectedFilterKey }: { selectedFilterKey: string | number }) => {
+      setMissingOption('selectedFilterKey', selectedFilterKey);
+    },
+    []
+  );
+
+  return (
+    <FilterModal
+      {...props}
+      sectionItems={records}
+      filterBuilderProps={MISSING_FILTER_BUILDER_PROPS}
+      customFilterType="wanted.missing"
+      dispatchSetFilter={dispatchSetFilter}
+    />
+  );
+}

--- a/frontend/src/Wanted/Missing/useMissing.ts
+++ b/frontend/src/Wanted/Missing/useMissing.ts
@@ -1,6 +1,7 @@
 import { keepPreviousData } from '@tanstack/react-query';
 import { useMemo } from 'react';
 import { Filter } from 'Filters/Filter';
+import { useCustomFiltersList } from 'Filters/useCustomFilters';
 import usePage from 'Helpers/Hooks/usePage';
 import usePagedApiQuery from 'Helpers/Hooks/usePagedApiQuery';
 import { filterTypes } from 'Helpers/Props';
@@ -39,11 +40,11 @@ const useMissing = () => {
   const { pageSize, selectedFilterKey, sortKey, sortDirection } =
     useMissingOptions();
 
-  // Neither wanted page offers custom filters, so there is nothing to merge
-  // into the two built-ins.
+  const customFilters = useCustomFiltersList('wanted.missing');
+
   const filters = useMemo(() => {
-    return findSelectedFilters(selectedFilterKey, FILTERS, []);
-  }, [selectedFilterKey]);
+    return findSelectedFilters(selectedFilterKey, FILTERS, customFilters);
+  }, [selectedFilterKey, customFilters]);
 
   const query = usePagedApiQuery<Movie>({
     path: '/wanted/missing',

--- a/frontend/src/Wanted/toWantedSearchCommandBody.ts
+++ b/frontend/src/Wanted/toWantedSearchCommandBody.ts
@@ -1,0 +1,41 @@
+import { PropertyFilter } from 'Filters/Filter';
+
+export interface WantedSearchCommandBody {
+  name: string;
+  movieIds?: number[];
+  qualityProfileIds?: number[];
+  movieTags?: number[];
+  quality?: number[];
+}
+
+const FILTER_KEYS = [
+  'movieIds',
+  'qualityProfileIds',
+  'movieTags',
+  'quality',
+] as const;
+
+// "Search All" runs against the same filter the page is showing, so the active
+// filter has to travel to the command as well as to the paged query.
+const toWantedSearchCommandBody = (
+  name: string,
+  filters: PropertyFilter[]
+): WantedSearchCommandBody => {
+  const body: WantedSearchCommandBody = { name };
+
+  filters.forEach((filter) => {
+    const key = FILTER_KEYS.find((k) => k === filter.key);
+
+    if (!key) {
+      return;
+    }
+
+    body[key] = (
+      Array.isArray(filter.value) ? filter.value : [filter.value]
+    ) as number[];
+  });
+
+  return body;
+};
+
+export default toWantedSearchCommandBody;

--- a/frontend/src/Wanted/wantedFilterBuilderProps.ts
+++ b/frontend/src/Wanted/wantedFilterBuilderProps.ts
@@ -1,0 +1,49 @@
+import { FilterBuilderProp } from 'Filters/Filter';
+import { filterBuilderTypes, filterBuilderValueTypes } from 'Helpers/Props';
+import Movie from 'Movie/Movie';
+import translate from 'Utilities/String/translate';
+
+// Shared by both wanted pages. The names are the query parameters the V3
+// wanted controllers bind, not Movie properties: filtering happens in SQL
+// rather than client-side, so `movieTags` is the tag filter even though the
+// property on Movie is `tags`.
+const WANTED_FILTER_BUILDER_PROPS: FilterBuilderProp<Movie>[] = [
+  {
+    name: 'monitored',
+    label: () => translate('Monitored'),
+    type: filterBuilderTypes.EXACT,
+    valueType: filterBuilderValueTypes.BOOL,
+  },
+  {
+    name: 'movieIds',
+    label: () => translate('Movies'),
+    type: filterBuilderTypes.EXACT,
+    valueType: filterBuilderValueTypes.MOVIE,
+  },
+  {
+    name: 'qualityProfileIds',
+    label: () => translate('QualityProfile'),
+    type: filterBuilderTypes.EXACT,
+    valueType: filterBuilderValueTypes.QUALITY_PROFILE,
+  },
+  {
+    name: 'movieTags',
+    label: () => translate('Tags'),
+    type: filterBuilderTypes.ARRAY,
+    valueType: filterBuilderValueTypes.TAG,
+  },
+];
+
+export const MISSING_FILTER_BUILDER_PROPS = WANTED_FILTER_BUILDER_PROPS;
+
+// Only the cutoff page filters by the quality already on disk; a missing movie
+// has no file to match against.
+export const CUTOFF_UNMET_FILTER_BUILDER_PROPS: FilterBuilderProp<Movie>[] = [
+  ...WANTED_FILTER_BUILDER_PROPS,
+  {
+    name: 'quality',
+    label: () => translate('Quality'),
+    type: filterBuilderTypes.EXACT,
+    valueType: filterBuilderValueTypes.QUALITY,
+  },
+];

--- a/src/NzbDrone.Core.Test/MovieTests/MovieRepositoryTests/MovieRepositoryFixture.cs
+++ b/src/NzbDrone.Core.Test/MovieTests/MovieRepositoryTests/MovieRepositoryFixture.cs
@@ -21,10 +21,12 @@ namespace NzbDrone.Core.Test.MovieTests.MovieRepositoryTests
     public class MovieRepositoryFixture : DbTest<MovieRepository, Movie>
     {
         private IQualityProfileRepository _profileRepository;
+        private int _metadataSequence;
 
         [SetUp]
         public void Setup()
         {
+            _metadataSequence = 0;
             _profileRepository = Mocker.Resolve<QualityProfileRepository>();
             Mocker.SetConstant<IQualityProfileRepository>(_profileRepository);
 
@@ -62,11 +64,12 @@ namespace NzbDrone.Core.Test.MovieTests.MovieRepositoryTests
         }
 
         // PagedBuilder INNER JOINs MovieMetadata, so a paged movie needs a metadata row to match.
-        private void GivenPagedMovie(int qualityProfileId, int movieFileId, int year = 2020)
+        private Movie GivenPagedMovie(int qualityProfileId, int movieFileId, int year = 2020, HashSet<int> tags = null)
         {
             var metadata = Db.Insert(Builder<MovieMetadata>.CreateNew()
                 .With(m => m.Id = 0)
                 .With(m => m.Year = year)
+                .With(m => m.ForeignId = $"metadata-{++_metadataSequence}")
                 .BuildNew());
 
             var movie = Builder<Movie>.CreateNew()
@@ -74,9 +77,39 @@ namespace NzbDrone.Core.Test.MovieTests.MovieRepositoryTests
                 .With(m => m.MovieMetadataId = metadata.Id)
                 .With(m => m.QualityProfileId = qualityProfileId)
                 .With(m => m.MovieFileId = movieFileId)
+                .With(m => m.Tags = tags ?? new HashSet<int>())
                 .BuildNew();
 
-            Subject.Insert(movie);
+            return Subject.Insert(movie);
+        }
+
+        // Builder() joins MovieFiles on MovieFile.MovieId, while the paging spec filters on
+        // Movie.MovieFileId, so a movie with a file has to have both sides pointing at each other.
+        private Movie GivenPagedMovieWithFile(int qualityProfileId, Quality quality, HashSet<int> tags = null)
+        {
+            var movie = GivenPagedMovie(qualityProfileId, movieFileId: 0, tags: tags);
+
+            var movieFile = Db.Insert(Builder<MovieFile>.CreateNew()
+                .With(f => f.Id = 0)
+                .With(f => f.MovieId = movie.Id)
+                .With(f => f.Quality = new QualityModel(quality))
+                .With(f => f.Languages = new List<Language> { Language.English })
+                .With(f => f.MediaInfo = new MediaInfoModel { RawStreamData = "{ \"streams\": [] }", VideoFormat = "h264" })
+                .BuildNew());
+
+            movie.MovieFileId = movieFile.Id;
+            Subject.Update(movie);
+
+            return movie;
+        }
+
+        // Cutoff is Bluray1080p, so anything below it is unmet.
+        private List<QualitiesBelowCutoff> GivenQualitiesBelowCutoff(QualityProfile profile)
+        {
+            return new List<QualitiesBelowCutoff>
+            {
+                new QualitiesBelowCutoff(profile.Id, new[] { Quality.HDTV720p.Id, Quality.DVD.Id })
+            };
         }
 
         private static PagingSpec<Movie> PagingSpec() => new PagingSpec<Movie>
@@ -181,6 +214,86 @@ namespace NzbDrone.Core.Test.MovieTests.MovieRepositoryTests
 
             spec.Records.Should().HaveCount(1);
             spec.TotalRecords.Should().Be(1);
+        }
+
+        [Test]
+        public void should_filter_movies_without_files_by_tag()
+        {
+            var profile = GivenProfile();
+            var tagged = GivenPagedMovie(profile.Id, movieFileId: 0, tags: new HashSet<int> { 1, 2 });
+            GivenPagedMovie(profile.Id, movieFileId: 0, tags: new HashSet<int> { 3 });
+            GivenPagedMovie(profile.Id, movieFileId: 0);
+
+            var spec = PagingSpec();
+            Subject.MoviesWithoutFiles(spec, new HashSet<int> { 2 });
+
+            spec.Records.Should().ContainSingle().Which.Id.Should().Be(tagged.Id);
+            spec.TotalRecords.Should().Be(1);
+        }
+
+        [Test]
+        public void should_match_a_movie_carrying_any_of_the_filtered_tags()
+        {
+            var profile = GivenProfile();
+            GivenPagedMovie(profile.Id, movieFileId: 0, tags: new HashSet<int> { 7 });
+            GivenPagedMovie(profile.Id, movieFileId: 0, tags: new HashSet<int> { 8 });
+
+            var spec = PagingSpec();
+            Subject.MoviesWithoutFiles(spec, new HashSet<int> { 7, 8 });
+
+            spec.Records.Should().HaveCount(2);
+        }
+
+        [Test]
+        public void should_not_filter_movies_without_files_when_no_tags_given()
+        {
+            var profile = GivenProfile();
+            GivenPagedMovie(profile.Id, movieFileId: 0, tags: new HashSet<int> { 1 });
+            GivenPagedMovie(profile.Id, movieFileId: 0);
+
+            var spec = PagingSpec();
+            Subject.MoviesWithoutFiles(spec, new HashSet<int>());
+
+            spec.Records.Should().HaveCount(2);
+        }
+
+        [Test]
+        public void should_filter_cutoff_unmet_by_tag()
+        {
+            var profile = GivenProfile();
+            var tagged = GivenPagedMovieWithFile(profile.Id, Quality.HDTV720p, tags: new HashSet<int> { 4 });
+            GivenPagedMovieWithFile(profile.Id, Quality.HDTV720p, tags: new HashSet<int> { 5 });
+
+            var spec = PagingSpec();
+            Subject.MoviesWhereCutoffUnmet(spec, GivenQualitiesBelowCutoff(profile), new HashSet<int> { 4 });
+
+            spec.Records.Should().ContainSingle().Which.Id.Should().Be(tagged.Id);
+        }
+
+        [Test]
+        public void should_filter_cutoff_unmet_by_quality()
+        {
+            var profile = GivenProfile();
+            var dvdMovie = GivenPagedMovieWithFile(profile.Id, Quality.DVD);
+            GivenPagedMovieWithFile(profile.Id, Quality.HDTV720p);
+
+            var spec = PagingSpec();
+            Subject.MoviesWhereCutoffUnmet(spec, GivenQualitiesBelowCutoff(profile), quality: new List<int> { Quality.DVD.Id });
+
+            spec.Records.Should().ContainSingle().Which.Id.Should().Be(dvdMovie.Id);
+        }
+
+        [Test]
+        public void should_not_filter_cutoff_unmet_when_no_tags_or_qualities_given()
+        {
+            var profile = GivenProfile();
+            GivenPagedMovieWithFile(profile.Id, Quality.DVD, tags: new HashSet<int> { 1 });
+            GivenPagedMovieWithFile(profile.Id, Quality.HDTV720p);
+
+            var spec = PagingSpec();
+            Subject.MoviesWhereCutoffUnmet(spec, GivenQualitiesBelowCutoff(profile));
+
+            spec.Records.Should().HaveCount(2);
         }
     }
 }

--- a/src/NzbDrone.Core/IndexerSearch/CutoffUnmetMoviesSearchCommand.cs
+++ b/src/NzbDrone.Core/IndexerSearch/CutoffUnmetMoviesSearchCommand.cs
@@ -1,4 +1,5 @@
-﻿using NzbDrone.Core.Messaging.Commands;
+using System.Collections.Generic;
+using NzbDrone.Core.Messaging.Commands;
 
 namespace NzbDrone.Core.IndexerSearch
 {
@@ -7,5 +8,9 @@ namespace NzbDrone.Core.IndexerSearch
         public override bool SendUpdatesToClient => true;
         public string FilterKey { get; set; }
         public string FilterValue { get; set; }
+        public List<int> MovieIds { get; set; } = new List<int>();
+        public List<int> QualityProfileIds { get; set; } = new List<int>();
+        public HashSet<int> MovieTags { get; set; } = new HashSet<int>();
+        public List<int> Quality { get; set; } = new List<int>();
     }
 }

--- a/src/NzbDrone.Core/IndexerSearch/MissingMoviesSearchCommand.cs
+++ b/src/NzbDrone.Core/IndexerSearch/MissingMoviesSearchCommand.cs
@@ -1,4 +1,5 @@
-﻿using NzbDrone.Core.Messaging.Commands;
+using System.Collections.Generic;
+using NzbDrone.Core.Messaging.Commands;
 
 namespace NzbDrone.Core.IndexerSearch
 {
@@ -7,5 +8,8 @@ namespace NzbDrone.Core.IndexerSearch
         public override bool SendUpdatesToClient => true;
         public string FilterKey { get; set; }
         public string FilterValue { get; set; }
+        public List<int> MovieIds { get; set; } = new List<int>();
+        public List<int> QualityProfileIds { get; set; } = new List<int>();
+        public HashSet<int> MovieTags { get; set; } = new HashSet<int>();
     }
 }

--- a/src/NzbDrone.Core/IndexerSearch/MoviesSearchService.cs
+++ b/src/NzbDrone.Core/IndexerSearch/MoviesSearchService.cs
@@ -60,7 +60,17 @@ namespace NzbDrone.Core.IndexerSearch
 
             pagingSpec.FilterExpressions.Add(v => v.Monitored == true);
 
-            var movies = _movieService.MoviesWithoutFiles(pagingSpec).Records.ToList();
+            if (message.MovieIds?.Any() == true)
+            {
+                pagingSpec.FilterExpressions.Add(m => message.MovieIds.Contains(m.Id));
+            }
+
+            if (message.QualityProfileIds?.Any() == true)
+            {
+                pagingSpec.FilterExpressions.Add(m => message.QualityProfileIds.Contains(m.QualityProfileId));
+            }
+
+            var movies = _movieService.MoviesWithoutFiles(pagingSpec, message.MovieTags).Records.ToList();
 
             var queue = _queueService.GetQueue().Where(q => q.Movie != null).Select(q => q.Movie.Id);
             var missing = movies.Where(e => !queue.Contains(e.Id)).ToList();
@@ -80,7 +90,17 @@ namespace NzbDrone.Core.IndexerSearch
 
             pagingSpec.FilterExpressions.Add(v => v.Monitored == true);
 
-            var movies = _movieCutoffService.MoviesWhereCutoffUnmet(pagingSpec).Records.ToList();
+            if (message.MovieIds?.Any() == true)
+            {
+                pagingSpec.FilterExpressions.Add(m => message.MovieIds.Contains(m.Id));
+            }
+
+            if (message.QualityProfileIds?.Any() == true)
+            {
+                pagingSpec.FilterExpressions.Add(m => message.QualityProfileIds.Contains(m.QualityProfileId));
+            }
+
+            var movies = _movieCutoffService.MoviesWhereCutoffUnmet(pagingSpec, message.MovieTags, message.Quality).Records.ToList();
 
             var queue = _queueService.GetQueue().Where(q => q.Movie != null).Select(q => q.Movie.Id);
             var missing = movies.Where(e => !queue.Contains(e.Id)).ToList();

--- a/src/NzbDrone.Core/Movies/MovieCutoffService.cs
+++ b/src/NzbDrone.Core/Movies/MovieCutoffService.cs
@@ -10,7 +10,7 @@ namespace NzbDrone.Core.Movies
 {
     public interface IMovieCutoffService
     {
-        PagingSpec<Movie> MoviesWhereCutoffUnmet(PagingSpec<Movie> pagingSpec);
+        PagingSpec<Movie> MoviesWhereCutoffUnmet(PagingSpec<Movie> pagingSpec, HashSet<int> movieTags = null, List<int> quality = null);
     }
 
     public class MovieCutoffService : IMovieCutoffService
@@ -24,7 +24,7 @@ namespace NzbDrone.Core.Movies
             _qualityProfileService = qualityProfileService;
         }
 
-        public PagingSpec<Movie> MoviesWhereCutoffUnmet(PagingSpec<Movie> pagingSpec)
+        public PagingSpec<Movie> MoviesWhereCutoffUnmet(PagingSpec<Movie> pagingSpec, HashSet<int> movieTags = null, List<int> quality = null)
         {
             var qualitiesBelowCutoff = new List<QualitiesBelowCutoff>();
             var profiles = _qualityProfileService.All();
@@ -49,7 +49,7 @@ namespace NzbDrone.Core.Movies
                 return pagingSpec;
             }
 
-            return _movieRepository.MoviesWhereCutoffUnmet(pagingSpec, qualitiesBelowCutoff);
+            return _movieRepository.MoviesWhereCutoffUnmet(pagingSpec, qualitiesBelowCutoff, movieTags, quality);
         }
     }
 }

--- a/src/NzbDrone.Core/Movies/MovieRepository.cs
+++ b/src/NzbDrone.Core/Movies/MovieRepository.cs
@@ -28,11 +28,11 @@ namespace NzbDrone.Core.Movies
         List<Movie> GetByStudioForeignId(string studioForeignId);
         List<Movie> GetByPerformerForeignId(string performerForeignId);
         List<Movie> MoviesBetweenDates(DateTime start, DateTime end, bool includeUnmonitored);
-        PagingSpec<Movie> MoviesWithoutFiles(PagingSpec<Movie> pagingSpec);
+        PagingSpec<Movie> MoviesWithoutFiles(PagingSpec<Movie> pagingSpec, HashSet<int> movieTags = null);
         List<Movie> GetMoviesByFileId(int fileId);
         List<Movie> GetMoviesByFileId(IEnumerable<int> fileId);
         List<Movie> GetMoviesByCollectionTmdbId(int collectionId);
-        PagingSpec<Movie> MoviesWhereCutoffUnmet(PagingSpec<Movie> pagingSpec, List<QualitiesBelowCutoff> qualitiesBelowCutoff);
+        PagingSpec<Movie> MoviesWhereCutoffUnmet(PagingSpec<Movie> pagingSpec, List<QualitiesBelowCutoff> qualitiesBelowCutoff, HashSet<int> movieTags = null, List<int> quality = null);
         Movie FindByPath(string path);
         Dictionary<int, string> AllMoviePaths();
         List<int> AllMovieIds();
@@ -429,30 +429,55 @@ namespace NzbDrone.Core.Movies
             return Query(builder);
         }
 
-        public SqlBuilder MoviesWithoutFilesBuilder() => Builder()
-            .Where<Movie>(x => x.MovieFileId == 0)
-            .Where<Movie>(m => m.MovieMetadata.Value.Year > 0)
-            .GroupBy<Movie>(m => m.Id)
-            .GroupBy<MovieMetadata>(m => m.Id);
-
-        public PagingSpec<Movie> MoviesWithoutFiles(PagingSpec<Movie> pagingSpec)
+        public SqlBuilder MoviesWithoutFilesBuilder(HashSet<int> movieTags = null)
         {
-            pagingSpec.Records = GetPagedRecords(MoviesWithoutFilesBuilder(), pagingSpec, PagedQuery);
-            pagingSpec.TotalRecords = GetPagedRecordCount(MoviesWithoutFilesBuilder().SelectCountDistinct<Movie>(x => x.Id), pagingSpec);
+            var builder = Builder()
+                .Where<Movie>(x => x.MovieFileId == 0)
+                .Where<Movie>(m => m.MovieMetadata.Value.Year > 0);
+
+            if (movieTags is { Count: > 0 })
+            {
+                builder = builder.Where(BuildMovieTagsWhereClause(movieTags));
+            }
+
+            return builder
+                .GroupBy<Movie>(m => m.Id)
+                .GroupBy<MovieMetadata>(m => m.Id);
+        }
+
+        public PagingSpec<Movie> MoviesWithoutFiles(PagingSpec<Movie> pagingSpec, HashSet<int> movieTags = null)
+        {
+            pagingSpec.Records = GetPagedRecords(MoviesWithoutFilesBuilder(movieTags), pagingSpec, PagedQuery);
+            pagingSpec.TotalRecords = GetPagedRecordCount(MoviesWithoutFilesBuilder(movieTags).SelectCountDistinct<Movie>(x => x.Id), pagingSpec);
 
             return pagingSpec;
         }
 
-        public SqlBuilder MoviesWhereCutoffUnmetBuilder(List<QualitiesBelowCutoff> qualitiesBelowCutoff) => Builder()
-            .Where<Movie>(x => x.MovieFileId != 0)
-            .Where(BuildQualityCutoffWhereClause(qualitiesBelowCutoff))
-            .GroupBy<Movie>(m => m.Id)
-            .GroupBy<MovieMetadata>(m => m.Id);
-
-        public PagingSpec<Movie> MoviesWhereCutoffUnmet(PagingSpec<Movie> pagingSpec, List<QualitiesBelowCutoff> qualitiesBelowCutoff)
+        public SqlBuilder MoviesWhereCutoffUnmetBuilder(List<QualitiesBelowCutoff> qualitiesBelowCutoff, HashSet<int> movieTags = null, List<int> qualities = null)
         {
-            pagingSpec.Records = GetPagedRecords(MoviesWhereCutoffUnmetBuilder(qualitiesBelowCutoff), pagingSpec, PagedQuery);
-            pagingSpec.TotalRecords = GetPagedRecordCount(MoviesWhereCutoffUnmetBuilder(qualitiesBelowCutoff).SelectCountDistinct<Movie>(x => x.Id), pagingSpec);
+            var builder = Builder()
+                .Where<Movie>(x => x.MovieFileId != 0)
+                .Where(BuildQualityCutoffWhereClause(qualitiesBelowCutoff));
+
+            if (movieTags is { Count: > 0 })
+            {
+                builder = builder.Where(BuildMovieTagsWhereClause(movieTags));
+            }
+
+            if (qualities is { Count: > 0 })
+            {
+                builder = builder.Where(BuildQualityFilterWhereClause(qualities));
+            }
+
+            return builder
+                .GroupBy<Movie>(m => m.Id)
+                .GroupBy<MovieMetadata>(m => m.Id);
+        }
+
+        public PagingSpec<Movie> MoviesWhereCutoffUnmet(PagingSpec<Movie> pagingSpec, List<QualitiesBelowCutoff> qualitiesBelowCutoff, HashSet<int> movieTags = null, List<int> quality = null)
+        {
+            pagingSpec.Records = GetPagedRecords(MoviesWhereCutoffUnmetBuilder(qualitiesBelowCutoff, movieTags, quality), pagingSpec, PagedQuery);
+            pagingSpec.TotalRecords = GetPagedRecordCount(MoviesWhereCutoffUnmetBuilder(qualitiesBelowCutoff, movieTags, quality).SelectCountDistinct<Movie>(x => x.Id), pagingSpec);
 
             return pagingSpec;
         }
@@ -468,6 +493,38 @@ namespace NzbDrone.Core.Movies
                     clauses.Add(string.Format($"(\"{_table}\".\"QualityProfileId\" = {profile.ProfileId} AND \"MovieFiles\".\"Quality\" LIKE '%_quality_: {belowCutoff},%')"));
                 }
             }
+
+            return string.Format("({0})", string.Join(" OR ", clauses));
+        }
+
+        // Tags live as a JSON array on the Movies row rather than in a join table,
+        // so membership has to be tested by expanding the array in SQL. The two
+        // engines spell that differently.
+        private string BuildMovieTagsWhereClause(HashSet<int> tagIds)
+        {
+            var ids = string.Join(",", tagIds);
+
+            if (_database.DatabaseType == DatabaseType.PostgreSQL)
+            {
+                return string.Format(
+                    "EXISTS (SELECT 1 FROM jsonb_array_elements_text(\"{0}\".\"Tags\"::jsonb) AS elem WHERE elem::int IN ({1}))",
+                    _table,
+                    ids);
+            }
+
+            return string.Format(
+                "EXISTS (SELECT 1 FROM json_each(\"{0}\".\"Tags\") WHERE json_each.value IN ({1}))",
+                _table,
+                ids);
+        }
+
+        // Matches BuildQualityCutoffWhereClause: the quality column holds a serialised
+        // revision object, so the id is matched inside the JSON text.
+        private string BuildQualityFilterWhereClause(List<int> qualityIds)
+        {
+            var clauses = qualityIds
+                .Select(id => string.Format("\"MovieFiles\".\"Quality\" LIKE '%_quality_: {0},%'", id))
+                .ToList();
 
             return string.Format("({0})", string.Join(" OR ", clauses));
         }

--- a/src/NzbDrone.Core/Movies/MovieService.cs
+++ b/src/NzbDrone.Core/Movies/MovieService.cs
@@ -57,7 +57,7 @@ namespace NzbDrone.Core.Movies
         List<Movie> GetMoviesByFileId(IEnumerable<int> fileId);
         List<Movie> GetMoviesByCollectionTmdbId(int collectionId);
         List<Movie> GetMoviesBetweenDates(DateTime start, DateTime end, bool includeUnmonitored);
-        PagingSpec<Movie> MoviesWithoutFiles(PagingSpec<Movie> pagingSpec);
+        PagingSpec<Movie> MoviesWithoutFiles(PagingSpec<Movie> pagingSpec, HashSet<int> movieTags = null);
         void DeleteMovie(int movieId, bool deleteFiles, bool addImportListExclusion = false);
         void DeleteMovies(List<int> movieIds, bool deleteFiles, bool addImportListExclusion = false);
         List<Movie> GetAllMovies();
@@ -601,10 +601,11 @@ namespace NzbDrone.Core.Movies
 
         /// <summary> Get a paged list of movies without associated files. </summary>
         /// <param name="pagingSpec">The paging specification for the query.</param>
+        /// <param name="movieTags">When set, restrict the results to movies carrying at least one of these tag ids.</param>
         /// <returns>A paged list of movies without associated files.</returns>
-        public PagingSpec<Movie> MoviesWithoutFiles(PagingSpec<Movie> pagingSpec)
+        public PagingSpec<Movie> MoviesWithoutFiles(PagingSpec<Movie> pagingSpec, HashSet<int> movieTags = null)
         {
-            var movieResult = _movieRepository.MoviesWithoutFiles(pagingSpec);
+            var movieResult = _movieRepository.MoviesWithoutFiles(pagingSpec, movieTags);
 
             return movieResult;
         }

--- a/src/Whisparr.Api.V3/Wanted/CutoffController.cs
+++ b/src/Whisparr.Api.V3/Wanted/CutoffController.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.AspNetCore.Mvc;
 using NzbDrone.Core.Configuration;
 using NzbDrone.Core.CustomFormats;
@@ -41,7 +42,7 @@ namespace Whisparr.Api.V3.Wanted
 
         [HttpGet]
         [Produces("application/json")]
-        public PagingResource<MovieResource> GetCutoffUnmetMovies([FromQuery] PagingRequestResource paging, bool monitored = true)
+        public PagingResource<MovieResource> GetCutoffUnmetMovies([FromQuery] PagingRequestResource paging, bool monitored = true, [FromQuery] List<int> movieIds = null, [FromQuery] List<int> qualityProfileIds = null, [FromQuery] List<int> movieTags = null, [FromQuery] List<int> quality = null)
         {
             var pagingResource = new PagingResource<MovieResource>(paging);
             var pagingSpec = pagingResource.MapToPagingSpec<MovieResource, Movie>(
@@ -57,7 +58,19 @@ namespace Whisparr.Api.V3.Wanted
 
             pagingSpec.FilterExpressions.Add(v => v.Monitored == monitored);
 
-            var resource = pagingSpec.ApplyToPage(_movieCutoffService.MoviesWhereCutoffUnmet, v => MapToResource(v));
+            if (movieIds?.Any() == true)
+            {
+                pagingSpec.FilterExpressions.Add(m => movieIds.Contains(m.Id));
+            }
+
+            if (qualityProfileIds?.Any() == true)
+            {
+                pagingSpec.FilterExpressions.Add(m => qualityProfileIds.Contains(m.QualityProfileId));
+            }
+
+            var tags = movieTags?.Any() == true ? new HashSet<int>(movieTags) : null;
+
+            var resource = pagingSpec.ApplyToPage(spec => _movieCutoffService.MoviesWhereCutoffUnmet(spec, tags, quality), v => MapToResource(v));
 
             return resource;
         }

--- a/src/Whisparr.Api.V3/Wanted/MissingController.cs
+++ b/src/Whisparr.Api.V3/Wanted/MissingController.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.AspNetCore.Mvc;
 using NzbDrone.Core.Configuration;
 using NzbDrone.Core.CustomFormats;
@@ -37,7 +38,7 @@ namespace Whisparr.Api.V3.Wanted
 
         [HttpGet]
         [Produces("application/json")]
-        public PagingResource<MovieResource> GetMissingMovies([FromQuery] PagingRequestResource paging, bool monitored = true)
+        public PagingResource<MovieResource> GetMissingMovies([FromQuery] PagingRequestResource paging, bool monitored = true, [FromQuery] List<int> movieIds = null, [FromQuery] List<int> qualityProfileIds = null, [FromQuery] List<int> movieTags = null)
         {
             var pagingResource = new PagingResource<MovieResource>(paging);
             var pagingSpec = pagingResource.MapToPagingSpec<MovieResource, Movie>(
@@ -53,7 +54,19 @@ namespace Whisparr.Api.V3.Wanted
 
             pagingSpec.FilterExpressions.Add(v => v.Monitored == monitored);
 
-            var resource = pagingSpec.ApplyToPage(_movieService.MoviesWithoutFiles, v => MapToResource(v));
+            if (movieIds?.Any() == true)
+            {
+                pagingSpec.FilterExpressions.Add(m => movieIds.Contains(m.Id));
+            }
+
+            if (qualityProfileIds?.Any() == true)
+            {
+                pagingSpec.FilterExpressions.Add(m => qualityProfileIds.Contains(m.QualityProfileId));
+            }
+
+            var tags = movieTags?.Any() == true ? new HashSet<int>(movieTags) : null;
+
+            var resource = pagingSpec.ApplyToPage(spec => _movieService.MoviesWithoutFiles(spec, tags), v => MapToResource(v));
 
             return resource;
         }


### PR DESCRIPTION
#### Database Migration

NO

#### Description

Adapts Sonarr `d2f4f2d03` to our entity model. Both wanted pages had `customFilters={[]}` and a comment saying there was nothing to merge into the two built-ins; this gives them the filter builder.

Filtering happens in SQL, not client-side, so it applies across the whole paged result rather than the visible page.

**Filter dimensions** — movie ids, quality profiles and tags on both pages, plus the quality already on disk for Cutoff Unmet (Missing has no file to match against). Upstream's `seriesType` is dropped: the nearest thing here is `ItemType`, there's no filter-builder value type for it, and inventing one is a separate feature.

Tags are a JSON array on the Movies row rather than a join table, so membership is an `EXISTS` over `json_each` / `jsonb_array_elements_text` depending on engine.

"Search All" now carries the active filter into the search command, so it searches what the page shows instead of the whole library.

No `en.json` changes — Monitored, Movies, QualityProfile, Tags and Quality all already exist.

#### Verification

Six new `MovieRepositoryFixture` tests cover tag filtering, multi-tag union, quality filtering, and the unfiltered paths on both queries. Full suite 4264 pass; tsc at the 3-error node_modules baseline; eslint and webpack clean.

Checked against the live API on 6969:

| request | records |
| --- | ---: |
| `wanted/missing` unfiltered | 9564 |
| `movieTags=3` | 4763 |
| `movieTags=2` | 420 |
| `qualityProfileIds=4` | 4996 |
| `movieIds=37980` | 1 |
| `wanted/cutoff` unfiltered | 1 |
| `movieTags=8` / `movieTags=2` | 1 / 0 |
| `quality=18` / `quality=7` | 1 / 0 |

The cutoff instance had no unmet records, so I temporarily enabled upgrades on one profile and tagged one movie to produce some, then restored both.

Driven in the browser as well: the builder modal renders the four Missing dimensions (no Quality, as intended), selecting a saved `movieTags` filter emits `?...&movieTags=2` and narrows the table 9564 → 420, and Search All posts `{"name":"MissingMoviesSearch","movieTags":[2]}`. No console errors.

#### Screenshot(s) (if UI related)

<details>

Filter builder on Wanted → Missing: `Custom Filter | Label | Filters | Monitored | Movies | Quality Profile | Tags | is | is not | Cancel | Save`

</details>

#### Todos

- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json) — none needed, all keys exist

#### Issues Fixed or Closed by this PR

<!-- If multiple, put each on a separate line -->

- None
