### PR TITLE
New: Sort and identify scenes on the Import Scenes page

### DIFF
--- a/frontend/src/AddMovie/AddNewMovie/AddNewMovie.tsx
+++ b/frontend/src/AddMovie/AddNewMovie/AddNewMovie.tsx
@@ -127,7 +127,7 @@ function AddNewMovie() {
               {translate('HaveNotAddedMovies')}
             </div>
             <div>
-              <Button to="/add/import" kind={kinds.PRIMARY}>
+              <Button to="/add/import/movies" kind={kinds.PRIMARY}>
                 {translate('ImportExistingMovies')}
               </Button>
             </div>

--- a/frontend/src/AddMovie/AddNewMovie/AddNewScene.tsx
+++ b/frontend/src/AddMovie/AddNewMovie/AddNewScene.tsx
@@ -135,7 +135,7 @@ function AddNewScene() {
               {translate('HaveNotAddedMovies')}
             </div>
             <div>
-              <Button to="/add/import" kind={kinds.PRIMARY}>
+              <Button to="/add/import/scenes" kind={kinds.PRIMARY}>
                 {translate('ImportExistingMovies')}
               </Button>
             </div>

--- a/frontend/src/AddMovie/ImportMovie/Import/ImportMovie.tsx
+++ b/frontend/src/AddMovie/ImportMovie/Import/ImportMovie.tsx
@@ -2,16 +2,18 @@ import { reduce } from 'lodash';
 import React, {
   useCallback,
   useEffect,
+  useMemo,
   useReducer,
   useRef,
   useState,
 } from 'react';
-import { useMatch, useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import Alert from 'Components/Alert';
 import LoadingIndicator from 'Components/Loading/LoadingIndicator';
 import PageContent from 'Components/Page/PageContent';
 import PageContentBody from 'Components/Page/PageContentBody';
-import { kinds } from 'Helpers/Props';
+import { kinds, sortDirections } from 'Helpers/Props';
+import { SortDirection } from 'Helpers/Props/sortDirections';
 import { useRootFolder } from 'RootFolder/useRootFolders';
 import { useQualityProfiles } from 'Settings/Profiles/Quality/useQualityProfiles';
 import ImportFile from 'typings/ImportFile';
@@ -26,6 +28,8 @@ import {
 } from '../../addMovieDefaultsStore';
 import {
   IMPORT_ITEM_LIMIT,
+  ImportItem,
+  ImportItemType,
   importReducer,
   MovieLookupResult,
 } from '../ImportMovieTypes';
@@ -35,6 +39,10 @@ import ImportMovieFooter from './ImportMovieFooter';
 import ImportMovieTable from './ImportMovieTable';
 
 const EMPTY_IMPORT_FILES: ImportFile[] = [];
+
+interface ImportMovieProps {
+  readonly itemType?: ImportItemType;
+}
 
 interface SelectionState {
   allSelected: boolean;
@@ -56,13 +64,11 @@ function getSelectedIds(selectedState: Record<string, boolean>): string[] {
   );
 }
 
-function ImportMovie() {
+function ImportMovie({ itemType }: ImportMovieProps) {
   const { rootFolderId: rootFolderIdParam } = useParams() as {
     rootFolderId: string;
   };
   const rootFolderId = Number.parseInt(rootFolderIdParam, 10);
-  const scenesMatch = useMatch('/add/import/scenes/:rootFolderId');
-  const itemType: 'movie' | 'scene' = scenesMatch ? 'scene' : 'movie';
 
   // The list endpoint already carries import files, but this page is reachable
   // by url with no list in the cache, so it reads the folder on its own.
@@ -104,6 +110,10 @@ function ImportMovie() {
     lastToggled: null,
     selectedState: {},
   });
+
+  const [sortDirection, setSortDirection] = useState<SortDirection>(
+    sortDirections.ASCENDING
+  );
 
   const [isImporting, setIsImporting] = useState(false);
   const [importError, setImportError] = useState<ApiError | null>(null);
@@ -147,6 +157,30 @@ function ImportMovie() {
     });
   }, [importState.items, queueLookup]);
 
+  // Rows land in whatever order the disk scan produced them, so the table is
+  // sorted by relative path — the only column whose value doesn't change as
+  // lookups come back and start shuffling rows around.
+  const sortedItems = useMemo(() => {
+    const sorted = [...importState.items].sort((a: ImportItem, b: ImportItem) =>
+      a.relativePath.localeCompare(b.relativePath, undefined, {
+        numeric: true,
+        sensitivity: 'base',
+      })
+    );
+
+    return sortDirection === sortDirections.DESCENDING
+      ? sorted.reverse()
+      : sorted;
+  }, [importState.items, sortDirection]);
+
+  const onSortPress = useCallback(() => {
+    setSortDirection((prev) =>
+      prev === sortDirections.ASCENDING
+        ? sortDirections.DESCENDING
+        : sortDirections.ASCENDING
+    );
+  }, []);
+
   const onSelectAllChange = useCallback(({ value }: { value: boolean }) => {
     setSelectionState(
       (prev) => selectAll(prev.selectedState, value) as SelectionState
@@ -160,14 +194,14 @@ function ImportMovie() {
           toggleSelected(
             prev,
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            importState.items as unknown as any[],
+            sortedItems as unknown as any[],
             String(id),
             value ?? false,
             shiftKey
           ) as SelectionState
       );
     },
-    [importState.items]
+    [sortedItems]
   );
 
   const onRemoveSelectedStateItem = useCallback((id: string) => {
@@ -182,7 +216,7 @@ function ImportMovie() {
     (opts: {
       id: string;
       term: string;
-      itemType: 'movie' | 'scene';
+      itemType?: ImportItemType;
       topOfQueue: boolean;
     }) => {
       queueLookup(opts);
@@ -271,8 +305,16 @@ function ImportMovie() {
 
   const selectedIds = getSelectedIds(selectionState.selectedState);
 
+  let titleKey = 'ImportLibrary';
+
+  if (itemType === 'scene') {
+    titleKey = 'ImportScenes';
+  } else if (itemType === 'movie') {
+    titleKey = 'ImportMovies';
+  }
+
   return (
-    <PageContent title={translate('ImportMovies')}>
+    <PageContent title={translate(titleKey)}>
       <PageContentBody>
         {rootFoldersFetching ? <LoadingIndicator /> : null}
 
@@ -285,7 +327,12 @@ function ImportMovie() {
         rootFoldersPopulated &&
         !importFiles.length ? (
           <Alert kind={kinds.INFO}>
-            {translate('AllMoviesInPathHaveBeenImported', { path: path ?? '' })}
+            {translate(
+              itemType === 'scene'
+                ? 'AllScenesInPathHaveBeenImported'
+                : 'AllMoviesInPathHaveBeenImported',
+              { path: path ?? '' }
+            )}
           </Alert>
         ) : null}
 
@@ -303,11 +350,13 @@ function ImportMovie() {
         rootFoldersPopulated &&
         !!importFiles.length ? (
           <ImportMovieTable
-            items={importState.items}
+            items={sortedItems}
             isLookingUp={isLookingUp}
             allSelected={selectionState.allSelected}
             allUnselected={selectionState.allUnselected}
             selectedState={selectionState.selectedState}
+            sortDirection={sortDirection}
+            onSortPress={onSortPress}
             onSelectAllChange={onSelectAllChange}
             onSelectedChange={onSelectedChange}
             onRemoveSelectedStateItem={onRemoveSelectedStateItem}

--- a/frontend/src/AddMovie/ImportMovie/Import/ImportMovieHeader.tsx
+++ b/frontend/src/AddMovie/ImportMovie/Import/ImportMovieHeader.tsx
@@ -2,18 +2,23 @@ import React from 'react';
 import VirtualTableHeader from 'Components/Table/VirtualTableHeader';
 import VirtualTableHeaderCell from 'Components/Table/VirtualTableHeaderCell';
 import VirtualTableSelectAllHeaderCell from 'Components/Table/VirtualTableSelectAllHeaderCell';
+import { SortDirection } from 'Helpers/Props/sortDirections';
 import translate from 'Utilities/String/translate';
 import styles from './ImportMovieHeader.css';
 
 interface ImportMovieHeaderProps {
   allSelected: boolean;
   allUnselected: boolean;
+  sortDirection: SortDirection;
+  onSortPress: () => void;
   onSelectAllChange: (opts: { value: boolean }) => void;
 }
 
 function ImportMovieHeader({
   allSelected,
   allUnselected,
+  sortDirection,
+  onSortPress,
   onSelectAllChange,
 }: Readonly<ImportMovieHeaderProps>) {
   return (
@@ -24,7 +29,14 @@ function ImportMovieHeader({
         onSelectAllChange={onSelectAllChange}
       />
 
-      <VirtualTableHeaderCell className={styles.folder} name="folder">
+      <VirtualTableHeaderCell
+        className={styles.folder}
+        name="folder"
+        isSortable={true}
+        sortKey="folder"
+        sortDirection={sortDirection}
+        onSortPress={onSortPress}
+      >
         {translate('RelativePath')}
       </VirtualTableHeaderCell>
 

--- a/frontend/src/AddMovie/ImportMovie/Import/ImportMovieRow.tsx
+++ b/frontend/src/AddMovie/ImportMovie/Import/ImportMovieRow.tsx
@@ -4,7 +4,11 @@ import VirtualTableRowCell from 'Components/Table/Cells/VirtualTableRowCell';
 import VirtualTableSelectCell from 'Components/Table/Cells/VirtualTableSelectCell';
 import { inputTypes } from 'Helpers/Props';
 import { SelectStateInputProps } from 'typings/props';
-import { ImportItem, MovieLookupResult } from '../ImportMovieTypes';
+import {
+  ImportItem,
+  ImportItemType,
+  MovieLookupResult,
+} from '../ImportMovieTypes';
 import ImportMovieSelectMovie from './SelectMovie/ImportMovieSelectMovie';
 import styles from './ImportMovieRow.css';
 
@@ -16,7 +20,7 @@ interface ImportMovieRowProps {
   readonly onLookup: (opts: {
     id: string;
     term: string;
-    itemType: 'movie' | 'scene';
+    itemType?: ImportItemType;
     topOfQueue: boolean;
   }) => void;
   readonly onMovieSelect: (id: string, movie: MovieLookupResult) => void;

--- a/frontend/src/AddMovie/ImportMovie/Import/ImportMovieTable.tsx
+++ b/frontend/src/AddMovie/ImportMovie/Import/ImportMovieTable.tsx
@@ -1,8 +1,13 @@
 import React, { useEffect, useRef } from 'react';
 import Scroller from 'Components/Scroller/Scroller';
 import { HORIZONTAL } from 'Helpers/Props/scrollDirections';
+import { SortDirection } from 'Helpers/Props/sortDirections';
 import { SelectStateInputProps } from 'typings/props';
-import { ImportItem, MovieLookupResult } from '../ImportMovieTypes';
+import {
+  ImportItem,
+  ImportItemType,
+  MovieLookupResult,
+} from '../ImportMovieTypes';
 import ImportMovieHeader from './ImportMovieHeader';
 import ImportMovieRow from './ImportMovieRow';
 import styles from './ImportMovieTable.css';
@@ -13,13 +18,15 @@ interface ImportMovieTableProps {
   readonly allSelected: boolean;
   readonly allUnselected: boolean;
   readonly selectedState: Record<string, boolean>;
+  readonly sortDirection: SortDirection;
+  readonly onSortPress: () => void;
   readonly onSelectAllChange: (opts: { value: boolean }) => void;
   readonly onSelectedChange: (opts: SelectStateInputProps) => void;
   readonly onRemoveSelectedStateItem: (id: string) => void;
   readonly onLookup: (opts: {
     id: string;
     term: string;
-    itemType: 'movie' | 'scene';
+    itemType?: ImportItemType;
     topOfQueue: boolean;
   }) => void;
   readonly onMovieSelect: (id: string, movie: MovieLookupResult) => void;
@@ -36,6 +43,8 @@ function ImportMovieTable({
   allSelected,
   allUnselected,
   selectedState,
+  sortDirection,
+  onSortPress,
   onSelectAllChange,
   onSelectedChange,
   onRemoveSelectedStateItem,
@@ -96,6 +105,8 @@ function ImportMovieTable({
         <ImportMovieHeader
           allSelected={allSelected}
           allUnselected={allUnselected}
+          sortDirection={sortDirection}
+          onSortPress={onSortPress}
           onSelectAllChange={onSelectAllChange}
         />
 

--- a/frontend/src/AddMovie/ImportMovie/Import/SelectMovie/ImportMovieSearchResult.tsx
+++ b/frontend/src/AddMovie/ImportMovie/Import/SelectMovie/ImportMovieSearchResult.tsx
@@ -24,6 +24,8 @@ function ImportMovieSearchResult({
     year,
     releaseDate,
     studioTitle,
+    performerNames,
+    searchCredits,
     isExisting,
   } = item;
 
@@ -42,6 +44,8 @@ function ImportMovieSearchResult({
           year={year}
           releaseDate={releaseDate}
           studioTitle={studioTitle}
+          performerNames={performerNames}
+          searchCredits={searchCredits}
           isExistingMovie={isExisting}
         />
       </Link>

--- a/frontend/src/AddMovie/ImportMovie/Import/SelectMovie/ImportMovieSelectMovie.tsx
+++ b/frontend/src/AddMovie/ImportMovie/Import/SelectMovie/ImportMovieSelectMovie.tsx
@@ -8,7 +8,11 @@ import LoadingIndicator from 'Components/Loading/LoadingIndicator';
 import Portal from 'Components/Portal';
 import { icons, kinds } from 'Helpers/Props';
 import translate from 'Utilities/String/translate';
-import { ImportItem, MovieLookupResult } from '../../ImportMovieTypes';
+import {
+  ImportItem,
+  ImportItemType,
+  MovieLookupResult,
+} from '../../ImportMovieTypes';
 import ImportMovieSearchResult from './ImportMovieSearchResult';
 import ImportMovieTitle from './ImportMovieTitle';
 import styles from './ImportMovieSelectMovie.css';
@@ -19,7 +23,7 @@ interface ImportMovieSelectMovieProps {
   readonly onLookup: (opts: {
     id: string;
     term: string;
-    itemType: 'movie' | 'scene';
+    itemType?: ImportItemType;
     topOfQueue: boolean;
   }) => void;
   readonly onMovieSelect: (id: string, movie: MovieLookupResult) => void;
@@ -134,6 +138,8 @@ function ImportMovieSelectMovie({
                   year={selectedMovie.year}
                   releaseDate={selectedMovie.releaseDate}
                   studioTitle={selectedMovie.studioTitle}
+                  performerNames={selectedMovie.performerNames}
+                  searchCredits={selectedMovie.searchCredits}
                   isExistingMovie={selectedMovie.isExisting}
                 />
               ) : null}

--- a/frontend/src/AddMovie/ImportMovie/Import/SelectMovie/ImportMovieTitle.css
+++ b/frontend/src/AddMovie/ImportMovie/Import/SelectMovie/ImportMovieTitle.css
@@ -17,3 +17,16 @@
 .existing {
   margin-left: 5px;
 }
+
+.performers {
+  display: inline-flex;
+  align-items: center;
+  flex-shrink: 0;
+  gap: 3px;
+
+  color: var(--disabledColor);
+}
+
+.performerIcon {
+  cursor: default;
+}

--- a/frontend/src/AddMovie/ImportMovie/Import/SelectMovie/ImportMovieTitle.css.d.ts
+++ b/frontend/src/AddMovie/ImportMovie/Import/SelectMovie/ImportMovieTitle.css.d.ts
@@ -1,6 +1,8 @@
 declare namespace ImportMovieTitleCssNamespace {
   export interface IImportMovieTitleCss {
     existing: string;
+    performerIcon: string;
+    performers: string;
     title: string;
     titleContainer: string;
     year: string;

--- a/frontend/src/AddMovie/ImportMovie/Import/SelectMovie/ImportMovieTitle.tsx
+++ b/frontend/src/AddMovie/ImportMovie/Import/SelectMovie/ImportMovieTitle.tsx
@@ -1,9 +1,12 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import Label from 'Components/Label';
 import { kinds } from 'Helpers/Props';
+import { all as allGenders, getGenderDetails } from 'Performer/Gender';
+import PerformerGenderIcon from 'Performer/PerformerGenderIcon';
 import { useUiSettingsValues } from 'Settings/UI/useUiSettings';
 import getRelativeDate from 'Utilities/Date/getRelativeDate';
 import translate from 'Utilities/String/translate';
+import { ImportCredit } from '../../ImportMovieTypes';
 import styles from './ImportMovieTitle.css';
 
 interface ImportMovieTitleProps {
@@ -12,7 +15,39 @@ interface ImportMovieTitleProps {
   year: number;
   releaseDate?: string;
   studioTitle?: string;
+  performerNames?: string[];
+  searchCredits?: ImportCredit[];
   isExistingMovie: boolean;
+}
+
+// Several genders share one glyph, so the icons are deduplicated by the icon
+// they resolve to rather than by the gender string — a scene with two trans
+// performers of different genders still gets a single icon.
+function getGenderRank(gender: string) {
+  const index = (allGenders as string[]).indexOf(gender.toLowerCase());
+
+  // Anything the app doesn't know a glyph for sorts last.
+  return index === -1 ? allGenders.length : index;
+}
+
+function getGenderIcons(credits: ImportCredit[]) {
+  const genders = credits
+    .map((credit) => credit.performer?.gender ?? '')
+    .sort((a, b) => getGenderRank(a) - getGenderRank(b));
+
+  const seen = new Set<unknown>();
+
+  return genders.filter((gender) => {
+    const { icon } = getGenderDetails(gender);
+
+    if (seen.has(icon)) {
+      return false;
+    }
+
+    seen.add(icon);
+
+    return true;
+  });
 }
 
 function ImportMovieTitle({
@@ -21,9 +56,37 @@ function ImportMovieTitle({
   year,
   releaseDate,
   studioTitle,
+  performerNames,
+  searchCredits,
   isExistingMovie,
 }: Readonly<ImportMovieTitleProps>) {
   const { shortDateFormat, showRelativeDates } = useUiSettingsValues();
+
+  // Scenes routinely share a title, so the performers are what tell two
+  // matches apart. The column has no room for the names, so a gender icon per
+  // distinct gender stands in for them and carries the full list on hover.
+  const performers = useMemo(() => {
+    const credits = searchCredits ?? [];
+
+    const names = credits.length
+      ? credits.map((credit) => credit.personName ?? credit.performer?.name)
+      : performerNames;
+
+    const unique = Array.from(
+      new Set((names ?? []).filter((name): name is string => !!name))
+    ).sort((a, b) => a.localeCompare(b));
+
+    if (!unique.length) {
+      return null;
+    }
+
+    return {
+      tooltip: unique.join(', '),
+      // Results the server already has locally come back without credits, so
+      // there is no gender to show — one neutral icon still carries the names.
+      genders: credits.length ? getGenderIcons(credits) : [''],
+    };
+  }, [performerNames, searchCredits]);
 
   let itemDescr = title;
   if (itemType === 'movie' && year) {
@@ -43,6 +106,20 @@ function ImportMovieTitle({
           })}
         </Label>
       )}
+
+      {performers ? (
+        <span className={styles.performers} title={performers.tooltip}>
+          {performers.genders.map((gender) => (
+            <PerformerGenderIcon
+              key={gender || 'unknown'}
+              className={styles.performerIcon}
+              gender={gender}
+              size={13}
+              title={performers.tooltip}
+            />
+          ))}
+        </span>
+      ) : null}
 
       <div className={styles.title}>{itemDescr}</div>
 

--- a/frontend/src/AddMovie/ImportMovie/ImportMovieTypes.ts
+++ b/frontend/src/AddMovie/ImportMovie/ImportMovieTypes.ts
@@ -4,15 +4,33 @@ export interface ImportFile {
   relativePath: string;
 }
 
+// The movies/scenes routes pin the lookup to one type; the bare
+// /add/import/:rootFolderId route leaves it unset so the server infers the
+// type per file.
+export type ImportItemType = 'movie' | 'scene';
+
+// Only the fields the import table reads. Credits carry the performer gender,
+// but the server skips mapping them for results that already exist locally —
+// those fall back to performerNames.
+export interface ImportCredit {
+  personName?: string;
+  performer?: {
+    name?: string;
+    gender?: string;
+  };
+}
+
 export interface MovieLookupResult {
   foreignId: string;
   tmdbId: number;
   tpdbId?: string;
-  itemType: 'movie' | 'scene';
+  itemType: ImportItemType;
   title: string;
   year: number;
   releaseDate?: string;
   studioTitle?: string;
+  performerNames?: string[];
+  searchCredits?: ImportCredit[];
   isExisting: boolean;
 }
 
@@ -21,7 +39,7 @@ export interface ImportItem {
   path: string;
   relativePath: string;
   term: string;
-  itemType: 'movie' | 'scene';
+  itemType?: ImportItemType;
   isFetching: boolean;
   isPopulated: boolean;
   isQueued: boolean;
@@ -36,7 +54,7 @@ export type ImportAction =
   | {
       type: 'INIT_ITEMS';
       files: ImportFile[];
-      itemType: 'movie' | 'scene';
+      itemType?: ImportItemType;
       defaults: { monitor: string; qualityProfileId: number };
     }
   | { type: 'SET_ITEM_FETCHING'; id: string }

--- a/frontend/src/AddMovie/ImportMovie/ImportMovies.tsx
+++ b/frontend/src/AddMovie/ImportMovie/ImportMovies.tsx
@@ -1,19 +1,35 @@
 import React from 'react';
-import { Route, Routes } from 'react-router-dom';
+import { Navigate, Route, Routes } from 'react-router-dom';
 import ImportMovie from './Import/ImportMovie';
 import ImportMovieSelectFolder from './SelectFolder/ImportMovieSelectFolder';
 
 function ImportMovies() {
   return (
     <Routes>
-      <Route path="movies" element={<ImportMovieSelectFolder />} />
+      <Route index={true} element={<Navigate to="scenes" replace={true} />} />
 
-      <Route path="scenes" element={<ImportMovieSelectFolder />} />
+      <Route
+        path="movies"
+        element={<ImportMovieSelectFolder itemType="movie" />}
+      />
 
-      <Route path="movies/:rootFolderId" element={<ImportMovie />} />
+      <Route
+        path="scenes"
+        element={<ImportMovieSelectFolder itemType="scene" />}
+      />
 
-      <Route path="scenes/:rootFolderId" element={<ImportMovie />} />
+      <Route
+        path="movies/:rootFolderId"
+        element={<ImportMovie itemType="movie" />}
+      />
 
+      <Route
+        path="scenes/:rootFolderId"
+        element={<ImportMovie itemType="scene" />}
+      />
+
+      {/* Reached from Settings > Media Management, where the root folder
+          carries no type — the server infers movie vs scene per file. */}
       <Route path=":rootFolderId" element={<ImportMovie />} />
     </Routes>
   );

--- a/frontend/src/AddMovie/ImportMovie/SelectFolder/ImportMovieRootFolderRow.tsx
+++ b/frontend/src/AddMovie/ImportMovie/SelectFolder/ImportMovieRootFolderRow.tsx
@@ -1,5 +1,4 @@
 import React, { useCallback } from 'react';
-import { useLocation } from 'react-router-dom';
 import IconButton from 'Components/Link/IconButton';
 import Link from 'Components/Link/Link';
 import TableRowCell from 'Components/Table/Cells/TableRowCell';
@@ -9,6 +8,7 @@ import { useRefreshRootFolder } from 'RootFolder/useRootFolders';
 import { useNamingSettings } from 'Settings/MediaManagement/Naming/useNamingSettings';
 import formatBytes from 'Utilities/Number/formatBytes';
 import translate from 'Utilities/String/translate';
+import { ImportItemType } from '../ImportMovieTypes';
 import styles from './ImportMovieRootFolderRow.css';
 
 interface ImportFile {
@@ -20,6 +20,7 @@ interface ImportMovieRootFolderRowProps {
   path: string;
   freeSpace?: number;
   importFiles: ImportFile[];
+  itemType: ImportItemType;
 }
 
 function ImportMovieRootFolderRow({
@@ -27,15 +28,15 @@ function ImportMovieRootFolderRow({
   path,
   freeSpace,
   importFiles,
+  itemType,
 }: Readonly<ImportMovieRootFolderRowProps>) {
-  const location = useLocation();
   const { refreshRootFolder } = useRefreshRootFolder();
   const { data: naming } = useNamingSettings();
 
-  const isMovies = location.pathname === '/add/import/movies';
-  const linkTo = isMovies
-    ? `/add/import/movies/${id}`
-    : `/add/import/scenes/${id}`;
+  const linkTo =
+    itemType === 'movie'
+      ? `/add/import/movies/${id}`
+      : `/add/import/scenes/${id}`;
   const importFilesCount = importFiles.length || '-';
 
   const handleRefreshPress = useCallback(() => {

--- a/frontend/src/AddMovie/ImportMovie/SelectFolder/ImportMovieSelectFolder.tsx
+++ b/frontend/src/AddMovie/ImportMovie/SelectFolder/ImportMovieSelectFolder.tsx
@@ -5,7 +5,7 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import Alert from 'Components/Alert';
 import FieldSet from 'Components/FieldSet';
 import FileBrowserModal from 'Components/FileBrowser/FileBrowserModal';
@@ -25,6 +25,7 @@ import useRootFolders, {
   useSortedRootFolders,
 } from 'RootFolder/useRootFolders';
 import translate from 'Utilities/String/translate';
+import { ImportItemType } from '../ImportMovieTypes';
 import ImportMovieRootFolderRow from './ImportMovieRootFolderRow';
 import styles from './ImportMovieSelectFolder.css';
 
@@ -39,9 +40,12 @@ const rootFolderColumns = [
   { name: 'actions', label: () => '', isVisible: true },
 ];
 
-function ImportMovieSelectFolder() {
+interface ImportMovieSelectFolderProps {
+  readonly itemType: ImportItemType;
+}
+
+function ImportMovieSelectFolder({ itemType }: ImportMovieSelectFolderProps) {
   const navigate = useNavigate();
-  const location = useLocation();
 
   const { isFetching, isFetched, error } = useRootFolders();
   const items = useSortedRootFolders();
@@ -60,7 +64,7 @@ function ImportMovieSelectFolder() {
 
   const previousIsAddingRootFolder = usePrevious(isAddingRootFolder);
 
-  const isMovies = location.pathname === '/add/import/movies';
+  const isMovies = itemType === 'movie';
   const importTitle = isMovies ? 'ImportMovies' : 'ImportScenes';
   const hasRootFolders = items.length > 0;
 
@@ -98,9 +102,12 @@ function ImportMovieSelectFolder() {
       !addRootFolderError &&
       newRootFolder
     ) {
-      navigate(`/add/import/movies/${newRootFolder.id}`);
+      navigate(
+        `/add/import/${isMovies ? 'movies' : 'scenes'}/${newRootFolder.id}`
+      );
     }
   }, [
+    isMovies,
     navigate,
     previousIsAddingRootFolder,
     isAddingRootFolder,
@@ -154,6 +161,7 @@ function ImportMovieSelectFolder() {
                           path={rootFolder.path}
                           freeSpace={rootFolder.freeSpace}
                           importFiles={rootFolder.importFiles}
+                          itemType={itemType}
                         />
                       ))}
                     </TableBody>

--- a/frontend/src/AddMovie/ImportMovie/useImportLookupQueue.ts
+++ b/frontend/src/AddMovie/ImportMovie/useImportLookupQueue.ts
@@ -1,12 +1,16 @@
 import React, { useCallback, useRef, useState } from 'react';
 import fetchJson from 'Utilities/Fetch/fetchJson';
 import getQueryPath from 'Utilities/Fetch/getQueryPath';
-import { ImportAction, MovieLookupResult } from './ImportMovieTypes';
+import {
+  ImportAction,
+  ImportItemType,
+  MovieLookupResult,
+} from './ImportMovieTypes';
 
 interface QueueEntry {
   id: string;
   term: string;
-  itemType: 'movie' | 'scene';
+  itemType?: ImportItemType;
 }
 
 interface UseImportLookupQueueResult {
@@ -15,7 +19,7 @@ interface UseImportLookupQueueResult {
     items: {
       id: string;
       term: string;
-      itemType: 'movie' | 'scene';
+      itemType?: ImportItemType;
       isPopulated: boolean;
     }[]
   ) => void;
@@ -49,10 +53,13 @@ function useImportLookupQueue(
     const controller = new AbortController();
     abortRef.current = controller;
 
-    const params = new URLSearchParams({
-      term: entry.term,
-      itemType: entry.itemType,
-    });
+    // An unset itemType is left off the query so the server infers it from
+    // the file name rather than forcing a movie search.
+    const params = new URLSearchParams({ term: entry.term });
+
+    if (entry.itemType) {
+      params.set('itemType', entry.itemType);
+    }
 
     try {
       const results = await fetchJson<MovieLookupResult[], never>({
@@ -129,7 +136,7 @@ function useImportLookupQueue(
       items: {
         id: string;
         term: string;
-        itemType: 'movie' | 'scene';
+        itemType?: ImportItemType;
         isPopulated: boolean;
       }[]
     ) => {

--- a/frontend/src/Performer/PerformerGenderIcon.tsx
+++ b/frontend/src/Performer/PerformerGenderIcon.tsx
@@ -6,15 +6,27 @@ interface PerformerGenderIconProps {
   gender: string;
   size?: number;
   className?: string;
+  // Defaults to the gender itself. Pass a caller-supplied string to describe a
+  // group of icons, or null to leave the tooltip to a wrapping element.
+  title?: string | null;
 }
 
 function PerformerGenderIcon({
   gender,
   size,
   className,
-}: PerformerGenderIconProps) {
+  title,
+}: Readonly<PerformerGenderIconProps>) {
   const icon = getGenderDetails(gender).icon;
-  return <Icon name={icon} size={size} title={gender} className={className} />;
+
+  return (
+    <Icon
+      name={icon}
+      size={size}
+      title={title === undefined ? gender : title}
+      className={className}
+    />
+  );
 }
 
 export default PerformerGenderIcon;


### PR DESCRIPTION
#### Database Migration

NO

#### Description

Sorting and performer identification on the Import Scenes page.

- **Relative Path is sortable**, ascending by default, so the table no longer arrives in disk-scan order. It's the only sortable column — the matched title changes as lookups land, so sorting on it would reshuffle rows mid-scan. Shift-click range select follows the sorted order.
- **Performers on the matched item.** `searchCredits[].performer.gender` is already on the lookup response, so each match shows one `PerformerGenderIcon` per distinct gender with the full performer list on hover. Icons are deduplicated by the *icon* they resolve to, since `getGenderDetails` maps transmale/transfemale/intersex/non-binary to one glyph. They sit before the title so a wrapping title can't drag them onto a second line.

While in here, the untyped import routes this page shares:

- `/add/import` matched no route, so the "Import Existing" buttons on Add New Movie and Add New Scene were dead links. They now point at the right flow.
- `/add/import/:rootFolderId` (Settings → Media Management → Root Folders) silently forced a movie search. Root folders carry no type, so it now omits `itemType` and lets the server infer per file — in a mixed folder, `Anal.Angels.2019.1080p.mkv` matches a movie while dated filenames match scenes.
- `ImportMovie` rendered "Import Movies" and *All movies…* on the scenes route, and adding a root folder from Import Scenes navigated into the movies flow. Both now follow the route.
- The three components that sniffed `location.pathname` for the flow take an explicit `itemType` route prop instead; the exact-match checks would have broken on any new import path.

`PerformerGenderIcon` gains an optional `title` prop — it hardcoded `title={gender}`, which beat the grouped tooltip. It defaults to `gender`, so existing call sites are unchanged.

Scenes already in the library come back from `MapSearchResult` without credits but with `performerNames`; those fall back to one neutral icon carrying the same names.

#### Screenshot(s) (if UI related)

<details>
<!-- paste screenshots below here.-->
<img width="1140" height="447" alt="image" src="https://github.com/user-attachments/assets/7b2d6067-a8e9-4c39-a21f-622ead673b8b" />

<!-- paste screenshots above here.  MAKE SURE THE ARE SFW -->
</details>

#### Todos

- [ ] Tests
- [x] Translation Keys — none added; reuses `RelativePath`, `ImportScenes`, `ImportLibrary` and `AllScenesInPathHaveBeenImported`

#### Issues Fixed or Closed by this PR

- Fixes Whisparr/Whisparr-Eros#822
