### PR TITLE
New: Add scene metadata to the webhook and Notifiarr payloads

### DIFF
--- a/src/NzbDrone.Core.Test/NotificationTests/WebhookTests/WebhookFixture.cs
+++ b/src/NzbDrone.Core.Test/NotificationTests/WebhookTests/WebhookFixture.cs
@@ -1,0 +1,146 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+using NzbDrone.Core.MediaCover;
+using NzbDrone.Core.Movies;
+using NzbDrone.Core.Movies.Studios;
+using NzbDrone.Core.Notifications;
+using NzbDrone.Core.Notifications.Webhook;
+using NzbDrone.Core.Tags;
+using NzbDrone.Core.Test.Framework;
+using NzbDrone.Test.Common;
+
+namespace NzbDrone.Core.Test.NotificationTests.WebhookTests
+{
+    [TestFixture]
+    public class WebhookFixture : CoreTest<Webhook>
+    {
+        private WebhookPayload _payload;
+
+        [SetUp]
+        public void Setup()
+        {
+            Subject.Definition = new NotificationDefinition { Settings = new WebhookSettings() };
+
+            Mocker.GetMock<IWebhookProxy>()
+                .Setup(s => s.SendWebhook(It.IsAny<WebhookPayload>(), It.IsAny<WebhookSettings>()))
+                .Callback<WebhookPayload, WebhookSettings>((payload, _) => _payload = payload);
+
+            Mocker.GetMock<ITagRepository>()
+                .Setup(s => s.GetTags(It.IsAny<HashSet<int>>()))
+                .Returns(new List<Tag>());
+        }
+
+        private Movie GivenMovie(MovieMetadata metadata)
+        {
+            return new Movie
+            {
+                Id = 1,
+                Path = @"C:\Test\Scene".AsOsAgnostic(),
+                MovieMetadata = metadata,
+                AddOptions = new AddMovieOptions()
+            };
+        }
+
+        private WebhookMovie AddedMovie(Movie movie)
+        {
+            Subject.OnMovieAdded(movie);
+
+            return ((WebhookAddedPayload)_payload).Movie;
+        }
+
+        [Test]
+        public void should_map_scene_metadata_onto_the_payload()
+        {
+            var movie = GivenMovie(new MovieMetadata
+            {
+                Title = "Test Scene",
+                ReleaseDateUtc = new DateTime(2024, 5, 6),
+                StudioForeignId = "studio-1",
+                StudioTitle = "Test Studio",
+                TpdbId = "tpdb-1",
+                Runtime = 42,
+                Website = "https://example.com/test-scene",
+                PerformerNames = new List<string> { "First Performer", "Second Performer" },
+                Genres = new List<string> { "test-genre" },
+                ItemType = ItemType.Scene
+            });
+
+            Mocker.GetMock<IStudioService>()
+                .Setup(s => s.FindByForeignId("studio-1"))
+                .Returns(new Studio { ForeignId = "studio-1", Network = "Test Network" });
+
+            var payloadMovie = AddedMovie(movie);
+
+            payloadMovie.StudioTitle.Should().Be("Test Studio");
+            payloadMovie.Network.Should().Be("Test Network");
+            payloadMovie.Performers.Should().BeEquivalentTo("First Performer", "Second Performer");
+            payloadMovie.Runtime.Should().Be(42);
+            payloadMovie.Website.Should().Be("https://example.com/test-scene");
+            payloadMovie.TpdbId.Should().Be("tpdb-1");
+            payloadMovie.ReleaseDate.Should().Be("2024-05-06");
+            payloadMovie.ItemType.Should().Be("Scene");
+        }
+
+        // A null release date used to dereference Nullable<DateTime>.Value and throw, taking down
+        // every notification for the item rather than just omitting the date.
+        [Test]
+        public void should_send_a_null_release_date_when_the_item_has_none()
+        {
+            var movie = GivenMovie(new MovieMetadata { Title = "Undated", ReleaseDateUtc = null });
+
+            var payloadMovie = AddedMovie(movie);
+
+            payloadMovie.ReleaseDate.Should().BeNull();
+        }
+
+        [Test]
+        public void should_not_look_up_a_studio_when_the_item_has_no_studio()
+        {
+            var movie = GivenMovie(new MovieMetadata { Title = "Studioless", StudioForeignId = null });
+
+            var payloadMovie = AddedMovie(movie);
+
+            payloadMovie.Network.Should().BeNull();
+
+            Mocker.GetMock<IStudioService>()
+                .Verify(s => s.FindByForeignId(It.IsAny<string>()), Times.Never());
+        }
+
+        [Test]
+        public void should_send_a_null_network_when_the_studio_is_not_in_the_library()
+        {
+            var movie = GivenMovie(new MovieMetadata { Title = "Unlinked", StudioForeignId = "studio-1" });
+
+            Mocker.GetMock<IStudioService>()
+                .Setup(s => s.FindByForeignId("studio-1"))
+                .Returns((Studio)null);
+
+            var payloadMovie = AddedMovie(movie);
+
+            payloadMovie.Network.Should().BeNull();
+        }
+
+        [Test]
+        public void should_send_local_and_remote_image_urls()
+        {
+            var movie = GivenMovie(new MovieMetadata
+            {
+                Title = "Imaged",
+                Images = new List<MediaCover.MediaCover>
+                {
+                    new MediaCover.MediaCover(MediaCoverTypes.Poster, "https://cdn.example.com/poster.jpg")
+                }
+            });
+
+            var payloadMovie = AddedMovie(movie);
+
+            payloadMovie.Images.Should().HaveCount(1);
+            payloadMovie.Images.Single().CoverType.Should().Be(MediaCoverTypes.Poster);
+            payloadMovie.Images.Single().RemoteUrl.Should().Be("https://cdn.example.com/poster.jpg");
+        }
+    }
+}

--- a/src/NzbDrone.Core/Notifications/Notifiarr/Notifiarr.cs
+++ b/src/NzbDrone.Core/Notifications/Notifiarr/Notifiarr.cs
@@ -6,6 +6,7 @@ using NzbDrone.Core.Localization;
 using NzbDrone.Core.MediaCover;
 using NzbDrone.Core.MediaFiles;
 using NzbDrone.Core.Movies;
+using NzbDrone.Core.Movies.Studios;
 using NzbDrone.Core.Notifications.Webhook;
 using NzbDrone.Core.Tags;
 using NzbDrone.Core.Validation;
@@ -16,8 +17,8 @@ namespace NzbDrone.Core.Notifications.Notifiarr
     {
         private readonly INotifiarrProxy _proxy;
 
-        public Notifiarr(INotifiarrProxy proxy, IConfigFileProvider configFileProvider, IConfigService configService, ILocalizationService localizationService, ITagRepository tagRepository, IMapCoversToLocal mediaCoverService)
-            : base(configFileProvider, configService, localizationService, tagRepository, mediaCoverService)
+        public Notifiarr(INotifiarrProxy proxy, IConfigFileProvider configFileProvider, IConfigService configService, ILocalizationService localizationService, ITagRepository tagRepository, IMapCoversToLocal mediaCoverService, IStudioService studioService)
+            : base(configFileProvider, configService, localizationService, tagRepository, mediaCoverService, studioService)
         {
             _proxy = proxy;
         }

--- a/src/NzbDrone.Core/Notifications/Webhook/Webhook.cs
+++ b/src/NzbDrone.Core/Notifications/Webhook/Webhook.cs
@@ -6,6 +6,7 @@ using NzbDrone.Core.Localization;
 using NzbDrone.Core.MediaCover;
 using NzbDrone.Core.MediaFiles;
 using NzbDrone.Core.Movies;
+using NzbDrone.Core.Movies.Studios;
 using NzbDrone.Core.Tags;
 using NzbDrone.Core.Validation;
 
@@ -15,8 +16,8 @@ namespace NzbDrone.Core.Notifications.Webhook
     {
         private readonly IWebhookProxy _proxy;
 
-        public Webhook(IWebhookProxy proxy, IConfigFileProvider configFileProvider, IConfigService configService, ILocalizationService localizationService, ITagRepository tagRepository, IMapCoversToLocal mediaCoverService)
-            : base(configFileProvider, configService, localizationService, tagRepository, mediaCoverService)
+        public Webhook(IWebhookProxy proxy, IConfigFileProvider configFileProvider, IConfigService configService, ILocalizationService localizationService, ITagRepository tagRepository, IMapCoversToLocal mediaCoverService, IStudioService studioService)
+            : base(configFileProvider, configService, localizationService, tagRepository, mediaCoverService, studioService)
         {
             _proxy = proxy;
         }

--- a/src/NzbDrone.Core/Notifications/Webhook/WebhookBase.cs
+++ b/src/NzbDrone.Core/Notifications/Webhook/WebhookBase.cs
@@ -7,6 +7,7 @@ using NzbDrone.Core.Localization;
 using NzbDrone.Core.MediaCover;
 using NzbDrone.Core.MediaFiles;
 using NzbDrone.Core.Movies;
+using NzbDrone.Core.Movies.Studios;
 using NzbDrone.Core.Tags;
 
 namespace NzbDrone.Core.Notifications.Webhook
@@ -19,14 +20,16 @@ namespace NzbDrone.Core.Notifications.Webhook
         protected readonly ILocalizationService _localizationService;
         private readonly ITagRepository _tagRepository;
         private readonly IMapCoversToLocal _mediaCoverService;
+        private readonly IStudioService _studioService;
 
-        protected WebhookBase(IConfigFileProvider configFileProvider, IConfigService configService, ILocalizationService localizationService, ITagRepository tagRepository, IMapCoversToLocal mediaCoverService)
+        protected WebhookBase(IConfigFileProvider configFileProvider, IConfigService configService, ILocalizationService localizationService, ITagRepository tagRepository, IMapCoversToLocal mediaCoverService, IStudioService studioService)
         {
             _configFileProvider = configFileProvider;
             _configService = configService;
             _localizationService = localizationService;
             _tagRepository = tagRepository;
             _mediaCoverService = mediaCoverService;
+            _studioService = studioService;
         }
 
         protected WebhookGrabPayload BuildOnGrabPayload(GrabMessage message)
@@ -217,6 +220,13 @@ namespace NzbDrone.Core.Notifications.Webhook
                     Year = 1970,
                     FolderPath = "C:\\testpath",
                     ReleaseDate = "1970-01-01",
+                    ItemType = ItemType.Scene.ToString(),
+                    Runtime = 42,
+                    Website = "https://example.com/test-title",
+                    StudioTitle = "Test Studio",
+                    Network = "Test Network",
+                    Performers = new List<string> { "Test Performer" },
+                    Genres = new List<string> { "test-genre" },
                     Tags = new List<string> { "test-tag" }
                 },
                 RemoteMovie = new WebhookRemoteMovie
@@ -247,7 +257,19 @@ namespace NzbDrone.Core.Notifications.Webhook
 
             _mediaCoverService.ConvertToLocalUrls(movie.Id, movie.MovieMetadata.Value.Images);
 
-            return new WebhookMovie(movie, GetTagLabels(movie));
+            return new WebhookMovie(movie, GetTagLabels(movie), GetNetwork(movie));
+        }
+
+        private string GetNetwork(Movie movie)
+        {
+            var studioForeignId = movie.MovieMetadata.Value.StudioForeignId;
+
+            if (studioForeignId.IsNullOrWhiteSpace())
+            {
+                return null;
+            }
+
+            return _studioService.FindByForeignId(studioForeignId)?.Network;
         }
 
         private List<string> GetTagLabels(Movie movie)

--- a/src/NzbDrone.Core/Notifications/Webhook/WebhookMovie.cs
+++ b/src/NzbDrone.Core/Notifications/Webhook/WebhookMovie.cs
@@ -17,8 +17,14 @@ namespace NzbDrone.Core.Notifications.Webhook
         public int TmdbId { get; set; }
         public string ImdbId { get; set; }
         public string StashId { get; set; }
+        public string TpdbId { get; set; }
         public string Overview { get; set; }
         public string ItemType { get; set; }
+        public int Runtime { get; set; }
+        public string Website { get; set; }
+        public string StudioTitle { get; set; }
+        public string Network { get; set; }
+        public List<string> Performers { get; set; }
         public List<string> Genres { get; set; }
         public List<WebhookImage> Images { get; set; }
         public List<string> Tags { get; set; }
@@ -27,25 +33,31 @@ namespace NzbDrone.Core.Notifications.Webhook
         {
         }
 
-        public WebhookMovie(Movie movie, List<string> tags)
+        public WebhookMovie(Movie movie, List<string> tags, string network)
         {
             Id = movie.Id;
             Title = movie.Title;
             Year = movie.Year;
-            ReleaseDate = movie.MovieMetadata.Value.ReleaseDateUtc.Value.ToString("yyyy-MM-dd");
+            ReleaseDate = movie.MovieMetadata.Value.ReleaseDateUtc?.ToString("yyyy-MM-dd");
             FolderPath = movie.Path;
             TmdbId = movie.TmdbId;
             ImdbId = movie.ImdbId;
             StashId = movie.MovieMetadata.Value.StashId;
+            TpdbId = movie.MovieMetadata.Value.TpdbId;
             Overview = movie.MovieMetadata.Value.Overview;
+            Runtime = movie.MovieMetadata.Value.Runtime;
+            Website = movie.MovieMetadata.Value.Website;
+            StudioTitle = movie.MovieMetadata.Value.StudioTitle;
+            Network = network;
+            Performers = movie.MovieMetadata.Value.PerformerNames;
             Genres = movie.MovieMetadata.Value.Genres;
             Images = movie.MovieMetadata.Value.Images.Select(i => new WebhookImage(i)).ToList();
             Tags = tags;
             ItemType = movie.MovieMetadata.Value.ItemType.ToString();
         }
 
-        public WebhookMovie(Movie movie, MovieFile movieFile, List<string> tags)
-            : this(movie, tags)
+        public WebhookMovie(Movie movie, MovieFile movieFile, List<string> tags, string network)
+            : this(movie, tags, network)
         {
             FilePath = Path.Combine(movie.Path, movieFile.RelativePath);
         }


### PR DESCRIPTION
#### Database Migration

NO

#### Description

Adds `studioTitle`, `network`, `performers`, `runtime`, `website` and `tpdbId` to the movie object in the Webhook and Notifiarr payloads. Additive only — nothing renamed or removed, so existing consumers are unaffected.

Everything except `network` comes from columns already loaded with `MovieMetadata`. `network` lives on `Studio`, so `WebhookBase` now takes `IStudioService` and resolves it from `StudioForeignId`; it's null when the item has no studio or the studio isn't in the library. The test payload was updated to match the real shape.

Of the nine fields in the issue, poster/banner already ship as `images[]` (with both `url` and `remoteUrl`), scene tags as `genres[]`, and air date as `releaseDate` — so nothing was added for those.

Also fixes an unrelated NRE in the same file: a null `ReleaseDateUtc` was dereferenced directly, which threw and killed every notification for an undated item instead of just omitting the date.

#### Todos

- [x] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)

#### Issues Fixed or Closed by this PR

- Fixes Whisparr/Whisparr-Eros#762
