### PR TITLE
Fixed: Log forging from paths, release quality and request urls

### DIFF
--- a/.github/workflows/build_v3.yml
+++ b/.github/workflows/build_v3.yml
@@ -106,6 +106,9 @@ jobs:
     needs: prepare
     permissions:
       contents: read
+      # The build action adds the private gh-openur feed authenticated with
+      # github.token; without this the freebsd-x64 runtime packs 403.
+      packages: read
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build_v3.yml
+++ b/.github/workflows/build_v3.yml
@@ -34,6 +34,8 @@ env:
 jobs:
   prepare:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       framework: ${{ steps.variables.outputs.framework }}
       major_version: ${{ steps.variables.outputs.major_version }}
@@ -102,6 +104,8 @@ jobs:
 
   backend:
     needs: prepare
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -154,6 +158,8 @@ jobs:
 
   frontend:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Check out
         uses: actions/checkout@v7
@@ -181,6 +187,8 @@ jobs:
 
   unit_test:
     needs: backend
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -221,6 +229,8 @@ jobs:
   unit_test_postgres:
     needs: backend
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -241,6 +251,8 @@ jobs:
 
   integration_test:
     needs: [prepare, backend]
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:

--- a/src/NzbDrone.Common.Test/ExtensionTests/StringExtensionTests/ForLogFixture.cs
+++ b/src/NzbDrone.Common.Test/ExtensionTests/StringExtensionTests/ForLogFixture.cs
@@ -10,7 +10,7 @@ namespace NzbDrone.Common.Test.ExtensionTests.StringExtensionTests
         [TestCase("Studio.Name.26.09.01.1080p", "Studio.Name.26.09.01.1080p")]
         [TestCase("", "")]
         [TestCase(null, null)]
-        public void should_leave_a_value_without_line_breaks_alone(string input, string expected)
+        public void should_leave_a_value_without_control_characters_alone(string input, string expected)
         {
             input.ForLog().Should().Be(expected);
         }
@@ -20,6 +20,16 @@ namespace NzbDrone.Common.Test.ExtensionTests.StringExtensionTests
         [TestCase("Title\r[Fatal] Everything is fine", "Title[Fatal] Everything is fine")]
         [TestCase("\n\r\n\rTitle", "Title")]
         public void should_strip_line_breaks_so_a_value_cannot_forge_a_log_entry(string input, string expected)
+        {
+            input.ForLog().Should().Be(expected);
+        }
+
+        // Not line breaks, but they still let a value rewrite what the log viewer shows.
+        [TestCase("Title\tIndented", "TitleIndented")]
+        [TestCase("Title\u0000Null", "TitleNull")]
+        [TestCase("Title\u001b[31mRed", "Title[31mRed")]
+        [TestCase("Title\u0007Bell", "TitleBell")]
+        public void should_strip_other_control_characters(string input, string expected)
         {
             input.ForLog().Should().Be(expected);
         }

--- a/src/NzbDrone.Common/Disk/DiskProviderBase.cs
+++ b/src/NzbDrone.Common/Disk/DiskProviderBase.cs
@@ -549,7 +549,7 @@ namespace NzbDrone.Common.Disk
             }
             catch (Exception ex)
             {
-                Logger.Debug(ex, $"Failed to get mount for path {path}");
+                Logger.Debug(ex, $"Failed to get mount for path {path.ForLog()}");
                 return null;
             }
         }

--- a/src/NzbDrone.Common/Extensions/StringExtensions.cs
+++ b/src/NzbDrone.Common/Extensions/StringExtensions.cs
@@ -120,17 +120,28 @@ namespace NzbDrone.Common.Extensions
         }
 
         /// <summary>
-        /// Strips carriage returns and line feeds so a value that came from a request
-        /// body or a filename cannot forge extra lines when written to the log.
+        /// Strips control characters - carriage returns and line feeds among them - so a
+        /// value that came from a request, a release name or a filename cannot forge extra
+        /// lines when written to the log.
         /// </summary>
         public static string ForLog(this string text)
         {
-            if (text == null)
+            if (text == null || !text.Any(char.IsControl))
             {
-                return null;
+                return text;
             }
 
-            return text.Replace("\r", string.Empty).Replace("\n", string.Empty);
+            var cleaned = new StringBuilder(text.Length);
+
+            foreach (var c in text)
+            {
+                if (!char.IsControl(c))
+                {
+                    cleaned.Append(c);
+                }
+            }
+
+            return cleaned.ToString();
         }
 
         public static bool IsNullOrWhiteSpace(this string text)

--- a/src/NzbDrone.Common/Extensions/StringExtensions.cs
+++ b/src/NzbDrone.Common/Extensions/StringExtensions.cs
@@ -122,13 +122,13 @@ namespace NzbDrone.Common.Extensions
         /// <summary>
         /// Strips control characters - carriage returns and line feeds among them - so a
         /// value that came from a request, a release name or a filename cannot forge extra
-        /// lines when written to the log.
+        /// lines when written to the log, or repaint one with an escape sequence.
         /// </summary>
         public static string ForLog(this string text)
         {
-            if (text == null || !text.Any(char.IsControl))
+            if (text == null)
             {
-                return text;
+                return null;
             }
 
             var cleaned = new StringBuilder(text.Length);
@@ -141,7 +141,13 @@ namespace NzbDrone.Common.Extensions
                 }
             }
 
-            return cleaned.ToString();
+            // The loop has already dropped CR and LF. The explicit Replace pair is
+            // redundant to a reader but not to CodeQL: cs/log-forging recognises
+            // String.Replace as a sanitiser and does not model the loop, so this is
+            // what marks the value clean. Every caller returns through this one path -
+            // an early "return text" for the common case would hand the query an
+            // unsanitised route from the argument straight to the result.
+            return cleaned.ToString().Replace("\r", string.Empty).Replace("\n", string.Empty);
         }
 
         public static bool IsNullOrWhiteSpace(this string text)

--- a/src/NzbDrone.Core/MediaFiles/MovieImport/Specifications/GrabbedReleaseQualitySpecification.cs
+++ b/src/NzbDrone.Core/MediaFiles/MovieImport/Specifications/GrabbedReleaseQualitySpecification.cs
@@ -42,7 +42,7 @@ namespace NzbDrone.Core.MediaFiles.MovieImport.Specifications
                 if (item.Quality.Quality != Quality.Unknown && item.Quality != localMovie.Quality)
                 {
                     // Log only for info, spec removed due to common webdl/webrip mismatches
-                    _logger.Debug("Quality for grabbed release ({0}) does not match the quality of the file ({1})", item.Quality, localMovie.Quality);
+                    _logger.Debug("Quality for grabbed release ({0}) does not match the quality of the file ({1})", item.Quality.ToString().ForLog(), localMovie.Quality.ToString().ForLog());
                 }
             }
 

--- a/src/NzbDrone.Core/MediaFiles/MovieImport/Specifications/UpgradeSpecification.cs
+++ b/src/NzbDrone.Core/MediaFiles/MovieImport/Specifications/UpgradeSpecification.cs
@@ -44,7 +44,7 @@ namespace NzbDrone.Core.MediaFiles.MovieImport.Specifications
 
                 if (qualityCompare < 0)
                 {
-                    _logger.Debug("This file isn't a quality upgrade for movie. Existing quality: {0}. New Quality {1}. Skipping {2}", movieFile.Quality.Quality, localMovie.Quality.Quality, localMovie.Path);
+                    _logger.Debug("This file isn't a quality upgrade for movie. Existing quality: {0}. New Quality {1}. Skipping {2}", movieFile.Quality.Quality, localMovie.Quality.Quality, localMovie.Path.ForLog());
                     return ImportSpecDecision.Reject(ImportRejectionReason.NotQualityUpgrade, "Not an upgrade for existing movie file. Existing quality: {0}. New Quality {1}.", movieFile.Quality.Quality, localMovie.Quality.Quality);
                 }
 
@@ -54,7 +54,7 @@ namespace NzbDrone.Core.MediaFiles.MovieImport.Specifications
                     downloadPropersAndRepacks != ProperDownloadTypes.DoNotPrefer &&
                     localMovie.Quality.Revision.CompareTo(movieFile.Quality.Revision) < 0)
                 {
-                    _logger.Debug("This file isn't a quality revision upgrade for movie. Skipping {0}", localMovie.Path);
+                    _logger.Debug("This file isn't a quality revision upgrade for movie. Skipping {0}", localMovie.Path.ForLog());
                     return ImportSpecDecision.Reject(ImportRejectionReason.NotRevisionUpgrade, "Not a quality revision upgrade for existing movie file(s)");
                 }
 

--- a/src/Whisparr.Http/Frontend/Mappers/StaticResourceMapperBase.cs
+++ b/src/Whisparr.Http/Frontend/Mappers/StaticResourceMapperBase.cs
@@ -50,7 +50,7 @@ namespace Whisparr.Http.Frontend.Mappers
 
             if (filePath == null)
             {
-                _logger.Warn("Resource {0} resolves outside of {1}", ForLog(resourceUrl), FolderPath);
+                _logger.Warn("Resource {0} resolves outside of {1}", resourceUrl.ForLog(), FolderPath);
 
                 return Task.FromResult<IActionResult>(null);
             }
@@ -68,28 +68,9 @@ namespace Whisparr.Http.Frontend.Mappers
                 }));
             }
 
-            _logger.Warn("File {0} not found", filePath);
+            _logger.Warn("File {0} not found", filePath.ForLog());
 
             return Task.FromResult<IActionResult>(null);
-        }
-
-        // The resource url comes straight from the request, so strip anything that could
-        // forge a new log line before it reaches the log.
-        private static string ForLog(string resourceUrl)
-        {
-            if (resourceUrl.IsNullOrWhiteSpace())
-            {
-                return string.Empty;
-            }
-
-            var cleaned = new StringBuilder(resourceUrl.Length);
-
-            foreach (var c in resourceUrl)
-            {
-                cleaned.Append(char.IsControl(c) ? '_' : c);
-            }
-
-            return cleaned.ToString();
         }
 
         protected virtual Stream GetContentStream(string filePath)

--- a/src/Whisparr.Http/Frontend/StaticResourceController.cs
+++ b/src/Whisparr.Http/Frontend/StaticResourceController.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Cors;
 using Microsoft.AspNetCore.Mvc;
 using NLog;
+using NzbDrone.Common.Extensions;
 using Whisparr.Http.Extensions;
 using Whisparr.Http.Frontend.Mappers;
 
@@ -69,7 +70,7 @@ namespace Whisparr.Http.Frontend
                 return NotFound();
             }
 
-            _logger.Warn("Couldn't find handler for {0}", path);
+            _logger.Warn("Couldn't find handler for {0}", path.ForLog());
 
             return NotFound();
         }


### PR DESCRIPTION
#### Database Migration

NO

#### Description

Sanitises the values CodeQL flagged as reaching a log message unfiltered, so a filename or request path carrying CRLF cannot forge a fabricated entry in the log file and the log viewer. Covers the three `cs/log-forging` alerts (145, 143, 142) plus the two same-shape frontend sites the issue notes, and the sibling `localMovie.Path` log in `UpgradeSpecification` that the alert did not land on.

Two things beyond the literal issue text:

- `ForLog()` now strips every control character rather than just CR and LF — an ESC sequence rewrites what the log viewer renders without needing a line break. That absorbs the private copy `StaticResourceMapperBase` carried, so the two sanitisers are one again. Printable punctuation (`[`, `:`, `(`) is untouched, so release names and Windows paths log unchanged.
- The `frontend` job in `build_v3.yml` had no `permissions:` block — but neither did any other job in that workflow, so all six build/test jobs now declare `contents: read`. The `deploy` job is left alone: it calls `deploy.yml`, whose `release` job needs `contents: write`, and a caller-level cap cannot be elevated back.

Verified: solution builds with 0 warnings. `ForLogFixture` 10/10, Common extension + disk tests 69/69, `UpgradeSpecificationFixture` + `GrabbedReleaseQualityFixture` 39/39.

The workflow half only proves itself once merged — `build_v3.yml` runs from the base branch's copy on a PR.

#### Todos

- [x] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)

#### Issues Fixed or Closed by this PR

- Fixes Whisparr/Whisparr-Eros#863
