### PR TITLE
New: Mark import list exclusions in interactive search

### DIFF
--- a/frontend/src/Helpers/Props/icons.ts
+++ b/frontend/src/Helpers/Props/icons.ts
@@ -50,6 +50,7 @@ import {
   faChevronCircleUp as fasChevronCircleUp,
   faCircle as fasCircle,
   faCircleDown as fasCircleDown,
+  faCircleMinus as fasCircleMinus,
   faCirclePlay as fasCirclePlay,
   faCloud as fasCloud,
   faCloudDownloadAlt as fasCloudDownloadAlt,
@@ -174,6 +175,7 @@ export const DOWNLOADING = fasCloudDownloadAlt;
 export const DRIVE = farHdd;
 export const EDIT = fasWrench;
 export const MOVIE_FILE = farFileVideo;
+export const EXCLUDE = fasCircleMinus;
 export const EXPAND = fasChevronCircleDown;
 export const EXPAND_INDETERMINATE = fasChevronCircleRight;
 export const EXPORT = fasFileExport;

--- a/frontend/src/InteractiveSearch/InteractiveSearchRow.css
+++ b/frontend/src/InteractiveSearch/InteractiveSearchRow.css
@@ -64,7 +64,8 @@
   width: 75px;
 }
 
-.blocklist {
+.blocklist,
+.exclusion {
   margin-left: 5px;
 }
 

--- a/frontend/src/InteractiveSearch/InteractiveSearchRow.css.d.ts
+++ b/frontend/src/InteractiveSearch/InteractiveSearchRow.css.d.ts
@@ -5,6 +5,7 @@ declare namespace InteractiveSearchRowCssNamespace {
     customFormatScore: string;
     download: string;
     downloadIcon: string;
+    exclusion: string;
     history: string;
     indexer: string;
     indexerFlags: string;

--- a/frontend/src/InteractiveSearch/InteractiveSearchRow.tsx
+++ b/frontend/src/InteractiveSearch/InteractiveSearchRow.tsx
@@ -16,12 +16,15 @@ import { icons, kinds, tooltipPositions } from 'Helpers/Props';
 import MovieFormats from 'Movie/MovieFormats';
 import MovieLanguages from 'Movie/MovieLanguages';
 import MovieQuality from 'Movie/MovieQuality';
+import { useMovie } from 'Movie/useMovie';
+import { useImportListExclusionByForeignId } from 'Settings/ImportLists/ImportListExclusions/useImportListExclusions';
 import { useUiSettingsValues } from 'Settings/UI/useUiSettings';
 import Release from 'typings/Release';
 import formatDateTime from 'Utilities/Date/formatDateTime';
 import formatAge from 'Utilities/Number/formatAge';
 import formatBytes from 'Utilities/Number/formatBytes';
 import formatCustomFormatScore from 'Utilities/Number/formatCustomFormatScore';
+import camelCaseToString from 'Utilities/String/camelCaseToString';
 import translate from 'Utilities/String/translate';
 import InteractiveSearchPayload from './InteractiveSearchPayload';
 import OverrideMatchModal from './OverrideMatch/OverrideMatchModal';
@@ -112,6 +115,24 @@ function useReleaseHistory(guid: string, movieId: number) {
   }, [guid, movieHistory, movieBlocklist]);
 }
 
+// Whether the searched item is excluded from import lists. Unlike the two reads
+// above this is a fact about the item, not the release, so it marks every row
+// the same way -- an exclusion and a grab are separate decisions that can
+// disagree, and the search is where that shows up.
+//
+// The exclusions table is keyed by foreign ID rather than movie id, hence the
+// hop through the movie. Both requests are already in flight for the search:
+// the modal that opened it reads the same movie, and the exclusion is keyed by
+// a value every row shares.
+function useMovieExclusion(movieId: number) {
+  const { data: movie } = useMovie(movieId);
+  const { data: exclusion } = useImportListExclusionByForeignId(
+    movie?.foreignId
+  );
+
+  return exclusion;
+}
+
 interface InteractiveSearchRowProps extends Release {
   searchPayload: InteractiveSearchPayload;
 }
@@ -150,6 +171,8 @@ function InteractiveSearchRow(props: InteractiveSearchRowProps) {
 
   const { historyGrabbedData, historyFailedData, blocklistedData } =
     useReleaseHistory(guid, searchPayload.movieId);
+
+  const importListExclusion = useMovieExclusion(searchPayload.movieId);
 
   const [isConfirmGrabModalOpen, setIsConfirmGrabModalOpen] = useState(false);
   const [isOverrideModalOpen, setIsOverrideModalOpen] = useState(false);
@@ -268,6 +291,21 @@ function InteractiveSearchRow(props: InteractiveSearchRowProps) {
                 timeFormat,
                 { includeSeconds: true }
               ),
+            })}
+          />
+        ) : null}
+
+        {importListExclusion ? (
+          <Icon
+            className={
+              historyGrabbedData || historyFailedData || blocklistedData
+                ? styles.exclusion
+                : ''
+            }
+            name={icons.EXCLUDE}
+            kind={kinds.WARNING}
+            title={translate('ExcludedFromImportListsReason', {
+              reason: camelCaseToString(importListExclusion.reason),
             })}
           />
         ) : null}

--- a/frontend/src/Settings/ImportLists/ImportListExclusions/useImportListExclusions.ts
+++ b/frontend/src/Settings/ImportLists/ImportListExclusions/useImportListExclusions.ts
@@ -1,5 +1,6 @@
 import { useCallback, useMemo } from 'react';
 import useApiMutation from 'Helpers/Hooks/useApiMutation';
+import useApiQuery from 'Helpers/Hooks/useApiQuery';
 import usePage from 'Helpers/Hooks/usePage';
 import usePagedApiQuery from 'Helpers/Hooks/usePagedApiQuery';
 import { usePendingChangesStore } from 'Helpers/Hooks/usePendingChangesStore';
@@ -45,6 +46,30 @@ const useImportListExclusions = () => {
 
 export default useImportListExclusions;
 
+// One item's exclusion, looked up by foreign ID -- the interactive search marks
+// excluded items with it. `stashId` is the API's name for the foreign ID; it
+// returns at most one record, and `[]` for an ID that is not excluded, so the
+// miss needs no handling beyond the `undefined` below.
+//
+// This is a third sibling to the movie history and blocklist reads the search
+// already makes. Like those it is keyed by something every row of a search
+// shares, so React Query issues it once per search rather than once per
+// release.
+export const useImportListExclusionByForeignId = (
+  foreignId: string | undefined
+) => {
+  const { data, ...query } = useApiQuery<ImportListExclusion[]>({
+    path: IMPORT_LIST_EXCLUSIONS_PATH,
+    queryParams: { stashId: foreignId },
+    queryOptions: { enabled: !!foreignId },
+  });
+
+  return {
+    ...query,
+    data: data?.[0],
+  };
+};
+
 export const useManageImportListExclusion = (
   importListExclusion?: ImportListExclusion
 ) => {
@@ -68,6 +93,10 @@ export const useManageImportListExclusion = (
       onSuccess: () => {
         queryClient.invalidateQueries({
           queryKey: [PAGED_IMPORT_LIST_EXCLUSIONS_PATH],
+        });
+
+        queryClient.invalidateQueries({
+          queryKey: [IMPORT_LIST_EXCLUSIONS_PATH],
         });
       },
     },
@@ -124,6 +153,10 @@ export const useDeleteImportListExclusion = (id: number) => {
         queryClient.invalidateQueries({
           queryKey: [PAGED_IMPORT_LIST_EXCLUSIONS_PATH],
         });
+
+        queryClient.invalidateQueries({
+          queryKey: [IMPORT_LIST_EXCLUSIONS_PATH],
+        });
       },
     },
   });
@@ -150,6 +183,10 @@ export const useDeleteImportListExclusions = (onSuccess?: () => void) => {
       onSuccess: () => {
         queryClient.invalidateQueries({
           queryKey: [PAGED_IMPORT_LIST_EXCLUSIONS_PATH],
+        });
+
+        queryClient.invalidateQueries({
+          queryKey: [IMPORT_LIST_EXCLUSIONS_PATH],
         });
 
         onSuccess?.();

--- a/src/NzbDrone.Core/Localization/Core/en.json
+++ b/src/NzbDrone.Core/Localization/Core/en.json
@@ -745,6 +745,7 @@
   "Example": "Example",
   "Exception": "Exception",
   "Excluded": "Excluded",
+  "ExcludedFromImportListsReason": "Excluded from import lists ({reason})",
   "ExcludeMovie": "Exclude Movie",
   "ExcludeTitle": "Exclude {0}? This will prevent {appName} from automatically adding via list sync.",
   "ExclusionTitle": "Title",


### PR DESCRIPTION
#### Database Migration

NO

#### Description

The interactive search's History column only ever showed the release blocklist,
so an item excluded from import lists was unmarked — the search offered releases
for something the user had told the app not to take from lists, with no sign the
two decisions were in tension.

Adds a third indicator (`circle-minus`, warning kind) beside the existing grabbed
/ failed / blocklisted icons, tooltipped `Excluded from import lists (Manual)`.
It reads `GET /exclusions?stashId=<foreignId>`, keyed by a value every row of a
search shares, so React Query issues **one** request per search — a third sibling
to the existing `/history/movie` and `/blocklist/movie` reads. The hop from
`movieId` to `foreignId` reuses the `/movie/{id}` read the search modal already
makes, so it adds nothing.

Also invalidates `/exclusions` alongside `/exclusions/paged` on the three
exclusion mutations; they are separate query keys, so the search would otherwise
hold a stale answer after an add, edit or delete.

Two things worth knowing:

- The icon repeats on every row, because an exclusion is a property of the item
  rather than the release. A banner above the results was the alternative; the
  per-row icon was the deliberate pick.
- Exclusions created by the delete-movie dialog or by studio/performer rules go
  through other endpoints and won't invalidate this query mid-session. Harmless
  for the delete case (the movie is gone), but a studio-driven exclusion added
  while a search is open won't appear until refetch.

#### Screenshot(s) (if UI related)

<details>
<!-- paste screenshots below here.-->

<!-- paste screenshots above here.  MAKE SURE THE ARE SFW -->
</details>

#### Todos

- [ ] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)

Frontend-only; the repo has no frontend test runner. Verified live on 6969
against a stub indexer: excluded item shows the icon on both rows, a
non-excluded item shows none, and a network trace confirms exactly one
`/exclusions?stashId=…` per search.

#### Issues Fixed or Closed by this PR

- Fixes Whisparr/Whisparr-Eros#849
