### PR TITLE
Fixed: Movie naming tokens that always rendered empty

### DIFF
--- a/frontend/src/Settings/MediaManagement/Naming/NamingModal.tsx
+++ b/frontend/src/Settings/MediaManagement/Naming/NamingModal.tsx
@@ -117,13 +117,7 @@ const movieTokens = [
   { token: '{Movie TitleThe}', example: "Movie's Title, The", footNote: true },
   {
     token: '{Movie CleanTitleThe}',
-    example: 'Movies Title, The',
-    footNote: true,
-  },
-  { token: '{Movie OriginalTitle}', example: 'Τίτλος ταινίας', footNote: true },
-  {
-    token: '{Movie CleanOriginalTitle}',
-    example: 'Τίτλος ταινίας',
+    example: 'Movies Title The',
     footNote: true,
   },
   { token: '{Movie TitleFirstCharacter}', example: 'M' },
@@ -133,7 +127,6 @@ const movieTokens = [
     example: 'The Movie Collection',
     footNote: true,
   },
-  { token: '{Movie Certification}', example: 'R' },
   { token: '{Release Year}', example: '2009' },
 ];
 

--- a/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/FileNameBuilderFixture.cs
+++ b/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/FileNameBuilderFixture.cs
@@ -424,12 +424,33 @@ namespace NzbDrone.Core.Test.OrganizerTests.FileNameBuilderTests
         }
 
         [Test]
+        public void should_replace_movie_collection()
+        {
+            _namingConfig.StandardMovieFormat = "{Movie Collection}";
+            _movie.MovieMetadata.Value.CollectionTitle = "South Park Collection";
+
+            Subject.BuildFileName(_movie, _movieFile)
+                   .Should().Be("South Park Collection");
+        }
+
+        [Test]
         public void should_be_empty_for_null_collection()
         {
             _namingConfig.StandardMovieFormat = "{Movie Collection}";
+            _movie.MovieMetadata.Value.CollectionTitle = null;
 
             Subject.BuildFileName(_movie, _movieFile)
                    .Should().BeEmpty();
+        }
+
+        [Test]
+        public void should_replace_movie_clean_title_the()
+        {
+            _namingConfig.StandardMovieFormat = "{Movie CleanTitleThe}";
+            _movie.Title = "The Movie's Title";
+
+            Subject.BuildFileName(_movie, _movieFile)
+                   .Should().Be("Movies Title The");
         }
 
         [Test]

--- a/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
@@ -360,7 +360,9 @@ namespace NzbDrone.Core.Organizer
             tokenHandlers["{Movie Title}"] = m => Truncate(GetLanguageTitle(movie, m.CustomFormat), m.CustomFormat);
             tokenHandlers["{Movie CleanTitle}"] = m => Truncate(CleanTitle(GetLanguageTitle(movie, m.CustomFormat)), m.CustomFormat);
             tokenHandlers["{Movie TitleThe}"] = m => Truncate(TitleThe(movie.Title), m.CustomFormat);
+            tokenHandlers["{Movie CleanTitleThe}"] = m => Truncate(CleanTitle(TitleThe(movie.Title)), m.CustomFormat);
             tokenHandlers["{Movie TitleFirstCharacter}"] = m => TitleFirstCharacter(TitleThe(GetLanguageTitle(movie, m.CustomFormat)));
+            tokenHandlers["{Movie Collection}"] = m => Truncate(movie.MovieMetadata.Value.CollectionTitle, m.CustomFormat);
         }
 
         private void AddStudioTokens(Dictionary<string, Func<TokenMatch, string>> tokenHandlers, Movie movie)

--- a/src/NzbDrone.Core/Organizer/FileNameSampleService.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameSampleService.cs
@@ -63,6 +63,7 @@ namespace NzbDrone.Core.Organizer
                 ImdbId = "tt0066921",
                 TmdbId = 345691,
                 ForeignId = "345691",
+                CollectionTitle = "The Movie Collection",
                 ItemType = ItemType.Movie
             };
 


### PR DESCRIPTION
#### Database Migration

NO

#### Description

Five `{Movie ...}` tokens were offered in the naming token picker but had no handler in `FileNameBuilder`, so `ReplaceToken`'s empty fallback silently dropped them from the built filename.

`{Movie Collection}` and `{Movie CleanTitleThe}` now have handlers — `CollectionTitle` is already on `MovieMetadata` and populated by `RefreshMovieService`, and `CleanTitleThe` derives from the title. The naming sample movie gets a collection title so the preview isn't blank.

`{Movie Certification}`, `{Movie OriginalTitle}` and `{Movie CleanOriginalTitle}` have no backing field on `MovieMetadata` (the only `Certification` in the tree is a TMDb import-list filter; `{Original Title}` is a different token — the source filename), so they are removed from the picker instead.

Note `{Movie CleanTitleThe}` renders `Movies Title The`, not `Movies Title, The` — `CleanTitle` strips a comma followed by a space. The picker example is corrected to match; Radarr has the same behaviour with the same inaccurate example.

`should_be_empty_for_null_collection` passed for the wrong reason (no handler at all), so it now nulls the collection explicitly, with a companion test asserting a real collection renders.

Verified against a live instance: `{Movie Collection} - {Movie CleanTitleThe} - {Movie TitleThe} - CERT[{Movie Certification}] ORIG[{Movie OriginalTitle}]` returns `The Movie Collection - Movie Title The - Movie Title, The - CERT[] ORIG[]`.

#### Todos

- [x] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json) — n/a, token strings are literals

#### Issues Fixed or Closed by this PR

- Fixes Whisparr/Whisparr-Eros#860
