### PR TITLE
Fixed: Studio matching fanned out across every UI-saved studio

### DIFF
--- a/frontend/src/Components/SignalRListener.tsx
+++ b/frontend/src/Components/SignalRListener.tsx
@@ -209,9 +209,11 @@ function invalidateMoviePagedQueryCache() {
   });
 }
 
-// The by-id list behind the tag details modal and the queued task rows. It is
-// keyed on the requested ids, so a deleted movie changes which records come
-// back, not just their contents, and patching in place would not cover it.
+// The by-id list behind the tag details modal, now its only caller -- the queued
+// task rows read the command's own progress message instead. It is keyed on the
+// requested ids, so a deleted movie changes which records come back, not just
+// their contents, and patching in place would not cover it. Updates are not
+// invalidated: the modal shows titles, and a scan emits a movie event per record.
 //
 // `useAllMovies`'s `/movie` is left alone on purpose. It is the whole library in
 // one response, and a scan emits a movie event per record -- invalidating it
@@ -400,7 +402,10 @@ function SignalRListener() {
         }
 
         invalidateMoviePagedQueryCache();
-        invalidateMovieBulkQueryCache();
+
+        if (body.action === 'deleted') {
+          invalidateMovieBulkQueryCache();
+        }
 
         if (body.action === 'updated') {
           invalidateWantedQueries();
@@ -420,7 +425,10 @@ function SignalRListener() {
       }
 
       invalidateMoviePagedQueryCache();
-      invalidateMovieBulkQueryCache();
+
+      if (body.action === 'deleted') {
+        invalidateMovieBulkQueryCache();
+      }
 
       if (body.action === 'updated') {
         invalidateWantedQueries();

--- a/frontend/src/System/Tasks/Queued/QueuedTaskRow.tsx
+++ b/frontend/src/System/Tasks/Queued/QueuedTaskRow.tsx
@@ -1,6 +1,5 @@
 import moment from 'moment';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { CommandBody } from 'Commands/Command';
 import { useCancelCommand } from 'Commands/useCommands';
 import Icon, { IconProps } from 'Components/Icon';
 import IconButton from 'Components/Link/IconButton';
@@ -98,7 +97,6 @@ export interface QueuedTaskRowProps {
   status: string;
   duration?: string;
   message?: string;
-  body: CommandBody;
   clientUserAgent?: string;
 }
 
@@ -113,7 +111,6 @@ export default function QueuedTaskRow(props: QueuedTaskRowProps) {
     status,
     duration,
     message,
-    body,
     clientUserAgent,
   } = props;
 
@@ -191,7 +188,7 @@ export default function QueuedTaskRow(props: QueuedTaskRowProps) {
 
       <QueuedTaskRowNameCell
         commandName={commandName}
-        body={body}
+        message={message}
         clientUserAgent={clientUserAgent}
       />
 

--- a/frontend/src/System/Tasks/Queued/QueuedTaskRowNameCell.tsx
+++ b/frontend/src/System/Tasks/Queued/QueuedTaskRowNameCell.tsx
@@ -1,48 +1,24 @@
-import React, { useMemo } from 'react';
-import { CommandBody } from 'Commands/Command';
+import React from 'react';
 import TableRowCell from 'Components/Table/Cells/TableRowCell';
-import { useMoviesByIds } from 'Movie/useMovie';
-import sortByProp from 'Utilities/Array/sortByProp';
 import translate from 'Utilities/String/translate';
 import styles from './QueuedTaskRowNameCell.css';
 
 export interface QueuedTaskRowNameCellProps {
   commandName: string;
-  body: CommandBody;
+  message?: string;
   clientUserAgent?: string;
 }
 
 export default function QueuedTaskRowNameCell(
   props: Readonly<QueuedTaskRowNameCellProps>
 ) {
-  const { commandName, body, clientUserAgent } = props;
-
-  const movieIds = useMemo(() => {
-    const ids = [...(body.movieIds ?? [])];
-
-    if (body.movieId) {
-      ids.push(body.movieId);
-    }
-
-    return ids;
-  }, [body.movieIds, body.movieId]);
-
-  const { movies } = useMoviesByIds(movieIds);
-
-  // `movies` is React Query's cached array; sorting in place would reorder it
-  // for every other reader of the same key.
-  const sortedMovies = useMemo(
-    () => [...movies].sort(sortByProp('sortTitle')),
-    [movies]
-  );
+  const { commandName, message, clientUserAgent } = props;
 
   return (
     <TableRowCell>
       <span className={styles.commandName}>
         {commandName}
-        {sortedMovies.length ? (
-          <span> - {sortedMovies.map((m) => m?.title)?.join(', ')}</span>
-        ) : null}
+        {message ? <span> - {message}</span> : null}
       </span>
 
       {clientUserAgent ? (

--- a/src/NzbDrone.Core.Test/MovieTests/MovieServiceTests/FindSceneFixture.cs
+++ b/src/NzbDrone.Core.Test/MovieTests/MovieServiceTests/FindSceneFixture.cs
@@ -1,0 +1,95 @@
+using System.Collections.Generic;
+using Moq;
+using NUnit.Framework;
+using NzbDrone.Core.Configuration;
+using NzbDrone.Core.Movies;
+using NzbDrone.Core.Movies.Studios;
+using NzbDrone.Core.Parser.Model;
+
+namespace NzbDrone.Core.Test.MovieTests.MovieServiceTests
+{
+    [TestFixture]
+    public class FindSceneFixture
+    {
+        private Mock<IMovieRepository> _movieRepositoryMock;
+        private Mock<IStudioService> _studioServiceMock;
+        private Mock<IConfigService> _configServiceMock;
+        private MovieService _movieService;
+
+        [SetUp]
+        public void Setup()
+        {
+            _movieRepositoryMock = new Mock<IMovieRepository>();
+            _studioServiceMock = new Mock<IStudioService>();
+            _configServiceMock = new Mock<IConfigService>();
+
+            _movieService = new MovieService(
+                _movieRepositoryMock.Object,
+                null, // ICreditsService
+                _studioServiceMock.Object,
+                null, // IEventAggregator
+                _configServiceMock.Object,
+                null, // IBuildMoviePaths
+                null, // IAutoTaggingService
+                null, // ICacheManager
+                NzbDrone.Common.Instrumentation.NzbDroneLogger.GetLogger(typeof(MovieService)));
+        }
+
+        [TestCase(null)]
+        [TestCase("")]
+        [TestCase("   ")]
+        public void Should_not_look_up_studios_when_release_has_no_studio_title(string studioTitle)
+        {
+            // Only the scene parse path assigns StudioTitle. A release that parsed as a movie
+            // arrives with none, and looking it up fanned a studio-catalog query out across
+            // every studio whose CleanSearchTitle was blank.
+            var parsedMovieInfo = new ParsedMovieInfo { StudioTitle = studioTitle };
+
+            var result = _movieService.FindScene(parsedMovieInfo);
+
+            Assert.That(result, Is.Null);
+            _studioServiceMock.Verify(s => s.FindAllByTitle(It.IsAny<string>()), Times.Never);
+            _movieRepositoryMock.Verify(r => r.GetByStudioForeignId(It.IsAny<string>()), Times.Never);
+        }
+
+        [Test]
+        public void Should_still_look_up_studios_when_release_has_a_studio_title()
+        {
+            var parsedMovieInfo = new ParsedMovieInfo { StudioTitle = "Cosmid", ReleaseDate = "2025-05-17" };
+
+            _studioServiceMock.Setup(s => s.FindAllByTitle("Cosmid"))
+                .Returns(new List<Studio>());
+
+            _movieService.FindScene(parsedMovieInfo);
+
+            _studioServiceMock.Verify(s => s.FindAllByTitle("Cosmid"), Times.Once);
+        }
+
+        [Test]
+        public void Should_query_studio_and_date_only_once_per_studio()
+        {
+            // The fuzzy pass and the match pass both used to run the same query.
+            var studioId = "studio-1";
+            var releaseDate = "2025-05-17";
+
+            var parsedMovieInfo = new ParsedMovieInfo
+            {
+                StudioTitle = "Cosmid",
+                ReleaseDate = releaseDate,
+                ReleaseTokens = "some tokens"
+            };
+
+            _studioServiceMock.Setup(s => s.FindAllByTitle("Cosmid"))
+                .Returns(new List<Studio> { new Studio { ForeignId = studioId } });
+
+            _movieRepositoryMock.Setup(r => r.FindByStudioAndDate(studioId, releaseDate))
+                .Returns(new List<Movie>());
+            _movieRepositoryMock.Setup(r => r.GetByStudioForeignId(studioId))
+                .Returns(new List<Movie>());
+
+            _movieService.FindScene(parsedMovieInfo);
+
+            _movieRepositoryMock.Verify(r => r.FindByStudioAndDate(studioId, releaseDate), Times.Once);
+        }
+    }
+}

--- a/src/NzbDrone.Core.Test/StudioTests/StudioRepositoryFixture.cs
+++ b/src/NzbDrone.Core.Test/StudioTests/StudioRepositoryFixture.cs
@@ -1,0 +1,64 @@
+using FluentAssertions;
+using NUnit.Framework;
+using NzbDrone.Core.Movies.Studios;
+using NzbDrone.Core.Test.Framework;
+
+namespace NzbDrone.Core.Test.StudioTests
+{
+    [TestFixture]
+    public class StudioRepositoryFixture : DbTest<StudioRepository, Studio>
+    {
+        private Studio GivenStudio(string title, string cleanSearchTitle)
+        {
+            var studio = new Studio
+            {
+                ForeignId = title.ToLowerInvariant() + "-id",
+                Title = title,
+                CleanTitle = title.ToLowerInvariant(),
+                RootFolderPath = "/movies",
+                CleanSearchTitle = cleanSearchTitle
+            };
+
+            return Subject.Insert(studio);
+        }
+
+        [Test]
+        public void should_find_studio_by_clean_title()
+        {
+            GivenStudio("Cosmid", null);
+
+            Subject.FindAllByTitle("cosmid").Should().HaveCount(1);
+        }
+
+        [Test]
+        public void should_find_studio_by_clean_search_title()
+        {
+            GivenStudio("Cosmid", "cosmidsearch");
+
+            Subject.FindAllByTitle("cosmidsearch").Should().HaveCount(1);
+        }
+
+        [TestCase(null)]
+        [TestCase("")]
+        [TestCase("   ")]
+        public void should_return_empty_for_a_blank_title(string title)
+        {
+            GivenStudio("Cosmid", string.Empty);
+            GivenStudio("Transfixed", null);
+
+            Subject.FindAllByTitle(title).Should().BeEmpty();
+        }
+
+        [Test]
+        public void should_not_match_studios_with_an_empty_clean_search_title()
+        {
+            // CleanSearchTitle is written as string.Empty by the API's resource mapper when a
+            // studio has no search title, and left null by the metadata and scan paths. An
+            // empty lookup used to return every studio saved through the UI.
+            GivenStudio("Cosmid", string.Empty);
+            GivenStudio("Transfixed", string.Empty);
+
+            Subject.FindAllByTitle(string.Empty).Should().BeEmpty();
+        }
+    }
+}

--- a/src/NzbDrone.Core/IndexerSearch/MoviesSearchService.cs
+++ b/src/NzbDrone.Core/IndexerSearch/MoviesSearchService.cs
@@ -110,7 +110,19 @@ namespace NzbDrone.Core.IndexerSearch
 
         private async Task SearchForBulkMovies(List<Movie> movies, bool userInvokedSearch)
         {
-            _logger.ProgressInfo("Performing search for {0} movies", movies.Count);
+            // The queued task row shows this message, so a single-movie search -- what the
+            // search button on a movie produces -- names the movie rather than counting it.
+            var isSingleMovie = movies.Count == 1;
+
+            if (isSingleMovie)
+            {
+                _logger.ProgressInfo("Performing search for {0}", movies[0].Title);
+            }
+            else
+            {
+                _logger.ProgressInfo("Performing search for {0} movies", movies.Count);
+            }
+
             var downloadedCount = 0;
 
             foreach (var movieId in movies.GroupBy(e => e.Id).OrderBy(g => g.Min(m => m.LastSearchTime ?? DateTime.MinValue)))
@@ -132,7 +144,14 @@ namespace NzbDrone.Core.IndexerSearch
                 downloadedCount += processDecisions.Grabbed.Count;
             }
 
-            _logger.ProgressInfo("Completed search for {0} movies. {1} reports downloaded.", movies.Count, downloadedCount);
+            if (isSingleMovie)
+            {
+                _logger.ProgressInfo("Completed search for {0}. {1} reports downloaded.", movies[0].Title, downloadedCount);
+            }
+            else
+            {
+                _logger.ProgressInfo("Completed search for {0} movies. {1} reports downloaded.", movies.Count, downloadedCount);
+            }
         }
     }
 }

--- a/src/NzbDrone.Core/Movies/MovieService.cs
+++ b/src/NzbDrone.Core/Movies/MovieService.cs
@@ -702,6 +702,16 @@ namespace NzbDrone.Core.Movies
                 result = FindByTitle(parsedMovieInfo.Code);
             }
 
+            // Only the scene parse path assigns StudioTitle, so a release that parsed as a
+            // movie arrives here with none. Looking that up matches on studio title alone and
+            // fans a studio-catalog query out across every hit, none of which can match a
+            // release we have no studio for.
+            if (result == null && parsedMovieInfo.StudioTitle.IsNullOrWhiteSpace())
+            {
+                _logger.Debug("No Studio name parsed from release, skipping studio and release date matching.");
+                return null;
+            }
+
             if (result == null)
             {
                 var studios = _studioService.FindAllByTitle(parsedMovieInfo.StudioTitle);
@@ -827,13 +837,8 @@ namespace NzbDrone.Core.Movies
 
             if (hasReleaseDate)
             {
-                _logger.Debug("{0}: DB query for for movies for Studio ForeignID: [{1}] and Date: [{2}].", methodName, studioForeignId, releaseDate);
-                movies = _movieRepository.FindByStudioAndDate(studioForeignId, releaseDate);
-
-                if (movies == null || !movies.Any())
-                {
-                    movies = new List<Movie>();
-                }
+                // Already queried above for the fuzzy pass, which does not mutate the list,
+                // so the same studio and date would return the same rows a second time.
 
                 // movies with release date if missing day
                 if (releaseDate.EndsWith("-01"))

--- a/src/NzbDrone.Core/Movies/Studios/StudioRepository.cs
+++ b/src/NzbDrone.Core/Movies/Studios/StudioRepository.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using Dapper;
+using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Datastore;
 using NzbDrone.Core.Messaging.Events;
 using NzbDrone.Core.Parser;
@@ -37,7 +38,19 @@ namespace NzbDrone.Core.Movies.Studios
 
         public List<Studio> FindAllByTitle(string title)
         {
-            return All().Where(x => x.CleanTitle == title || x.CleanSearchTitle == title || (x.Aliases != null && x.Aliases.Where(x => x.CleanStudioTitle()?.ToLower() == title).Any())).ToList();
+            if (title.IsNullOrWhiteSpace())
+            {
+                return new List<Studio>();
+            }
+
+            // CleanSearchTitle is only ever written by the API's resource mapper, and stores
+            // string.Empty when the studio has no search title. Studios created by the
+            // metadata and scan paths leave it null. Comparing a blank title against either
+            // would return every studio the user has saved through the UI, so blanks are
+            // excluded rather than relied upon to be null.
+            return All().Where(x => x.CleanTitle == title
+                                 || (x.CleanSearchTitle.IsNotNullOrWhiteSpace() && x.CleanSearchTitle == title)
+                                 || (x.Aliases != null && x.Aliases.Any(alias => alias.CleanStudioTitle()?.ToLower() == title))).ToList();
         }
 
         public Studio FindByForeignId(string foreignId)


### PR DESCRIPTION
#### Database Migration

NO

#### Description

From a user's sluggishness report on 3.4.0. 24 seconds of their debug log held 7,231 lines, ~41% of it from 12 releases that were rejected anyway.

Releases that parse as a movie rather than a scene never get a `StudioTitle` — only the scene path sets it. `FindScene` looked studios up with that empty title, and `FindAllByTitle` compared it against `CleanSearchTitle`, which the API's resource mapper stores as `string.Empty` while the metadata and scan paths leave `null`. So an empty lookup returned every studio the user had ever saved through the studio edit modal — 85 of their 1,800 — and each hit ran a full `GetByStudioForeignId` catalog load that could not match a release with no studio. ~1,020 catalog queries from 12 junk releases, against a library of 51k scenes and 5.5k movies.

Three fixes:

- `FindScene` returns early when no studio was parsed.
- `FindAllByTitle` ignores blank titles on both sides of the comparison, so the `null` vs `""` inconsistency stops mattering.
- `FindByStudioAndDate` ran twice per call with identical arguments — once for the fuzzy pass, again for the match pass. The second reuses the first result.

The same log showed `GET /api/v3/command` at 3,102 ms and six concurrent `POST /movie/bulk` aborted mid-body. That endpoint is documented in the controller as legacy Redux hydration; the queued task rows were its only index-shaped caller, left behind when the movies slice was retired in #515 — a free `useSelector` became one full-`MovieResource` round-trip per row, keyed per row so nothing deduped. The rows now read the command's own progress message, which already carried the title for refresh and rename. A single-movie search names the movie in that message rather than counting it, and the `/movie/bulk` SignalR invalidation narrows to deletes now that the tag details modal is its only caller.

Known gap: a queued-but-not-yet-started command has no message yet, so those rows show just the command name until they start. Closing that would mean adding titles to `CommandResource`, which is a larger change.

#### Todos

- [x] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)

`FindSceneFixture` (5) and `StudioRepositoryFixture` (6); both verified to fail against the unfixed code. Full Core suite green at 4,420. No new translation keys — the removed cell text was interpolated command data, not a string.

`MoviesSearchService` has no fixture and the change there is a logging call, so it is covered by build and typecheck only. Worth a click through System → Tasks with a search running.
