### PR TITLE
Fixed: -nobrowser ignored when another instance is already running

### DIFF
--- a/src/NzbDrone.Host.Test/NzbDroneProcessServiceFixture.cs
+++ b/src/NzbDrone.Host.Test/NzbDroneProcessServiceFixture.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using Moq;
 using NUnit.Framework;
+using NzbDrone.Common.EnvironmentInfo;
 using NzbDrone.Common.Model;
 using NzbDrone.Common.Processes;
 using NzbDrone.Host;
@@ -26,6 +27,19 @@ namespace NzbDrone.App.Test
             Mocker.GetMock<IProcessProvider>()
                   .Setup(s => s.FindProcessByName(ProcessProvider.WHISPARR_PROCESS_NAME))
                   .Returns(new List<ProcessInfo>());
+
+            Mocker.SetConstant<IStartupContext>(new StartupContext());
+        }
+
+        private void GivenAnotherConsoleIsRunning()
+        {
+            Mocker.GetMock<IProcessProvider>()
+                  .Setup(c => c.FindProcessByName(ProcessProvider.WHISPARR_CONSOLE_PROCESS_NAME))
+                  .Returns(new List<ProcessInfo>
+                           {
+                               new ProcessInfo { Id = 10 },
+                               new ProcessInfo { Id = CURRENT_PROCESS_ID }
+                           });
         }
 
         [Test]
@@ -46,13 +60,7 @@ namespace NzbDrone.App.Test
         [Test]
         public void should_enforce_if_another_console_is_running()
         {
-            Mocker.GetMock<IProcessProvider>()
-                  .Setup(c => c.FindProcessByName(ProcessProvider.WHISPARR_CONSOLE_PROCESS_NAME))
-                  .Returns(new List<ProcessInfo>
-                           {
-                               new ProcessInfo { Id = 10 },
-                               new ProcessInfo { Id = CURRENT_PROCESS_ID }
-                           });
+            GivenAnotherConsoleIsRunning();
 
             Assert.Throws<TerminateApplicationException>(() => Subject.PreventStartIfAlreadyRunning());
             Mocker.GetMock<IBrowserService>().Verify(c => c.LaunchWebUI(), Times.Once());
@@ -72,6 +80,18 @@ namespace NzbDrone.App.Test
 
             Assert.Throws<TerminateApplicationException>(() => Subject.PreventStartIfAlreadyRunning());
             Mocker.GetMock<IBrowserService>().Verify(c => c.LaunchWebUI(), Times.Once());
+            ExceptionVerification.ExpectedWarns(1);
+        }
+
+        [Test]
+        public void should_not_launch_browser_if_nobrowser_flag_is_set()
+        {
+            GivenAnotherConsoleIsRunning();
+
+            Mocker.SetConstant<IStartupContext>(new StartupContext("-nobrowser"));
+
+            Assert.Throws<TerminateApplicationException>(() => Subject.PreventStartIfAlreadyRunning());
+            Mocker.GetMock<IBrowserService>().Verify(c => c.LaunchWebUI(), Times.Never());
             ExceptionVerification.ExpectedWarns(1);
         }
     }

--- a/src/NzbDrone.Host/SingleInstancePolicy.cs
+++ b/src/NzbDrone.Host/SingleInstancePolicy.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using NLog;
+using NzbDrone.Common.EnvironmentInfo;
 using NzbDrone.Common.Processes;
 
 namespace NzbDrone.Host
@@ -17,14 +18,17 @@ namespace NzbDrone.Host
     {
         private readonly IProcessProvider _processProvider;
         private readonly IBrowserService _browserService;
+        private readonly IStartupContext _startupContext;
         private readonly Logger _logger;
 
         public SingleInstancePolicy(IProcessProvider processProvider,
                                     IBrowserService browserService,
+                                    IStartupContext startupContext,
                                     Logger logger)
         {
             _processProvider = processProvider;
             _browserService = browserService;
+            _startupContext = startupContext;
             _logger = logger;
         }
 
@@ -33,7 +37,12 @@ namespace NzbDrone.Host
             if (IsAlreadyRunning())
             {
                 _logger.Warn("Another instance of Whisparr is already running.");
-                _browserService.LaunchWebUI();
+
+                if (!_startupContext.Flags.Contains(StartupContext.NO_BROWSER))
+                {
+                    _browserService.LaunchWebUI();
+                }
+
                 throw new TerminateApplicationException("Another instance is already running");
             }
         }


### PR DESCRIPTION
#### Database Migration

NO

#### Description

`SingleInstancePolicy.PreventStartIfAlreadyRunning()` called `LaunchWebUI()` unconditionally before throwing, so a start blocked by an existing instance opened a browser tab even when the caller passed `-nobrowser`. It now applies the same `StartupContext.NO_BROWSER` guard `AppLifetime` already uses, so the two startup paths agree.

`BrowserService` is untouched — the systray path still launches on demand.

#### Todos

- [x] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)

#### Issues Fixed or Closed by this PR

- Fixes Whisparr/Whisparr-Eros#861
