### PR TITLE
Fixed: Disk space usage bar showing NaN% for zero-size mounts

### DIFF
--- a/frontend/src/Components/ProgressBar.tsx
+++ b/frontend/src/Components/ProgressBar.tsx
@@ -32,8 +32,11 @@ function ProgressBar({
   kind = 'primary',
   size = 'medium',
   width,
-}: ProgressBarProps) {
-  const progressPercent = `${progress.toFixed(precision)}%`;
+}: Readonly<ProgressBarProps>) {
+  const safeProgress = Number.isFinite(progress)
+    ? Math.min(Math.max(progress, 0), 100)
+    : 0;
+  const progressPercent = `${safeProgress.toFixed(precision)}%`;
   const progressText = text || progressPercent;
   const actualWidth = width ? `${width}px` : '100%';
 
@@ -67,10 +70,10 @@ function ProgressBar({
               aria-label={
                 ariaLabel ??
                 translate('ProgressBarProgress', {
-                  progress: progress.toFixed(0),
+                  progress: safeProgress.toFixed(0),
                 })
               }
-              aria-valuenow={Math.floor(progress)}
+              aria-valuenow={Math.floor(safeProgress)}
               aria-valuemin={0}
               aria-valuemax={100}
               style={{ width: progressPercent }}

--- a/frontend/src/System/Status/DiskSpace/DiskSpace.tsx
+++ b/frontend/src/System/Status/DiskSpace/DiskSpace.tsx
@@ -50,7 +50,9 @@ function DiskSpace() {
             {data.map((item) => {
               const { freeSpace, totalSpace } = item;
 
-              const diskUsage = 100 - (freeSpace / totalSpace) * 100;
+              const diskUsage = totalSpace
+                ? 100 - (freeSpace / totalSpace) * 100
+                : 0;
               let diskUsageKind: Kind = 'primary';
 
               if (diskUsage > 90) {


### PR DESCRIPTION
#### Database Migration

NO

#### Description

Mounts reporting a total size of zero made `DiskSpace` divide by zero, so
`ProgressBar` received `NaN`: empty inline width, `aria-valuenow="NaN"` and
`aria-label="Progress Bar at NaN%"`. On macOS the synthetic
`/System/Volumes/Data/home` firmlink reports zeroes and hits this every time.

Two changes:

- `DiskSpace` guards the divisor, matching the pattern already used in
  `MovieStatus`.
- `ProgressBar` clamps `progress` to a finite 0-100 before it reaches the width
  and ARIA attributes, so no other caller can push `NaN` or an out-of-range
  value through.

Verified against a live `/api/v3/diskspace` on macOS, reading the rendered DOM
for every disk row. Before: `/System/Volumes/Data/home` → `width: ""`,
`aria-valuenow="NaN"`, `aria-label="Progress Bar at NaN%"`. After: `width:
"0%"`, `aria-valuenow="0"`, `aria-label="Progress Bar at 0%"`, with every other
row byte-identical (`86.2%`, `3.6%`, …).

#### Screenshot(s) (if UI related)

Not useful here. `DiskSpace` renders the bar with `showText` off, so both before
and after show the same empty grey track — the defect is only visible in the
inline width and the ARIA attributes quoted above.

#### Todos

- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)

No new strings. The repo has no frontend test runner, so the change is covered
by the live-DOM verification above rather than a unit test.

#### Issues Fixed or Closed by this PR

- Fixes Whisparr/Whisparr-Eros#862
