### PR TITLE
Fixed: Validate quality profile and root folder on performers and studios

### DIFF
--- a/src/NzbDrone.Api.Test/v3/Performers/PerformerControllerFixture.cs
+++ b/src/NzbDrone.Api.Test/v3/Performers/PerformerControllerFixture.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using FluentAssertions;
 using Moq;
 using NUnit.Framework;
@@ -11,10 +12,13 @@ using NzbDrone.Core.Movies;
 using NzbDrone.Core.Movies.Performers;
 using NzbDrone.Core.Movies.Performers.Events;
 using NzbDrone.Core.MovieStats;
+using NzbDrone.Core.Profiles.Qualities;
+using NzbDrone.Core.RootFolders;
 using NzbDrone.SignalR;
 using NzbDrone.Test.Common;
 using Whisparr.Api.V3.Performers;
 using Whisparr.Http;
+using Whisparr.Http.REST;
 
 namespace NzbDrone.Api.Test.v3.Performers
 {
@@ -22,6 +26,7 @@ namespace NzbDrone.Api.Test.v3.Performers
     public class PerformerControllerFixture : TestBase<PerformerController>
     {
         private const string ForeignId = "performer-foreign-id";
+        private static readonly string RootFolder = @"C:\Movies".AsOsAgnostic();
         private Dictionary<string, FileInfo> _coverFileInfos;
 
         [SetUp]
@@ -90,6 +95,75 @@ namespace NzbDrone.Api.Test.v3.Performers
                         It.Is<IEnumerable<Tuple<int, IEnumerable<MediaCover>>>>(items => !items.Any()),
                         _coverFileInfos),
                     Times.Once());
+        }
+
+        // The rules live in the controller's constructor and ValidateResource is only
+        // reachable through the MVC pipeline, so read the validator back directly.
+        private ResourceValidator<PerformerResource> SharedValidator()
+        {
+            return (ResourceValidator<PerformerResource>)typeof(RestController<PerformerResource>)
+                .GetProperty("SharedValidator", BindingFlags.Instance | BindingFlags.NonPublic)
+                .GetValue(Subject);
+        }
+
+        private PerformerResource GivenResource(int qualityProfileId = 1, string rootFolderPath = null)
+        {
+            return new PerformerResource
+            {
+                Id = 1,
+                ForeignId = ForeignId,
+                QualityProfileId = qualityProfileId,
+                RootFolderPath = rootFolderPath
+            };
+        }
+
+        [Test]
+        public void should_accept_an_existing_quality_profile_and_root_folder()
+        {
+            GivenProfileAndRootFolder();
+
+            SharedValidator().Validate(GivenResource(rootFolderPath: RootFolder)).IsValid.Should().BeTrue();
+        }
+
+        [Test]
+        public void should_reject_a_quality_profile_that_does_not_exist()
+        {
+            GivenProfileAndRootFolder();
+
+            var result = SharedValidator().Validate(GivenResource(9999, RootFolder));
+
+            result.IsValid.Should().BeFalse();
+            result.Errors.Should().Contain(e => e.PropertyName == "QualityProfileId" && e.ErrorCode == "QualityProfileExistsValidator");
+        }
+
+        [Test]
+        public void should_reject_a_root_folder_that_does_not_exist()
+        {
+            GivenProfileAndRootFolder();
+
+            var result = SharedValidator().Validate(GivenResource(rootFolderPath: @"C:\Nonexistent\Bogus".AsOsAgnostic()));
+
+            result.IsValid.Should().BeFalse();
+            result.Errors.Should().Contain(e => e.PropertyName == "RootFolderPath" && e.ErrorCode == "RootFolderExistsValidator");
+        }
+
+        [Test]
+        public void should_skip_the_root_folder_check_when_it_is_not_set()
+        {
+            GivenProfileAndRootFolder();
+
+            SharedValidator().Validate(GivenResource()).IsValid.Should().BeTrue();
+        }
+
+        private void GivenProfileAndRootFolder()
+        {
+            Mocker.GetMock<IQualityProfileService>()
+                .Setup(s => s.Exists(1))
+                .Returns(true);
+
+            Mocker.GetMock<IRootFolderService>()
+                .Setup(s => s.All())
+                .Returns(new List<RootFolder> { new RootFolder { Path = RootFolder } });
         }
     }
 }

--- a/src/NzbDrone.Api.Test/v3/Performers/PerformerEditorValidatorFixture.cs
+++ b/src/NzbDrone.Api.Test/v3/Performers/PerformerEditorValidatorFixture.cs
@@ -1,0 +1,80 @@
+using System.Collections.Generic;
+using FluentAssertions;
+using NUnit.Framework;
+using NzbDrone.Core.Movies.Performers;
+using NzbDrone.Core.Profiles.Qualities;
+using NzbDrone.Core.RootFolders;
+using NzbDrone.Test.Common;
+using Whisparr.Api.V3.Performers;
+
+namespace NzbDrone.Api.Test.v3.Performers
+{
+    [Parallelizable(ParallelScope.Self)]
+    public class PerformerEditorValidatorFixture : TestBase<PerformerEditorValidator>
+    {
+        private static readonly string RootFolder = @"C:\Movies".AsOsAgnostic();
+
+        [SetUp]
+        public void Setup()
+        {
+            Mocker.GetMock<IQualityProfileService>()
+                .Setup(s => s.Exists(1))
+                .Returns(true);
+
+            Mocker.GetMock<IRootFolderService>()
+                .Setup(s => s.All())
+                .Returns(new List<RootFolder> { new RootFolder { Path = RootFolder } });
+        }
+
+        private static Performer GivenPerformer(int qualityProfileId = 1, string rootFolderPath = null)
+        {
+            return new Performer
+            {
+                Id = 1,
+                ForeignId = "performer-foreign-id",
+                QualityProfileId = qualityProfileId,
+                RootFolderPath = rootFolderPath
+            };
+        }
+
+        [Test]
+        public void should_accept_an_existing_quality_profile_and_root_folder()
+        {
+            Subject.Validate(GivenPerformer(rootFolderPath: RootFolder)).IsValid.Should().BeTrue();
+        }
+
+        [Test]
+        public void should_reject_a_quality_profile_that_does_not_exist()
+        {
+            var result = Subject.Validate(GivenPerformer(9999, RootFolder));
+
+            result.IsValid.Should().BeFalse();
+            result.Errors.Should().Contain(e => e.PropertyName == "QualityProfileId" && e.ErrorCode == "QualityProfileExistsValidator");
+        }
+
+        [Test]
+        public void should_reject_an_unset_quality_profile()
+        {
+            var result = Subject.Validate(GivenPerformer(0, RootFolder));
+
+            result.IsValid.Should().BeFalse();
+            result.Errors.Should().Contain(e => e.PropertyName == "QualityProfileId");
+        }
+
+        [Test]
+        public void should_reject_a_root_folder_that_does_not_exist()
+        {
+            var result = Subject.Validate(GivenPerformer(rootFolderPath: @"C:\Nonexistent\Bogus".AsOsAgnostic()));
+
+            result.IsValid.Should().BeFalse();
+            result.Errors.Should().Contain(e => e.PropertyName == "RootFolderPath" && e.ErrorCode == "RootFolderExistsValidator");
+        }
+
+        [TestCase(null)]
+        [TestCase("")]
+        public void should_skip_the_root_folder_check_when_it_is_not_set(string rootFolderPath)
+        {
+            Subject.Validate(GivenPerformer(rootFolderPath: rootFolderPath)).IsValid.Should().BeTrue();
+        }
+    }
+}

--- a/src/NzbDrone.Api.Test/v3/Studios/StudioControllerFixture.cs
+++ b/src/NzbDrone.Api.Test/v3/Studios/StudioControllerFixture.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using FluentAssertions;
 using Microsoft.AspNetCore.Mvc;
 using Moq;
@@ -12,10 +13,13 @@ using NzbDrone.Core.Movies;
 using NzbDrone.Core.Movies.Studios;
 using NzbDrone.Core.Movies.Studios.Events;
 using NzbDrone.Core.MovieStats;
+using NzbDrone.Core.Profiles.Qualities;
+using NzbDrone.Core.RootFolders;
 using NzbDrone.SignalR;
 using NzbDrone.Test.Common;
 using Whisparr.Api.V3.Studios;
 using Whisparr.Http;
+using Whisparr.Http.REST;
 
 namespace NzbDrone.Api.Test.v3.Studios
 {
@@ -23,6 +27,7 @@ namespace NzbDrone.Api.Test.v3.Studios
     public class StudioControllerFixture : TestBase<StudioController>
     {
         private const string ForeignId = "studio-foreign-id";
+        private static readonly string RootFolder = @"C:\Movies".AsOsAgnostic();
         private Dictionary<string, FileInfo> _coverFileInfos;
 
         [SetUp]
@@ -120,6 +125,75 @@ namespace NzbDrone.Api.Test.v3.Studios
                         It.Is<IEnumerable<Tuple<int, IEnumerable<MediaCover>>>>(items => !items.Any()),
                         _coverFileInfos),
                     Times.Once());
+        }
+
+        // The rules live in the controller's constructor and ValidateResource is only
+        // reachable through the MVC pipeline, so read the validator back directly.
+        private ResourceValidator<StudioResource> SharedValidator()
+        {
+            return (ResourceValidator<StudioResource>)typeof(RestController<StudioResource>)
+                .GetProperty("SharedValidator", BindingFlags.Instance | BindingFlags.NonPublic)
+                .GetValue(Subject);
+        }
+
+        private StudioResource GivenResource(int qualityProfileId = 1, string rootFolderPath = null)
+        {
+            return new StudioResource
+            {
+                Id = 1,
+                ForeignId = ForeignId,
+                QualityProfileId = qualityProfileId,
+                RootFolderPath = rootFolderPath
+            };
+        }
+
+        [Test]
+        public void should_accept_an_existing_quality_profile_and_root_folder()
+        {
+            GivenProfileAndRootFolder();
+
+            SharedValidator().Validate(GivenResource(rootFolderPath: RootFolder)).IsValid.Should().BeTrue();
+        }
+
+        [Test]
+        public void should_reject_a_quality_profile_that_does_not_exist()
+        {
+            GivenProfileAndRootFolder();
+
+            var result = SharedValidator().Validate(GivenResource(9999, RootFolder));
+
+            result.IsValid.Should().BeFalse();
+            result.Errors.Should().Contain(e => e.PropertyName == "QualityProfileId" && e.ErrorCode == "QualityProfileExistsValidator");
+        }
+
+        [Test]
+        public void should_reject_a_root_folder_that_does_not_exist()
+        {
+            GivenProfileAndRootFolder();
+
+            var result = SharedValidator().Validate(GivenResource(rootFolderPath: @"C:\Nonexistent\Bogus".AsOsAgnostic()));
+
+            result.IsValid.Should().BeFalse();
+            result.Errors.Should().Contain(e => e.PropertyName == "RootFolderPath" && e.ErrorCode == "RootFolderExistsValidator");
+        }
+
+        [Test]
+        public void should_skip_the_root_folder_check_when_it_is_not_set()
+        {
+            GivenProfileAndRootFolder();
+
+            SharedValidator().Validate(GivenResource()).IsValid.Should().BeTrue();
+        }
+
+        private void GivenProfileAndRootFolder()
+        {
+            Mocker.GetMock<IQualityProfileService>()
+                .Setup(s => s.Exists(1))
+                .Returns(true);
+
+            Mocker.GetMock<IRootFolderService>()
+                .Setup(s => s.All())
+                .Returns(new List<RootFolder> { new RootFolder { Path = RootFolder } });
         }
     }
 }

--- a/src/NzbDrone.Api.Test/v3/Studios/StudioEditorValidatorFixture.cs
+++ b/src/NzbDrone.Api.Test/v3/Studios/StudioEditorValidatorFixture.cs
@@ -1,0 +1,80 @@
+using System.Collections.Generic;
+using FluentAssertions;
+using NUnit.Framework;
+using NzbDrone.Core.Movies.Studios;
+using NzbDrone.Core.Profiles.Qualities;
+using NzbDrone.Core.RootFolders;
+using NzbDrone.Test.Common;
+using Whisparr.Api.V3.Studios;
+
+namespace NzbDrone.Api.Test.v3.Studios
+{
+    [Parallelizable(ParallelScope.Self)]
+    public class StudioEditorValidatorFixture : TestBase<StudioEditorValidator>
+    {
+        private static readonly string RootFolder = @"C:\Movies".AsOsAgnostic();
+
+        [SetUp]
+        public void Setup()
+        {
+            Mocker.GetMock<IQualityProfileService>()
+                .Setup(s => s.Exists(1))
+                .Returns(true);
+
+            Mocker.GetMock<IRootFolderService>()
+                .Setup(s => s.All())
+                .Returns(new List<RootFolder> { new RootFolder { Path = RootFolder } });
+        }
+
+        private static Studio GivenStudio(int qualityProfileId = 1, string rootFolderPath = null)
+        {
+            return new Studio
+            {
+                Id = 1,
+                ForeignId = "studio-foreign-id",
+                QualityProfileId = qualityProfileId,
+                RootFolderPath = rootFolderPath
+            };
+        }
+
+        [Test]
+        public void should_accept_an_existing_quality_profile_and_root_folder()
+        {
+            Subject.Validate(GivenStudio(rootFolderPath: RootFolder)).IsValid.Should().BeTrue();
+        }
+
+        [Test]
+        public void should_reject_a_quality_profile_that_does_not_exist()
+        {
+            var result = Subject.Validate(GivenStudio(9999, RootFolder));
+
+            result.IsValid.Should().BeFalse();
+            result.Errors.Should().Contain(e => e.PropertyName == "QualityProfileId" && e.ErrorCode == "QualityProfileExistsValidator");
+        }
+
+        [Test]
+        public void should_reject_an_unset_quality_profile()
+        {
+            var result = Subject.Validate(GivenStudio(0, RootFolder));
+
+            result.IsValid.Should().BeFalse();
+            result.Errors.Should().Contain(e => e.PropertyName == "QualityProfileId");
+        }
+
+        [Test]
+        public void should_reject_a_root_folder_that_does_not_exist()
+        {
+            var result = Subject.Validate(GivenStudio(rootFolderPath: @"C:\Nonexistent\Bogus".AsOsAgnostic()));
+
+            result.IsValid.Should().BeFalse();
+            result.Errors.Should().Contain(e => e.PropertyName == "RootFolderPath" && e.ErrorCode == "RootFolderExistsValidator");
+        }
+
+        [TestCase(null)]
+        [TestCase("")]
+        public void should_skip_the_root_folder_check_when_it_is_not_set(string rootFolderPath)
+        {
+            Subject.Validate(GivenStudio(rootFolderPath: rootFolderPath)).IsValid.Should().BeTrue();
+        }
+    }
+}

--- a/src/Whisparr.Api.V3/Performers/PerformerController.cs
+++ b/src/Whisparr.Api.V3/Performers/PerformerController.cs
@@ -18,6 +18,8 @@ using NzbDrone.Core.Movies;
 using NzbDrone.Core.Movies.Performers;
 using NzbDrone.Core.Movies.Performers.Events;
 using NzbDrone.Core.MovieStats;
+using NzbDrone.Core.Validation;
+using NzbDrone.Core.Validation.Paths;
 using NzbDrone.SignalR;
 using Whisparr.Api.V3.Movies;
 using Whisparr.Api.V3.Performers.Helpers;
@@ -68,6 +70,8 @@ namespace Whisparr.Api.V3.Performers
                                    IImportListExclusionService exclusionService,
                                    ICacheManager cacheManager,
                                    IConfigService configService,
+                                   QualityProfileExistsValidator<PerformerResource> qualityProfileExistsValidator,
+                                   RootFolderExistsValidator<PerformerResource> rootFolderExistsValidator,
                                    Logger logger,
                                    IBroadcastSignalRMessage signalRBroadcaster)
         : base(signalRBroadcaster)
@@ -82,6 +86,15 @@ namespace Whisparr.Api.V3.Performers
             _useCache = _configService.WhisparrCachePerformerAPI;
             _performerResourceCache = cacheManager.GetCache<PerformerResource>(typeof(PerformerResource), "performerResources");
             _logger = logger;
+
+            SharedValidator.RuleFor(s => s.QualityProfileId).Cascade(CascadeMode.Stop)
+                .ValidId()
+                .SetValidator(qualityProfileExistsValidator);
+
+            SharedValidator.RuleFor(s => s.RootFolderPath).Cascade(CascadeMode.Stop)
+                .IsValidPath()
+                .SetValidator(rootFolderExistsValidator)
+                .When(s => s.RootFolderPath.IsNotNullOrWhiteSpace());
 
             if (configService.WhisparrMovieMetadataSource == MovieMetadataType.TMDB)
             {

--- a/src/Whisparr.Api.V3/Performers/PerformerEditorController.cs
+++ b/src/Whisparr.Api.V3/Performers/PerformerEditorController.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using FluentValidation;
 using Microsoft.AspNetCore.Mvc;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.DecisionEngine.Specifications;
@@ -14,12 +15,14 @@ namespace Whisparr.Api.V3.Performers
         private readonly IPerformerService _performerService;
         private readonly IManageCommandQueue _commandQueueManager;
         private readonly IUpgradableSpecification _upgradableSpecification;
+        private readonly PerformerEditorValidator _performerEditorValidator;
 
-        public PerformerEditorController(IPerformerService performerService, IManageCommandQueue commandQueueManager, IUpgradableSpecification upgradableSpecification)
+        public PerformerEditorController(IPerformerService performerService, IManageCommandQueue commandQueueManager, IUpgradableSpecification upgradableSpecification, PerformerEditorValidator performerEditorValidator)
         {
             _performerService = performerService;
             _commandQueueManager = commandQueueManager;
             _upgradableSpecification = upgradableSpecification;
+            _performerEditorValidator = performerEditorValidator;
         }
 
         /// <summary>
@@ -78,6 +81,13 @@ namespace Whisparr.Api.V3.Performers
                             performer.Tags = new HashSet<int>(newTags);
                             break;
                     }
+                }
+
+                var validationResult = _performerEditorValidator.Validate(performer);
+
+                if (!validationResult.IsValid)
+                {
+                    throw new ValidationException(validationResult.Errors);
                 }
             }
 

--- a/src/Whisparr.Api.V3/Performers/PerformerEditorValidator.cs
+++ b/src/Whisparr.Api.V3/Performers/PerformerEditorValidator.cs
@@ -1,0 +1,23 @@
+using FluentValidation;
+using NzbDrone.Common.Extensions;
+using NzbDrone.Core.Movies.Performers;
+using NzbDrone.Core.Validation;
+using NzbDrone.Core.Validation.Paths;
+
+namespace Whisparr.Api.V3.Performers
+{
+    public class PerformerEditorValidator : AbstractValidator<Performer>
+    {
+        public PerformerEditorValidator(RootFolderExistsValidator<Performer> rootFolderExistsValidator, QualityProfileExistsValidator<Performer> qualityProfileExistsValidator)
+        {
+            RuleFor(s => s.RootFolderPath).Cascade(CascadeMode.Stop)
+                .IsValidPath()
+                .SetValidator(rootFolderExistsValidator)
+                .When(s => s.RootFolderPath.IsNotNullOrWhiteSpace());
+
+            RuleFor(s => s.QualityProfileId).Cascade(CascadeMode.Stop)
+                .ValidId()
+                .SetValidator(qualityProfileExistsValidator);
+        }
+    }
+}

--- a/src/Whisparr.Api.V3/Studios/StudioController.cs
+++ b/src/Whisparr.Api.V3/Studios/StudioController.cs
@@ -18,6 +18,8 @@ using NzbDrone.Core.Movies;
 using NzbDrone.Core.Movies.Studios;
 using NzbDrone.Core.Movies.Studios.Events;
 using NzbDrone.Core.MovieStats;
+using NzbDrone.Core.Validation;
+using NzbDrone.Core.Validation.Paths;
 using NzbDrone.SignalR;
 using Whisparr.Api.V3.Movies;
 using Whisparr.Api.V3.Studios.Helpers;
@@ -64,6 +66,8 @@ namespace Whisparr.Api.V3.Studios
                                 IImportListExclusionService exclusionService,
                                 ICacheManager cacheManager,
                                 IConfigService configService,
+                                QualityProfileExistsValidator<StudioResource> qualityProfileExistsValidator,
+                                RootFolderExistsValidator<StudioResource> rootFolderExistsValidator,
                                 Logger logger,
                                 IBroadcastSignalRMessage signalRBroadcaster)
         : base(signalRBroadcaster)
@@ -77,6 +81,15 @@ namespace Whisparr.Api.V3.Studios
             _useCache = configService.WhisparrCacheStudioAPI;
             _studioResourceCache = cacheManager.GetCache<StudioResource>(typeof(StudioResource), "studioResources");
             _logger = logger;
+
+            SharedValidator.RuleFor(s => s.QualityProfileId).Cascade(CascadeMode.Stop)
+                .ValidId()
+                .SetValidator(qualityProfileExistsValidator);
+
+            SharedValidator.RuleFor(s => s.RootFolderPath).Cascade(CascadeMode.Stop)
+                .IsValidPath()
+                .SetValidator(rootFolderExistsValidator)
+                .When(s => s.RootFolderPath.IsNotNullOrWhiteSpace());
 
             if (configService.WhisparrMovieMetadataSource == MovieMetadataType.TMDB)
             {

--- a/src/Whisparr.Api.V3/Studios/StudioEditorController.cs
+++ b/src/Whisparr.Api.V3/Studios/StudioEditorController.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using FluentValidation;
 using Microsoft.AspNetCore.Mvc;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.DecisionEngine.Specifications;
@@ -14,12 +15,14 @@ namespace Whisparr.Api.V3.Studios
         private readonly IStudioService _studioService;
         private readonly IManageCommandQueue _commandQueueManager;
         private readonly IUpgradableSpecification _upgradableSpecification;
+        private readonly StudioEditorValidator _studioEditorValidator;
 
-        public StudioEditorController(IStudioService studioService, IManageCommandQueue commandQueueManager, IUpgradableSpecification upgradableSpecification)
+        public StudioEditorController(IStudioService studioService, IManageCommandQueue commandQueueManager, IUpgradableSpecification upgradableSpecification, StudioEditorValidator studioEditorValidator)
         {
             _studioService = studioService;
             _commandQueueManager = commandQueueManager;
             _upgradableSpecification = upgradableSpecification;
+            _studioEditorValidator = studioEditorValidator;
         }
 
         /// <summary>
@@ -73,6 +76,13 @@ namespace Whisparr.Api.V3.Studios
                             studios.Tags = new HashSet<int>(newTags);
                             break;
                     }
+                }
+
+                var validationResult = _studioEditorValidator.Validate(studios);
+
+                if (!validationResult.IsValid)
+                {
+                    throw new ValidationException(validationResult.Errors);
                 }
             }
 

--- a/src/Whisparr.Api.V3/Studios/StudioEditorValidator.cs
+++ b/src/Whisparr.Api.V3/Studios/StudioEditorValidator.cs
@@ -1,0 +1,23 @@
+using FluentValidation;
+using NzbDrone.Common.Extensions;
+using NzbDrone.Core.Movies.Studios;
+using NzbDrone.Core.Validation;
+using NzbDrone.Core.Validation.Paths;
+
+namespace Whisparr.Api.V3.Studios
+{
+    public class StudioEditorValidator : AbstractValidator<Studio>
+    {
+        public StudioEditorValidator(RootFolderExistsValidator<Studio> rootFolderExistsValidator, QualityProfileExistsValidator<Studio> qualityProfileExistsValidator)
+        {
+            RuleFor(s => s.RootFolderPath).Cascade(CascadeMode.Stop)
+                .IsValidPath()
+                .SetValidator(rootFolderExistsValidator)
+                .When(s => s.RootFolderPath.IsNotNullOrWhiteSpace());
+
+            RuleFor(s => s.QualityProfileId).Cascade(CascadeMode.Stop)
+                .ValidId()
+                .SetValidator(qualityProfileExistsValidator);
+        }
+    }
+}


### PR DESCRIPTION
#### Database Migration

NO

#### Description

`PerformerController` and `StudioController` registered only the `MoviesMonitored`
rule, so `PUT /performer/{id}`, `PUT /studio/{id}` and both editor endpoints accepted
a `QualityProfileId` no profile uses and a `RootFolderPath` that does not exist, and
persisted them. `MovieController` already rejects the same payloads.

Adds the two rules to both `SharedValidator`s, plus a `PerformerEditorValidator` /
`StudioEditorValidator` for the bulk-edit endpoints — those are plain controllers with
no `SharedValidator`, the same arrangement `MovieEditorController` already uses.

Note the issue's snippet applies `rootFolderValidator` to `RootFolderPath`; that one
rejects a path *because* it is a configured root folder and is meant for a movie's own
`Path`, so it would reject exactly the valid values. This uses
`RootFolderExistsValidator`, matching `MovieController` and `MovieEditorValidator`.

Verified against a running instance — all eight bad payloads return 400 with the
expected `errorCode` (`QualityProfileExistsValidator` / `RootFolderExistsValidator`),
valid bodies still return 202, and nothing was persisted.

Not included: the frontend `createProfileInUseSelector` delete-guard the issue mentions
in passing. It is outside the stated expected behaviour and is a separate change.

#### Todos

- [x] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)

#### Issues Fixed or Closed by this PR

- Fixes Whisparr/Whisparr-Eros#854
