### PR TITLE
Fixed: History filter menu missing Disk Scan Imported

### DIFF
--- a/frontend/src/Activity/History/useHistory.ts
+++ b/frontend/src/Activity/History/useHistory.ts
@@ -93,6 +93,17 @@ export const FILTERS: Filter[] = [
       },
     ],
   },
+  {
+    key: 'diskScanImported',
+    label: () => translate('DiskScanImported'),
+    filters: [
+      {
+        key: 'eventType',
+        value: '10',
+        type: filterTypes.EQUAL,
+      },
+    ],
+  },
 ];
 
 export const FILTER_BUILDER: FilterBuilderProp<History>[] = [

--- a/frontend/src/Components/Filter/Builder/HistoryEventTypeFilterBuilderRowValue.tsx
+++ b/frontend/src/Components/Filter/Builder/HistoryEventTypeFilterBuilderRowValue.tsx
@@ -40,6 +40,12 @@ const EVENT_TYPE_OPTIONS = [
       return translate('Ignored');
     },
   },
+  {
+    id: 10,
+    get name() {
+      return translate('DiskScanImported');
+    },
+  },
 ];
 
 function HistoryEventTypeFilterBuilderRowValue(


### PR DESCRIPTION
#### Database Migration

NO

#### Description

`MovieHistoryEventType.DiskScanImported` (10) had no entry in the History page's
built-in filter list, so those rows were only reachable under **All**. It was
missing from the custom filter builder's Event Type options too, which means the
workaround suggested in the issue did not actually work either. Added the entry to
both lists; the `DiskScanImported` translation key already existed.

Verified against a local instance with a seeded `eventType=10` row: the menu now
lists **Disk Scan Imported**, selecting it narrows the table to that row, and the
custom filter builder offers it as an Event Type value.

#### Screenshot(s) (if UI related)

<details>

Filter menu: All, Grabbed, Imported, Failed, Deleted, Renamed, Ignored, **Disk Scan Imported**.

</details>

#### Todos

- [ ] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)

#### Issues Fixed or Closed by this PR

- Fixes Whisparr/Whisparr-Eros#848
