### PR TITLE
New: Add After Date on the Studios mass edit page

### DIFF
--- a/frontend/src/Studio/Index/Select/Edit/EditStudiosModalContent.tsx
+++ b/frontend/src/Studio/Index/Select/Edit/EditStudiosModalContent.tsx
@@ -18,6 +18,7 @@ interface SavePayload {
   qualityProfileId?: number;
   rootFolderPath?: string;
   searchOnAdd?: boolean;
+  afterDate?: string;
 }
 
 interface EditStudiosModalContentProps {
@@ -27,6 +28,8 @@ interface EditStudiosModalContentProps {
 }
 
 const NO_CHANGE = 'noChange';
+const SET_DATE = 'setDate';
+const CLEAR_DATE = 'clearDate';
 
 const monitoredOptions = [
   {
@@ -72,7 +75,34 @@ const searchOnAddOptions = [
   },
 ];
 
-function EditStudiosModalContent(props: EditStudiosModalContentProps) {
+// A date box on its own can't say whether a blank means "leave every studio alone"
+// or "clear them all", so the choice is made in a select and the box only appears
+// once the user has asked to set a date.
+const afterDateOptions = [
+  {
+    key: NO_CHANGE,
+    get value() {
+      return translate('NoChange');
+    },
+    disabled: true,
+  },
+  {
+    key: SET_DATE,
+    get value() {
+      return translate('SetDate');
+    },
+  },
+  {
+    key: CLEAR_DATE,
+    get value() {
+      return translate('Clear');
+    },
+  },
+];
+
+function EditStudiosModalContent(
+  props: Readonly<EditStudiosModalContentProps>
+) {
   const { studioIds, onSavePress, onModalClose } = props;
 
   const [monitored, setMonitored] = useState<string | number>(NO_CHANGE);
@@ -89,6 +119,11 @@ function EditStudiosModalContent(props: EditStudiosModalContentProps) {
   );
 
   const [searchOnAdd, setSearchOnAdd] = useState<string | number>(NO_CHANGE);
+
+  const [afterDateMode, setAfterDateMode] = useState<string | number>(
+    NO_CHANGE
+  );
+  const [afterDate, setAfterDate] = useState('');
 
   const save = useCallback(() => {
     let hasChanges = false;
@@ -119,6 +154,14 @@ function EditStudiosModalContent(props: EditStudiosModalContentProps) {
       payload.searchOnAdd = searchOnAdd === 'true';
     }
 
+    if (afterDateMode === CLEAR_DATE) {
+      hasChanges = true;
+      payload.afterDate = '';
+    } else if (afterDateMode === SET_DATE && afterDate) {
+      hasChanges = true;
+      payload.afterDate = afterDate;
+    }
+
     if (hasChanges) {
       onSavePress(payload);
     }
@@ -130,6 +173,8 @@ function EditStudiosModalContent(props: EditStudiosModalContentProps) {
     qualityProfileId,
     rootFolderPath,
     searchOnAdd,
+    afterDateMode,
+    afterDate,
     onSavePress,
     onModalClose,
   ]);
@@ -151,6 +196,12 @@ function EditStudiosModalContent(props: EditStudiosModalContentProps) {
           break;
         case 'searchOnAdd':
           setSearchOnAdd(value);
+          break;
+        case 'afterDateMode':
+          setAfterDateMode(value);
+          break;
+        case 'afterDate':
+          setAfterDate(value as string);
           break;
         default:
           console.warn('EditStudiosModalContent Unknown Input');
@@ -236,6 +287,32 @@ function EditStudiosModalContent(props: EditStudiosModalContentProps) {
             onChange={onInputChange}
           />
         </FormGroup>
+
+        <FormGroup>
+          <FormLabel>{translate('MonitorAfter')}</FormLabel>
+
+          <FormInputGroup
+            type={inputTypes.SELECT}
+            name="afterDateMode"
+            value={afterDateMode}
+            values={afterDateOptions}
+            onChange={onInputChange}
+          />
+        </FormGroup>
+
+        {afterDateMode === SET_DATE ? (
+          <FormGroup>
+            <FormLabel>{translate('Date')}</FormLabel>
+
+            <FormInputGroup
+              type={inputTypes.DATE}
+              name="afterDate"
+              helpText={translate('MonitorAfterStudioHelpText')}
+              value={afterDate}
+              onChange={onInputChange}
+            />
+          </FormGroup>
+        ) : null}
       </ModalBody>
 
       <ModalFooter className={styles.modalFooter}>

--- a/frontend/src/Studio/Index/Select/Edit/useEditStudiosModalMutation.ts
+++ b/frontend/src/Studio/Index/Select/Edit/useEditStudiosModalMutation.ts
@@ -9,6 +9,7 @@ interface StudioEditorPayload {
   qualityProfileId?: number;
   rootFolderPath?: string;
   searchOnAdd?: boolean;
+  afterDate?: string;
   tags?: number[];
   applyTags?: 'add' | 'remove' | 'replace';
 }

--- a/frontend/src/Studio/Index/Select/StudioIndexSelectFooter.tsx
+++ b/frontend/src/Studio/Index/Select/StudioIndexSelectFooter.tsx
@@ -19,6 +19,7 @@ interface SavePayload {
   qualityProfileId?: number;
   rootFolderPath?: string;
   searchOnAdd?: boolean;
+  afterDate?: string;
 }
 
 interface StudioIndexSelectFooterProps {

--- a/src/NzbDrone.Api.Test/v3/Studios/StudioEditorControllerFixture.cs
+++ b/src/NzbDrone.Api.Test/v3/Studios/StudioEditorControllerFixture.cs
@@ -1,0 +1,138 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using FluentValidation;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using NUnit.Framework;
+using NzbDrone.Core.Movies.Studios;
+using NzbDrone.Core.Profiles.Qualities;
+using NzbDrone.Core.RootFolders;
+using NzbDrone.Test.Common;
+using Whisparr.Api.V3.Studios;
+
+namespace NzbDrone.Api.Test.v3.Studios
+{
+    [Parallelizable(ParallelScope.Self)]
+    public class StudioEditorControllerFixture : TestBase<StudioEditorController>
+    {
+        private static readonly string RootFolder = @"C:\Movies".AsOsAgnostic();
+
+        private List<Studio> _studios;
+
+        [SetUp]
+        public void Setup()
+        {
+            _studios = new List<Studio>
+            {
+                new Studio { Id = 1, ForeignId = "studio-1", Title = "Studio 1", QualityProfileId = 1, RootFolderPath = RootFolder },
+                new Studio { Id = 2, ForeignId = "studio-2", Title = "Studio 2", QualityProfileId = 1, RootFolderPath = RootFolder }
+            };
+
+            Mocker.GetMock<IQualityProfileService>()
+                .Setup(s => s.Exists(1))
+                .Returns(true);
+
+            Mocker.GetMock<IRootFolderService>()
+                .Setup(s => s.All())
+                .Returns(new List<RootFolder> { new RootFolder { Path = RootFolder } });
+
+            Mocker.GetMock<IStudioService>()
+                .Setup(s => s.GetStudios(It.IsAny<IEnumerable<int>>()))
+                .Returns(_studios);
+
+            Mocker.GetMock<IStudioService>()
+                .Setup(s => s.Update(It.IsAny<List<Studio>>()))
+                .Returns<List<Studio>>(s => s);
+        }
+
+        private static StudioEditorResource GivenResource()
+        {
+            return new StudioEditorResource { StudioIds = new List<int> { 1, 2 } };
+        }
+
+        private void GivenExistingAfterDates()
+        {
+            _studios[0].AfterDate = new DateTime(2020, 1, 1);
+            _studios[1].AfterDate = new DateTime(2021, 2, 2);
+        }
+
+        [Test]
+        public void should_set_the_after_date_on_every_studio()
+        {
+            var resource = GivenResource();
+            resource.AfterDate = "2024-06-01";
+
+            Subject.SaveAll(resource);
+
+            _studios.Should().OnlyContain(s => s.AfterDate == new DateTime(2024, 6, 1));
+        }
+
+        [Test]
+        public void should_clear_the_after_date_when_given_an_empty_string()
+        {
+            GivenExistingAfterDates();
+
+            var resource = GivenResource();
+            resource.AfterDate = string.Empty;
+
+            Subject.SaveAll(resource);
+
+            _studios.Should().OnlyContain(s => s.AfterDate == null);
+        }
+
+        [Test]
+        public void should_leave_each_after_date_alone_when_it_is_not_in_the_request()
+        {
+            GivenExistingAfterDates();
+
+            Subject.SaveAll(GivenResource());
+
+            _studios[0].AfterDate.Should().Be(new DateTime(2020, 1, 1));
+            _studios[1].AfterDate.Should().Be(new DateTime(2021, 2, 2));
+        }
+
+        [Test]
+        public void should_reject_an_after_date_that_cannot_be_parsed()
+        {
+            GivenExistingAfterDates();
+
+            var resource = GivenResource();
+            resource.AfterDate = "not-a-date";
+
+            // Rejecting outright matters more than usual here: falling through would clear
+            // the date on every selected studio instead of setting the one the user typed.
+            Assert.Throws<ValidationException>(() => Subject.SaveAll(resource));
+
+            _studios[0].AfterDate.Should().Be(new DateTime(2020, 1, 1));
+            Mocker.GetMock<IStudioService>().Verify(s => s.Update(It.IsAny<List<Studio>>()), Times.Never());
+        }
+
+        [Test]
+        public void should_apply_movies_monitored()
+        {
+            var resource = GivenResource();
+            resource.MoviesMonitored = true;
+
+            Subject.SaveAll(resource);
+
+            _studios.Should().OnlyContain(s => s.MoviesMonitored);
+        }
+
+        [Test]
+        public void should_return_the_edited_studios_as_resources()
+        {
+            var resource = GivenResource();
+            resource.MoviesMonitored = true;
+
+            var response = (AcceptedResult)Subject.SaveAll(resource);
+
+            // The client replaces its cached studios with this body, so it has to be
+            // mapped resources rather than the raw models.
+            var resources = response.Value.Should().BeOfType<List<StudioResource>>().Subject;
+            resources.Select(s => s.Id).Should().BeEquivalentTo(new[] { 1, 2 });
+            resources.Should().OnlyContain(s => s.MoviesMonitored);
+        }
+    }
+}

--- a/src/NzbDrone.Api.Test/v3/Studios/StudioResourceFixture.cs
+++ b/src/NzbDrone.Api.Test/v3/Studios/StudioResourceFixture.cs
@@ -1,3 +1,4 @@
+using System;
 using FluentAssertions;
 using NUnit.Framework;
 using NzbDrone.Core.Movies.Studios;
@@ -44,6 +45,36 @@ namespace NzbDrone.Api.Test.v3.Studios
             resource.WhisparrMonitorNewItems = monitorNewItems;
 
             resource.ToModel(existing).WhisparrMonitorNewItems.Should().Be(monitorNewItems);
+        }
+
+        [Test]
+        public void should_round_trip_the_after_date_regardless_of_time_zone()
+        {
+            var model = new Studio
+            {
+                Id = 1,
+                ForeignId = "studio-foreign-id",
+                Title = "Some Studio",
+                SearchTitle = "Some Studio",
+
+                // Dapper hands every DateTime back as UTC, so shifting to local time on
+                // the way out walked the date back a day on every save west of UTC.
+                AfterDate = new DateTime(2024, 6, 1, 0, 0, 0, DateTimeKind.Utc)
+            };
+
+            var resource = model.ToResource();
+
+            resource.AfterDate.Should().Be("2024-06-01");
+            resource.ToModel().AfterDate.Should().Be(new DateTime(2024, 6, 1));
+        }
+
+        [Test]
+        public void should_round_trip_an_unset_after_date()
+        {
+            var resource = new Studio { Id = 1, ForeignId = "studio-foreign-id", Title = "Some Studio", SearchTitle = "Some Studio" }.ToResource();
+
+            resource.AfterDate.Should().BeNull();
+            resource.ToModel().AfterDate.Should().BeNull();
         }
     }
 }

--- a/src/NzbDrone.Core/Localization/Core/en.json
+++ b/src/NzbDrone.Core/Localization/Core/en.json
@@ -2067,6 +2067,7 @@
   "SelectReleaseGroup": "Select Release Group",
   "SelectRow": "Select Row",
   "SendAnonymousUsageData": "Send Anonymous Usage Data",
+  "SetDate": "Set Date",
   "SetIndexerFlags": "Set Indexer Flags",
   "SetIndexerFlagsModalTitle": "{modalTitle} - Set Indexer Flags",
   "SetPermissions": "Set Permissions",

--- a/src/Whisparr.Api.V3/Studios/StudioEditorController.cs
+++ b/src/Whisparr.Api.V3/Studios/StudioEditorController.cs
@@ -1,5 +1,8 @@
+using System;
 using System.Collections.Generic;
+using System.Globalization;
 using FluentValidation;
+using FluentValidation.Results;
 using Microsoft.AspNetCore.Mvc;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.DecisionEngine.Specifications;
@@ -37,11 +40,31 @@ namespace Whisparr.Api.V3.Studios
         {
             var studiosToUpdate = _studioService.GetStudios(resource.StudioIds);
 
+            // A bulk date has three states the wire can't express with a plain DateTime?:
+            // absent leaves each studio's own date alone, empty clears it, and anything
+            // else has to parse here rather than silently clearing every selected studio.
+            DateTime? afterDate = null;
+
+            if (resource.AfterDate.IsNotNullOrWhiteSpace())
+            {
+                if (!DateTime.TryParse(resource.AfterDate, CultureInfo.InvariantCulture, DateTimeStyles.None, out var parsedAfterDate))
+                {
+                    throw new ValidationException(new[] { new ValidationFailure(nameof(resource.AfterDate), $"Invalid after date: {resource.AfterDate}") });
+                }
+
+                afterDate = parsedAfterDate;
+            }
+
             foreach (var studios in studiosToUpdate)
             {
                 if (resource.Monitored.HasValue)
                 {
                     studios.Monitored = resource.Monitored.Value;
+                }
+
+                if (resource.MoviesMonitored.HasValue)
+                {
+                    studios.MoviesMonitored = resource.MoviesMonitored.Value;
                 }
 
                 if (resource.QualityProfileId.HasValue)
@@ -57,6 +80,11 @@ namespace Whisparr.Api.V3.Studios
                 if (resource.SearchOnAdd.HasValue)
                 {
                     studios.SearchOnAdd = resource.SearchOnAdd.Value;
+                }
+
+                if (resource.AfterDate != null)
+                {
+                    studios.AfterDate = afterDate;
                 }
 
                 if (resource.Tags != null)

--- a/src/Whisparr.Api.V3/Studios/StudioEditorResource.cs
+++ b/src/Whisparr.Api.V3/Studios/StudioEditorResource.cs
@@ -23,6 +23,9 @@ namespace Whisparr.Api.V3.Studios
         /// <summary>Whether to search for new items when added to studio</summary>
         public bool? SearchOnAdd { get; set; }
 
+        /// <summary>The date to only add items after, as yyyy-MM-dd. Omit to leave the studios' existing dates alone, or send an empty string to clear them</summary>
+        public string AfterDate { get; set; }
+
         /// <summary>The tags to apply to the studios</summary>
         public List<int> Tags { get; set; }
 

--- a/src/Whisparr.Api.V3/Studios/StudioResource.cs
+++ b/src/Whisparr.Api.V3/Studios/StudioResource.cs
@@ -64,7 +64,7 @@ namespace Whisparr.Api.V3.Studios
                 MoviesMonitored = model.MoviesMonitored,
                 WhisparrMonitorNewItems = model.WhisparrMonitorNewItems,
                 Status = model.Status,
-                AfterDate = model.AfterDate?.ToLocalTime().ToString("yyyy-MM-dd"),
+                AfterDate = model.AfterDate?.ToString("yyyy-MM-dd"),
                 Images = model.Images,
                 QualityProfileId = model.QualityProfileId,
                 RootFolderPath = model.RootFolderPath,


### PR DESCRIPTION
#### Database Migration

NO

#### Description

A studio's after date could only be set one studio at a time. It now joins the other fields on the Studios mass edit page.

A plain date box can't sit alongside the other bulk fields, because blank would have to mean both "leave every studio alone" and "clear them all". The date is chosen in a select instead — **No Change / Set Date / Clear** — and the box only appears once *Set Date* is picked. On the wire an absent `afterDate` leaves each studio's own date alone, an empty string clears it, and anything else has to parse or the request is rejected rather than silently clearing every selected studio.

Two fixes fall out of the same code, both outside issue 969 but on the lines this touches:

- The editor never applied `MoviesMonitored`, though `StudioEditorResource` declared it and the mass edit modal had been sending it all along.
- Dapper hands every `DateTime` back as UTC, so mapping `AfterDate` through `ToLocalTime()` walked the date back a day on each save west of UTC. That hit the single-studio edit page too.

Performers are deliberately out of scope: they have no `AfterDate` field at all, so supporting them means a column, a migration and new exclusion logic in `AddMovieService` keyed on a scene's credited performers. Tracked separately in Whisparr/Whisparr-Eros#868.

Verified against a live instance as well as the unit tests: setting a date through the modal persisted it as typed (confirming the timezone fix end to end), *Clear* emptied only the selected studios, and a malformed date returned 400 with every studio's existing date intact.

#### Screenshot(s) (if UI related)

<details>
<img width="703" height="584" alt="image" src="https://github.com/user-attachments/assets/216ab3e7-411b-4522-9f0b-7a73a5f7b097" />

</details>

#### Todos

- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)

#### Issues Fixed or Closed by this PR

- Fixes Whisparr/Whisparr-Eros#759
