### PR TITLE
Fixed: Missing cover URLs and statistics when fetching a movie by integer id

### DIFF
--- a/src/NzbDrone.Api.Test/v3/Movies/MovieControllerFixture.cs
+++ b/src/NzbDrone.Api.Test/v3/Movies/MovieControllerFixture.cs
@@ -1,0 +1,85 @@
+using System.Collections.Generic;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+using NzbDrone.Core.MediaCover;
+using NzbDrone.Core.Movies;
+using NzbDrone.Core.MovieStats;
+using NzbDrone.Test.Common;
+using Whisparr.Api.V3.Movies;
+
+namespace NzbDrone.Api.Test.v3.Movies
+{
+    [Parallelizable(ParallelScope.Self)]
+    public class MovieControllerFixture : TestBase<MovieController>
+    {
+        private const string ForeignId = "019bfb1f-89a6-77c8-a5b2-856d3735a2b1";
+        private Movie _movie;
+
+        [SetUp]
+        public void Setup()
+        {
+            _movie = new Movie
+            {
+                Id = 18,
+                MovieMetadata = new MovieMetadata
+                {
+                    ForeignId = ForeignId,
+                    Title = "Droned",
+                    Images = new List<MediaCover>
+                    {
+                        new (MediaCoverTypes.Screenshot, "https://stashdb.org/images/0501cbc9-cc70-4e43-9114-11582c2e8b39")
+                    }
+                }
+            };
+
+            Mocker.GetMock<IMovieService>().Setup(s => s.GetMovie(18)).Returns(_movie);
+            Mocker.GetMock<IMovieService>().Setup(s => s.FindByForeignId(ForeignId)).Returns(_movie);
+
+            Mocker.GetMock<IMovieStatisticsService>()
+                .Setup(s => s.MovieStatistics(It.IsAny<int>()))
+                .Returns(new MovieStatistics { MovieId = 18, MovieFileCount = 1, SizeOnDisk = 1234 });
+        }
+
+        // GET /movie/{id:int} is the more specific route, so a numeric request never reaches
+        // GetMovieById. It used to return the bare resource: no cover URLs, no statistics.
+        [Test]
+        public void should_map_covers_to_local_when_fetching_by_integer_id()
+        {
+            var resource = Subject.GetResourceByIdWithErrorHandler(18);
+
+            resource.Value.Id.Should().Be(18);
+            Mocker.GetMock<IMapCoversToLocal>()
+                .Verify(s => s.ConvertToLocalUrls(18, It.IsAny<List<MediaCover>>()), Times.Once());
+        }
+
+        [Test]
+        public void should_link_statistics_when_fetching_by_integer_id()
+        {
+            var resource = Subject.GetResourceByIdWithErrorHandler(18);
+
+            resource.Value.Statistics.Should().NotBeNull();
+            resource.Value.Statistics.MovieFileCount.Should().Be(1);
+            resource.Value.Statistics.SizeOnDisk.Should().Be(1234);
+        }
+
+        [Test]
+        public void should_map_covers_to_local_when_fetching_by_foreign_id()
+        {
+            var resource = Subject.GetMovieById(ForeignId);
+
+            resource.Value.Id.Should().Be(18);
+            Mocker.GetMock<IMapCoversToLocal>()
+                .Verify(s => s.ConvertToLocalUrls(18, It.IsAny<List<MediaCover>>()), Times.Once());
+        }
+
+        [Test]
+        public void should_link_statistics_when_fetching_by_foreign_id()
+        {
+            var resource = Subject.GetMovieById(ForeignId);
+
+            resource.Value.Statistics.Should().NotBeNull();
+            resource.Value.Statistics.MovieFileCount.Should().Be(1);
+        }
+    }
+}

--- a/src/Whisparr.Api.V3/Movies/MovieController.cs
+++ b/src/Whisparr.Api.V3/Movies/MovieController.cs
@@ -310,10 +310,7 @@ namespace Whisparr.Api.V3.Movies
                 return NotFound();
             }
 
-            var stats = _movieStatisticsService.MovieStatistics(resource.Id);
-            LinkMovieStatistics(resource, stats);
-            _coverMapper.ConvertToLocalUrls(resource.Id, resource.Images);
-            return resource;
+            return EnrichResource(resource);
         }
 
         /// <summary>GET /movie/{id}</summary>
@@ -328,7 +325,23 @@ namespace Whisparr.Api.V3.Movies
                 .FindByForeignId(id.ToString())
                 ?? _moviesService.GetMovie(id);
 
-            return movie?.ToResource(_configService.AvailabilityDelay, _qualityUpgradableSpecification);
+            return EnrichResource(movie?.ToResource(_configService.AvailabilityDelay, _qualityUpgradableSpecification));
+        }
+
+        // Both single-movie routes have to link statistics and map cover URLs. The base class
+        // route GET {id:int} is the more specific match, so a numeric request lands here rather
+        // than in GetMovieById, whose numeric branch is unreachable at runtime.
+        private MovieResource EnrichResource(MovieResource resource)
+        {
+            if (resource == null || resource.Id == 0)
+            {
+                return resource;
+            }
+
+            LinkMovieStatistics(resource, _movieStatisticsService.MovieStatistics(resource.Id));
+            MapCoversToLocal(resource);
+
+            return resource;
         }
 
         /// <summary>POST /movie/list</summary>


### PR DESCRIPTION
#### Database Migration

NO

#### Description

`GET /api/v3/movie/{id}` returned a different payload depending on whether the id was numeric.

The base `RestController` declares `GET {id:int}`, which is a **more specific route match** than this controller's `GET {id}`. So a numeric request lands in `GetResourceById` and never reaches `GetMovieById`. `GetResourceById` returned the bare resource — no cover URLs and no statistics. `GetMovieById`'s own `isNumeric` branch is unreachable at runtime, which is why this survived: the code that does the enrichment *looks* like it handles integer ids.

Same movie, two routes, before:

```
GET /api/v3/movie/18            id=18  url=None                          statistics=None
GET /api/v3/movie/<foreignId>   id=18  url=/MediaCover/movie/18/screen…  statistics={…}
```

After, both return the same payload.

Cover mapping goes through the existing guarded `MapCoversToLocal` wrapper rather than calling `_coverMapper` directly, so a mapping failure degrades to hotlinked art instead of failing the request — matching every other path in this controller.

Performer and Studio were checked for the same split and are fine: their `GetResourceById` overrides already map covers. (An earlier reading suggested Studio was affected too; that was a nonexistent id in the dev database, not a defect.)

Found while verifying #640, and confirmed pre-existing by running the same query against `eros-develop` — it is not a regression from that PR.

#### Verification

Live on 6969 against the dev database, both routes after the fix:

```
by int id 18:  url=/MediaCover/movie/18/screenshot.jpg?h=55c3a85c976ff4b6a39a  statistics={…}
by foreign id: url=/MediaCover/movie/18/screenshot.jpg?h=55c3a85c976ff4b6a39a  statistics={…}
```

Zero errors in the app log. New `MovieControllerFixture` covers both routes for both covers and statistics; full `Whisparr.Api.Test` green (119 passed), solution builds with 0 warnings. Negative-tested: reverting the fix fails exactly the two integer-id tests and leaves the two foreign-id tests passing.

#### Todos

- [x] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)

#### Issues Fixed or Closed by this PR

<!-- none -->
