### PR TITLE
Fixed: Foreign ID overlapping the Type column in list exclusions

### DIFF
--- a/frontend/src/Settings/ImportLists/ImportListExclusions/ImportListExclusionRow.css
+++ b/frontend/src/Settings/ImportLists/ImportListExclusions/ImportListExclusionRow.css
@@ -5,9 +5,14 @@
   white-space: nowrap;
 }
 
+/* No max-width: a stashdb foreign ID is a fixed-length 36-character UUID, which
+   needs ~282px. Capping the cell at 250px did not shrink the text -- nowrap has
+   no wrap opportunity and nothing clips it -- so the UUID painted over the Type
+   column. The column sizes to its content instead, which is bounded: UUIDs are
+   the widest value it ever holds, and TMDB ids are shorter. Truncating is not an
+   option here; the foreign ID is an identifier users copy out of this table. */
 .foreignId {
   composes: cell from 'Components/Table/Cells/TableRowCell.css';
 
-  max-width: 250px;
   white-space: nowrap;
 }


### PR DESCRIPTION
#### Database Migration

NO

#### Description

On Settings → Import Lists → List Exclusions, the foreign ID painted over the
Type column on every scene row.

`.foreignId` set `max-width: 250px` with `white-space: nowrap` and nothing to
clip the overflow — no `overflow: hidden`, no wrap opportunity — so the text
simply spilled out of the cell. A stashdb foreign ID is a fixed 36-character
UUID that needs ~282px, so it overhung by ~15px at any viewport width. Measured
before the fix at 1600px: cell 267px, text right edge 1340 vs cell right edge
1334.

Dropping the cap lets the column size to its content, which is bounded — a UUID
is the widest value the column ever holds, and TMDB movie ids are shorter.
Truncating with an ellipsis would be the wrong trade here; the foreign ID is an
identifier people copy out of this table.

Note this was **not** caused by the Title column's minimum width, which was the
first guess — the overlap reproduced on short titles too, and at 1600px Title
had 51px of slack while the foreign ID was already overflowing.

Verified at 1600 / 1280 / 1100px: overflow is now ≤ 0 at all three, the foreign
ID column settles at its 282px min-content, and Title absorbs the difference,
wrapping to two lines at the narrow end.

#### Screenshot(s) (if UI related)

<details>
<!-- paste screenshots below here.-->

<!-- paste screenshots above here.  MAKE SURE THE ARE SFW -->
</details>

#### Todos

- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)

CSS-only; no new strings, and the repo has no frontend test runner.

#### Issues Fixed or Closed by this PR

- None filed; found while testing #614.
