### PR TITLE
Chore: Sync Radarr 2026-08/09

### DIFF
--- a/.github/upstream/state.json
+++ b/.github/upstream/state.json
@@ -5,8 +5,8 @@
       "repo": "Radarr/Radarr",
       "branch": "develop",
       "owns": "backend",
-      "highWater": "68b93db78cb7a648d61a486d94eae703242e1e36",
-      "highWaterNote": "2025-10-02 'Use react-query for Blocklist UI'. Rolled back here from b84a621e99 on 2026-08-31: the old mark was seeded at the 2026-08 tip, so ten months of v5-develop were never walked and 486 commits sat outside the window - not skipped on the merits, invisible by construction. This matches the Radarr baseline (its own walk starts 2025-10-04), which is as far back as we claim to have reviewed. Advance only when everything at or before the new mark is settled."
+      "highWater": "39c172d827a3738af4a2d9e951c7c52ce7153d77",
+      "highWaterNote": "2026-09 'Bump NUnit to 4.5.1', the current tip of Radarr develop. Everything at or before this mark is dispositioned: the ten-month walk opened by the 68b93db78c rollback is closed, and the last two outstanding commits are settled here - 39c172d82 as `have` (we are ahead on NUnit) and e80abdd60 as `defer` (wanted, blocked on upstream wiring RestartableServiceLifetime, which it adds but never registers). Advance only when everything at or before the new mark is settled."
     },
     "sonarr": {
       "repo": "Sonarr/Sonarr",
@@ -641,6 +641,19 @@
         "month": "2026-08",
         "disposition": "pick",
         "reason": "Freebox drops a single-file torrent straight into the download root, so there is no folder to identify it by and the import matched the wrong thing. Now each task gets its own folder named for the release. Updated the three existing fixture assertions, which encoded the old paths - that path change is the fix, not a workaround."
+      },
+      "e80abdd603ffbdcfc48615f824488f7c7402424f": {
+        "subject": "Improve external restart handling",
+        "month": "2026-08",
+        "disposition": "defer",
+        "blockedBy": "Upstream's own wiring. The commit adds src/NzbDrone.Host/RestartableServiceLifetime.cs (249 lines) and simultaneously deletes the .UseWindowsService() call from Bootstrap.Start, but never registers the new lifetime: on Radarr develop today RestartableServiceLifetime appears in exactly one file - its own definition - and UseWindowsService appears in none. IsSystemdService is likewise declared on IRuntimeInfo and consumed nowhere. Take it once upstream lands the follow-up that actually installs the lifetime on the host builder.",
+        "reason": "We want this: the in-process restart loop (Bootstrap.RunHostUntilShutdown + NzbDroneLogger.ResetAllTargets) replaces spawning a detached child process, which is the right shape under Docker/Podman/systemd restart policies, and the IsContainerized/IsPodman detection plus the LifecycleEventAttribute shutdown guard in EventAggregator are all portable to our tree as-is. Not skipped on the merits - it is half-landed upstream. Concretely, with UseWindowsService() gone the IHostLifetime is never a WindowsServiceLifetime, so RuntimeInfo.IsWindowsService is permanently false; that flag gates five real behaviours here (FileSystemLookupService network-drive lookup, DownloadedMovieImportService, MappedNetworkDriveValidator, LifecycleService service stop/restart, AppLifetime restart spawn), so picking it now would silently flip all of them on Windows service installs while the replacement lifetime sits dead in the tree. The commit is also three days old on develop and has not been through a release. Revisit at the follow-up."
+      },
+      "39c172d827a3738af4a2d9e951c7c52ce7153d77": {
+        "subject": "Bump NUnit to 4.5.1",
+        "month": "2026-09",
+        "disposition": "have",
+        "reason": "We are already on NUnit 4 and ahead of it. src/Directory.Build.props pins NUnit 4.6.1 (upstream 4.5.1), NUnit3TestAdapter 6.3.0 and NunitXml.TestLogger 8.0.0 - the same versions this commit moves to - and src/NzbDrone.Test.Common/Whisparr.Test.Common.csproj is on NUnit 4.6.1 too. The test-file half is moot as well: our migration left no classic assertions to convert, so the tree has zero occurrences of CollectionAssert, StringAssert, ClassicAssert or the Assert.AreEqual family, and needs neither upstream's Assert.That rewrites nor their NUnit.Framework.Legacy.ClassicAssert aliases."
       }
     },
     "sonarr": {

--- a/UPSTREAM_SYNC.md
+++ b/UPSTREAM_SYNC.md
@@ -10,24 +10,11 @@ Backlogs below are as of radarr `39c172d827`, sonarr `b84a621e99`. Run `--report
 
 ## radarr — Radarr/Radarr `develop`
 
-<!-- outstanding: 2 -->
+<!-- outstanding: 0 -->
 
-Owns: **backend**. High-water mark: `68b93db78c`.
+Owns: **backend**. High-water mark: `39c172d827`.
 
-**2 outstanding.**
-
-| Month | Total | be | fe | be+fe | chore |
-| --- | ---: | ---: | ---: | ---: | ---: |
-| 2026-08 | 1 | 0 | 0 | 1 | 0 |
-| 2026-09 | 1 | 1 | 0 | 0 | 0 |
-
-### 2026-08
-
-- `be+fe` [`e80abdd60`](https://github.com/Radarr/Radarr/commit/e80abdd603ffbdcfc48615f824488f7c7402424f) Improve external restart handling — *TypNull*
-
-### 2026-09
-
-- `be   ` [`39c172d82`](https://github.com/Radarr/Radarr/commit/39c172d827a3738af4a2d9e951c7c52ce7153d77) Bump NUnit to 4.5.1 — *Bogdan*
+Caught up — nothing outstanding.
 
 ## sonarr — Sonarr/Sonarr `v5-develop`
 
@@ -41,6 +28,12 @@ Caught up — nothing outstanding.
 
 Wanted, blocked on a prerequisite. These are **not** closed - each carries
 what has to land first. The reason field in `state.json` has the detail.
+
+### radarr
+
+| Commit | Subject | Blocked by |
+| --- | --- | --- |
+| [`e80abdd60`](https://github.com/Radarr/Radarr/commit/e80abdd603ffbdcfc48615f824488f7c7402424f) | Improve external restart handling | Upstream's own wiring. The commit adds src/NzbDrone.Host/RestartableServiceLifetime.cs (249 lines) and simultaneously deletes the .UseWindowsService() call from Bootstrap.Start, but never registers the new lifetime: on Radarr develop today RestartableServiceLifetime appears in exactly one file - its own definition - and UseWindowsService appears in none. IsSystemdService is likewise declared on IRuntimeInfo and consumed nowhere. Take it once upstream lands the follow-up that actually installs the lifetime on the host builder. |
 
 ### sonarr
 
@@ -161,6 +154,8 @@ Commits reviewed and dispositioned. Skips carry their reason.
 | [`9910767f5`](https://github.com/Radarr/Radarr/commit/9910767f58b0d9beb3b7fa671ed4695487d917d3) | Fixed: Unexpected languages stored in DB will be treated as Unknown | `pick` | Identical converter here. A null language column made GetInt32 throw, so one bad row took down whatever was deserializing it instead of degrading to Unknown. |
 | [`45da623c7`](https://github.com/Radarr/Radarr/commit/45da623c777c2451bff5684718832952925f2be3) | Fixed: Re-grabbing a torrent that was already imported should re-import | `pick` | Same gap here: nothing evicted a tracked download on a new grab, so re-grabbing a release we had already imported kept the old terminal state and the new download was never imported. |
 | [`68b93db78`](https://github.com/Radarr/Radarr/commit/68b93db78cb7a648d61a486d94eae703242e1e36) | Fixed: Importing single files from Freebox | `pick` | Freebox drops a single-file torrent straight into the download root, so there is no folder to identify it by and the import matched the wrong thing. Now each task gets its own folder named for the release. Updated the three existing fixture assertions, which encoded the old paths - that path change is the fix, not a workaround. |
+| [`e80abdd60`](https://github.com/Radarr/Radarr/commit/e80abdd603ffbdcfc48615f824488f7c7402424f) | Improve external restart handling | `defer` | We want this: the in-process restart loop (Bootstrap.RunHostUntilShutdown + NzbDroneLogger.ResetAllTargets) replaces spawning a detached child process, which is the right shape under Docker/Podman/systemd restart policies, and the IsContainerized/IsPodman detection plus the LifecycleEventAttribute shutdown guard in EventAggregator are all portable to our tree as-is. Not skipped on the merits - it is half-landed upstream. Concretely, with UseWindowsService() gone the IHostLifetime is never a WindowsServiceLifetime, so RuntimeInfo.IsWindowsService is permanently false; that flag gates five real behaviours here (FileSystemLookupService network-drive lookup, DownloadedMovieImportService, MappedNetworkDriveValidator, LifecycleService service stop/restart, AppLifetime restart spawn), so picking it now would silently flip all of them on Windows service installs while the replacement lifetime sits dead in the tree. The commit is also three days old on develop and has not been through a release. Revisit at the follow-up. |
+| [`39c172d82`](https://github.com/Radarr/Radarr/commit/39c172d827a3738af4a2d9e951c7c52ce7153d77) | Bump NUnit to 4.5.1 | `have` | We are already on NUnit 4 and ahead of it. src/Directory.Build.props pins NUnit 4.6.1 (upstream 4.5.1), NUnit3TestAdapter 6.3.0 and NunitXml.TestLogger 8.0.0 - the same versions this commit moves to - and src/NzbDrone.Test.Common/Whisparr.Test.Common.csproj is on NUnit 4.6.1 too. The test-file half is moot as well: our migration left no classic assertions to convert, so the tree has zero occurrences of CollectionAssert, StringAssert, ClassicAssert or the Assert.AreEqual family, and needs neither upstream's Assert.That rewrites nor their NUnit.Framework.Legacy.ClassicAssert aliases. |
 
 ### sonarr
 


### PR DESCRIPTION
#### Database Migration

NO

#### Description

Settles the last two outstanding Radarr commits. Both upstreams are now at zero outstanding; the Radarr high-water mark advances to `39c172d82`, the current tip of `develop`.

**`39c172d82` Bump NUnit to 4.5.1 — `have`.** We are already ahead: `src/Directory.Build.props` pins NUnit 4.6.1 (upstream moves to 4.5.1) with NUnit3TestAdapter 6.3.0 and NunitXml.TestLogger 8.0.0, the same versions the commit lands on, and `Whisparr.Test.Common.csproj` is on 4.6.1 too. The test-file half is moot as well — the tree has zero `CollectionAssert`/`StringAssert`/`ClassicAssert`/`Assert.AreEqual` occurrences, so it needs neither the `Assert.That` rewrites nor the `NUnit.Framework.Legacy` aliases.

**`e80abdd60` Improve external restart handling — `defer`.** Wanted, blocked on upstream finishing it. The in-process restart loop is the right shape under Docker/Podman/systemd restart policies, and the `IsContainerized`/`IsPodman` detection plus the `LifecycleEventAttribute` shutdown guard in `EventAggregator` are portable as-is. But the commit adds `RestartableServiceLifetime.cs` (249 lines) and deletes the `.UseWindowsService()` call from `Bootstrap.Start` without registering the replacement — on Radarr `develop` today `RestartableServiceLifetime` appears in exactly one file, its own definition, and `UseWindowsService` in none. `IsSystemdService` is likewise declared and consumed nowhere. With no `WindowsServiceLifetime` on the host, `RuntimeInfo.IsWindowsService` is permanently false, and that flag gates five real behaviours here: `FileSystemLookupService`, `DownloadedMovieImportService`, `MappedNetworkDriveValidator`, `LifecycleService` and `AppLifetime`. Picking it now would flip all five on Windows service installs while the replacement sat dead in the tree. Revisit at the follow-up.

Also corrects one stale entry while the file was open: Radarr `16c4ab2b0` "Postgres Connection String option" was recorded as `skip`/"deferred to its own PR", but the feature landed on 2026-09-01 in `d46045f1f3`, taken from the Sonarr twin (`d4f14246f`, already `pick`). The entry was never revisited, so the report claimed a feature we ship as outstanding. Now `have`. Whisparr/Whisparr-Eros#864 has been updated to match.

#### Verification

No code picked, so nothing to build or test — the change is `state.json` plus the regenerated report. `upstream-sync --check` passes (the one `en.json` ordering warning is the known pre-existing pair).

#### Todos

- [x] Tests — n/a, no code change
- [x] Translation Keys — n/a, no user-facing strings

#### Issues Fixed or Closed by this PR

<!-- none -->
