### PR TITLE
Fixed: Return 409 instead of 500 for import exclusions

### DIFF
--- a/src/NzbDrone.Api.Test/ErrorManagement/WhisparrErrorPipelineFixture.cs
+++ b/src/NzbDrone.Api.Test/ErrorManagement/WhisparrErrorPipelineFixture.cs
@@ -1,0 +1,143 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Text;
+using FluentAssertions;
+using Microsoft.AspNetCore.Diagnostics;
+using Microsoft.AspNetCore.Http;
+using NLog;
+using NLog.Config;
+using NLog.Targets;
+using NUnit.Framework;
+using NzbDrone.Core.Datastore;
+using NzbDrone.Core.Exceptions;
+using NzbDrone.Test.Common;
+using Whisparr.Http.ErrorManagement;
+
+namespace NzbDrone.Api.Test.ErrorManagement
+{
+    [TestFixture]
+    public class WhisparrErrorPipelineFixture : TestBase<WhisparrErrorPipeline>
+    {
+        private CapturingTarget _capturedLogs;
+        private LoggingRule _capturingRule;
+
+        [SetUp]
+        public void Setup()
+        {
+            // ExceptionVerification only sees logs once another fixture has run first, so capture
+            // the pipeline's own log events directly.
+            _capturedLogs = new CapturingTarget();
+            _capturingRule = new LoggingRule("*", LogLevel.Trace, _capturedLogs);
+
+            var config = LogManager.Configuration;
+            config.AddTarget("WhisparrErrorPipelineFixture", _capturedLogs);
+            config.LoggingRules.Insert(0, _capturingRule);
+            LogManager.Configuration = config;
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            var config = LogManager.Configuration;
+            config.LoggingRules.Remove(_capturingRule);
+            config.RemoveTarget("WhisparrErrorPipelineFixture");
+            LogManager.Configuration = config;
+        }
+
+        private static HttpContext GetHttpContext(Exception exception)
+        {
+            var httpContext = new DefaultHttpContext();
+
+            httpContext.Request.Method = "POST";
+            httpContext.Request.Path = "/api/v3/movie";
+            httpContext.Response.Body = new MemoryStream();
+            httpContext.Features.Set<IExceptionHandlerPathFeature>(new ExceptionHandlerFeature
+            {
+                Error = exception,
+                Path = httpContext.Request.Path
+            });
+
+            return httpContext;
+        }
+
+        private static string GetBody(HttpContext context)
+        {
+            context.Response.Body.Position = 0;
+
+            using var reader = new StreamReader(context.Response.Body, Encoding.UTF8);
+
+            return reader.ReadToEnd();
+        }
+
+        private HttpContext WhenExceptionIsHandled(Exception exception)
+        {
+            var context = GetHttpContext(exception);
+
+            Subject.HandleException(context).GetAwaiter().GetResult();
+
+            return context;
+        }
+
+        [Test]
+        public void should_return_conflict_for_excluded_exception()
+        {
+            var context = WhenExceptionIsHandled(new ExcludedException("Studio: [Some Studio] has been excluded"));
+
+            context.Response.StatusCode.Should().Be((int)HttpStatusCode.Conflict);
+        }
+
+        [Test]
+        public void should_return_message_without_stack_trace_for_excluded_exception()
+        {
+            var context = WhenExceptionIsHandled(new ExcludedException("Studio: [Some Studio] has been excluded"));
+
+            var body = GetBody(context);
+
+            body.Should().Contain("Studio: [Some Studio] has been excluded");
+            body.Should().NotContain("description");
+            body.Should().NotContain("NzbDrone.Core.Exceptions.ExcludedException");
+        }
+
+        [Test]
+        public void should_log_excluded_exception_below_warn()
+        {
+            WhenExceptionIsHandled(new ExcludedException("Studio: [Some Studio] has been excluded"));
+
+            _capturedLogs.Events.Should().Contain(e => e.Level == LogLevel.Info);
+            _capturedLogs.Events.Should().NotContain(e => e.Level >= LogLevel.Warn);
+        }
+
+        [Test]
+        public void should_still_return_internal_server_error_for_unhandled_exception()
+        {
+            var context = WhenExceptionIsHandled(new InvalidOperationException("Something actually broke"));
+
+            context.Response.StatusCode.Should().Be((int)HttpStatusCode.InternalServerError);
+            GetBody(context).Should().Contain("Something actually broke");
+
+            _capturedLogs.Events.Should().Contain(e => e.Level == LogLevel.Fatal);
+
+            ExceptionVerification.ExpectedFatals(1);
+        }
+
+        [Test]
+        public void should_return_not_found_for_model_not_found_exception()
+        {
+            var context = WhenExceptionIsHandled(new ModelNotFoundException(typeof(object), 1));
+
+            context.Response.StatusCode.Should().Be((int)HttpStatusCode.NotFound);
+        }
+
+        private sealed class CapturingTarget : Target
+        {
+            public List<LogEventInfo> Events { get; } = new List<LogEventInfo>();
+
+            protected override void Write(LogEventInfo logEvent)
+            {
+                Events.Add(logEvent);
+            }
+        }
+    }
+}

--- a/src/Whisparr.Http/ErrorManagement/WhisparrErrorPipeline.cs
+++ b/src/Whisparr.Http/ErrorManagement/WhisparrErrorPipeline.cs
@@ -56,6 +56,13 @@ namespace Whisparr.Http.ErrorManagement
             {
                 statusCode = clientException.StatusCode;
             }
+            else if (exception is ExcludedException excludedException)
+            {
+                _logger.Info("Request refused by exclusion rules. {0} {1}: {2}", context.Request.Method, context.Request.Path, excludedException.Message);
+
+                errorModel.Description = null;
+                statusCode = HttpStatusCode.Conflict;
+            }
             else if (exception is ModelNotFoundException)
             {
                 statusCode = HttpStatusCode.NotFound;

--- a/src/Whisparr.Http/ErrorManagement/WhisparrErrorPipeline.cs
+++ b/src/Whisparr.Http/ErrorManagement/WhisparrErrorPipeline.cs
@@ -5,6 +5,7 @@ using FluentValidation;
 using Microsoft.AspNetCore.Diagnostics;
 using Microsoft.AspNetCore.Http;
 using NLog;
+using NzbDrone.Common.Extensions;
 using NzbDrone.Common.Serializer;
 using NzbDrone.Core.Datastore;
 using NzbDrone.Core.Exceptions;
@@ -58,7 +59,7 @@ namespace Whisparr.Http.ErrorManagement
             }
             else if (exception is ExcludedException excludedException)
             {
-                _logger.Info("Request refused by exclusion rules. {0} {1}: {2}", context.Request.Method, context.Request.Path, excludedException.Message);
+                _logger.Info("Request refused by exclusion rules. {0} {1}: {2}", context.Request.Method.ForLog(), context.Request.Path.ToString().ForLog(), excludedException.Message.ForLog());
 
                 errorModel.Description = null;
                 statusCode = HttpStatusCode.Conflict;


### PR DESCRIPTION
#### Database Migration

NO

#### Description

`ExcludedException` had no branch in `WhisparrErrorPipeline`, so every deliberate import exclusion fell through to the catch-all: HTTP 500, a Fatal log entry inflating the error badge, and `exception.ToString()` (full stack trace) in the response body.

Adds a typed branch that returns 409 Conflict, logs at Info, and returns the message without the trace — the way the `ValidationException` branch already does. This covers all six throw sites in `AddMovieService.SetPropertiesAndValidate` (studio/collection/performer/tag exclusions and both after-date paths).

The `QualityProfileInUseException` family noted in the issue is deliberately not touched here — it needs a separate decision (rebase onto `NzbDroneClientException` vs. more pipeline branches).

#### Screenshot(s) (if UI related)

N/A

#### Todos

- [x] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)

New `WhisparrErrorPipelineFixture` covers the status code, the trace-free body, the log level, and that unhandled exceptions still return 500 and log Fatal. Verified the exclusion cases fail on `eros-develop` and pass with the change.

Note: the fixture attaches its own NLog target rather than using `ExceptionVerification` for the log-level assertions — `ExceptionVerification` captures nothing for the first test in a process, since NLog 6 doesn't pick up rules added after the config assignment until it is reassigned.

#### Issues Fixed or Closed by this PR

- Fixes Whisparr/Whisparr-Eros#869
