### PR TITLE
Fixed: Studio works list emptying after an edit is saved

### DIFF
--- a/src/NzbDrone.Api.Test/v3/Performers/PerformerControllerFixture.cs
+++ b/src/NzbDrone.Api.Test/v3/Performers/PerformerControllerFixture.cs
@@ -8,9 +8,13 @@ using NUnit.Framework;
 using NzbDrone.Common.Cache;
 using NzbDrone.Core.MediaCover;
 using NzbDrone.Core.Movies;
+using NzbDrone.Core.Movies.Performers;
+using NzbDrone.Core.Movies.Performers.Events;
 using NzbDrone.Core.MovieStats;
+using NzbDrone.SignalR;
 using NzbDrone.Test.Common;
 using Whisparr.Api.V3.Performers;
+using Whisparr.Http;
 
 namespace NzbDrone.Api.Test.v3.Performers
 {
@@ -38,6 +42,40 @@ namespace NzbDrone.Api.Test.v3.Performers
             Mocker.GetMock<IMapCoversToLocal>()
                 .Setup(s => s.GetMovieCoverFileInfos())
                 .Returns(_coverFileInfos);
+        }
+
+        [Test]
+        public void should_link_movies_when_broadcasting_a_performer_update()
+        {
+            var performer = new Performer { Id = 1, ForeignId = ForeignId, Name = "Performer" };
+
+            // PerformerService populates these on its own handler for the same event, but
+            // the handlers are unordered, so the model can still be zeroed here.
+            Mocker.GetMock<IMovieService>()
+                .Setup(s => s.GetByPerformerForeignId(ForeignId))
+                .Returns(new List<Movie>
+                {
+                    new Movie
+                    {
+                        Id = 7,
+                        MovieMetadata = new MovieMetadata { Year = 2024, ItemType = ItemType.Scene }
+                    }
+                });
+
+            SignalRMessage broadcast = null;
+            Mocker.GetMock<IBroadcastSignalRMessage>()
+                .Setup(s => s.IsConnected)
+                .Returns(true);
+            Mocker.GetMock<IBroadcastSignalRMessage>()
+                .Setup(s => s.BroadcastMessage(It.IsAny<SignalRMessage>()))
+                .Callback<SignalRMessage>(m => broadcast = m);
+
+            Subject.Handle(new PerformerUpdatedEvent(performer));
+
+            broadcast.Should().NotBeNull();
+            var resource = ((ResourceChangeMessage<PerformerResource>)broadcast.Body).Resource;
+            resource.TotalSceneCount.Should().Be(1);
+            resource.TotalMovieCount.Should().Be(0);
         }
 
         [Test]

--- a/src/NzbDrone.Api.Test/v3/Studios/StudioControllerFixture.cs
+++ b/src/NzbDrone.Api.Test/v3/Studios/StudioControllerFixture.cs
@@ -3,14 +3,19 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
 using Moq;
 using NUnit.Framework;
 using NzbDrone.Common.Cache;
 using NzbDrone.Core.MediaCover;
 using NzbDrone.Core.Movies;
+using NzbDrone.Core.Movies.Studios;
+using NzbDrone.Core.Movies.Studios.Events;
 using NzbDrone.Core.MovieStats;
+using NzbDrone.SignalR;
 using NzbDrone.Test.Common;
 using Whisparr.Api.V3.Studios;
+using Whisparr.Http;
 
 namespace NzbDrone.Api.Test.v3.Studios
 {
@@ -38,6 +43,69 @@ namespace NzbDrone.Api.Test.v3.Studios
             Mocker.GetMock<IMapCoversToLocal>()
                 .Setup(s => s.GetMovieCoverFileInfos())
                 .Returns(_coverFileInfos);
+        }
+
+        [Test]
+        public void should_return_a_linked_resource_from_update()
+        {
+            var studio = new Studio { Id = 1, ForeignId = ForeignId, Title = "Studio", SearchTitle = "Studio" };
+
+            Mocker.GetMock<IStudioService>().Setup(s => s.GetById(1)).Returns(studio);
+            Mocker.GetMock<IStudioService>().Setup(s => s.Update(It.IsAny<Studio>())).Returns(studio);
+            Mocker.GetMock<IMovieService>()
+                .Setup(s => s.GetByStudioForeignId(ForeignId))
+                .Returns(new List<Movie>
+                {
+                    new Movie
+                    {
+                        Id = 7,
+                        MovieMetadata = new MovieMetadata { Year = 2024, ItemType = ItemType.Scene }
+                    }
+                });
+
+            var response = Subject.Update(new StudioResource { Id = 1, ForeignId = ForeignId, Title = "Studio", SearchTitle = "Studio" });
+
+            // Must be a mapped resource, not the raw model: the client replaces its cached
+            // studio with this body, and the details page keys the works list off HasScenes.
+            var resource = ((AcceptedAtActionResult)response.Result).Value.Should().BeOfType<StudioResource>().Subject;
+            resource.HasScenes.Should().BeTrue();
+            resource.Years.Should().BeEquivalentTo(new[] { 2024 });
+        }
+
+        [Test]
+        public void should_link_movies_when_broadcasting_a_studio_update()
+        {
+            var studio = new Studio { Id = 1, ForeignId = ForeignId, Title = "Studio" };
+
+            // The counts on the model are transient: the IHandleAsync side of the event
+            // fills them in after this handler runs, so they are still zero here.
+            Mocker.GetMock<IMovieService>()
+                .Setup(s => s.GetByStudioForeignId(ForeignId))
+                .Returns(new List<Movie>
+                {
+                    new Movie
+                    {
+                        Id = 7,
+                        MovieMetadata = new MovieMetadata { Year = 2024, ItemType = ItemType.Scene }
+                    }
+                });
+
+            SignalRMessage broadcast = null;
+            Mocker.GetMock<IBroadcastSignalRMessage>()
+                .Setup(s => s.IsConnected)
+                .Returns(true);
+            Mocker.GetMock<IBroadcastSignalRMessage>()
+                .Setup(s => s.BroadcastMessage(It.IsAny<SignalRMessage>()))
+                .Callback<SignalRMessage>(m => broadcast = m);
+
+            Subject.Handle(new StudioUpdatedEvent(studio));
+
+            broadcast.Should().NotBeNull();
+            var resource = ((ResourceChangeMessage<StudioResource>)broadcast.Body).Resource;
+            resource.HasScenes.Should().BeTrue();
+            resource.HasMovies.Should().BeFalse();
+            resource.TotalSceneCount.Should().Be(1);
+            resource.Years.Should().BeEquivalentTo(new[] { 2024 });
         }
 
         [Test]

--- a/src/Whisparr.Api.V3/Performers/PerformerController.cs
+++ b/src/Whisparr.Api.V3/Performers/PerformerController.cs
@@ -290,6 +290,11 @@ namespace Whisparr.Api.V3.Performers
         {
             var resource = MapToResource(message.Performer);
 
+            // PerformerService fills the counts in on its own IHandle for this event, but
+            // neither handler is ordered, so it may not have run yet. Link the movies here
+            // so the broadcast never zeroes the counts out in the client's cache.
+            FetchAndLinkMovies(resource);
+
             BroadcastResourceChange(ModelAction.Updated, resource);
         }
 
@@ -359,6 +364,22 @@ namespace Whisparr.Api.V3.Performers
             }
 
             return performerResources;
+        }
+
+        private void FetchAndLinkMovies(PerformerResource resource)
+        {
+            var movies = _moviesService.GetByPerformerForeignId(resource.ForeignId);
+            var movieStats = _movieStatisticsService.MovieStatistics(movies.Select(x => x.Id).ToList());
+
+            resource.MovieCount = movieStats
+                .Where(stat => movies.Any(m => m.Id == stat.MovieId && m.MovieMetadata.Value.ItemType == ItemType.Movie))
+                .Sum(stat => stat.MovieFileCount);
+            resource.SceneCount = movieStats
+                .Where(stat => movies.Any(m => m.Id == stat.MovieId && m.MovieMetadata.Value.ItemType == ItemType.Scene))
+                .Sum(stat => stat.MovieFileCount);
+            resource.TotalMovieCount = movies.Count(x => x.MovieMetadata.Value.ItemType == ItemType.Movie);
+            resource.TotalSceneCount = movies.Count(x => x.MovieMetadata.Value.ItemType == ItemType.Scene);
+            resource.SizeOnDisk = movieStats.Sum(x => x.SizeOnDisk);
         }
 
         private PerformerResource MapToResource(Performer performer)

--- a/src/Whisparr.Api.V3/Studios/StudioController.cs
+++ b/src/Whisparr.Api.V3/Studios/StudioController.cs
@@ -282,7 +282,10 @@ namespace Whisparr.Api.V3.Studios
 
             _studioResourceCache.Remove(updatedStudio.ForeignId);
 
-            return Accepted(updatedStudio);
+            // Pass the id, not the model: `Accepted(Studio)` binds to ControllerBase's
+            // object overload and serialises the raw model, which has no HasMovies /
+            // HasScenes / Years. Clients replace their cached studio with the response.
+            return Accepted(updatedStudio.Id);
         }
 
         [RestDeleteById]
@@ -326,6 +329,12 @@ namespace Whisparr.Api.V3.Studios
         public void Handle(StudioUpdatedEvent message)
         {
             var resource = MapToResource(message.Studio);
+
+            // The counts on the model are transient -- they are only filled in by the
+            // IHandleAsync side of this event, which has not run yet. Link the movies
+            // here so the broadcast carries the same HasMovies/HasScenes/Years the
+            // clients would get from a GET, instead of a resource that reads as empty.
+            FetchAndLinkMovies(resource);
 
             BroadcastResourceChange(ModelAction.Updated, resource);
         }


### PR DESCRIPTION
#### Database Migration

NO

#### Description

Editing a studio and saving emptied the works list until a page reload.

`PUT /studio/{id}` passed the `Studio` model to `Accepted()`. `ModelBase` has no
implicit conversion to `int`, so the call bound to `ControllerBase.Accepted(object)`
rather than `RestController.Accepted(int id)` and serialised the raw model — no
`hasMovies`, `hasScenes` or `years`, plus model-only fields like `cleanTitle` and
`lastInfoSync`. The client replaces its cached studio with that response, so the
details page lost the flags its works list is gated on. Passing the id routes the
response through `GetResourceById` again. Every other controller already passes an
id or a mapped resource; studio was the outlier.

Verified against a local instance: before the fix the PUT response was missing
`hasMovies`/`hasScenes`/`years`; after, it returns a full `StudioResource`.

Second commit is a latent fix, not part of the reported bug: the studio and
performer `Updated` broadcasts were built without linking movies first, so they
advertised zeroed counts. Happy to drop it if you'd rather keep this PR to the one
change.

#### Todos

- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json) - none needed

#### Issues Fixed or Closed by this PR

None filed - found during local testing.
