### PR TITLE
Fix: OpenAPI security requirements now reference their scheme definitions

### DIFF
--- a/src/NzbDrone.Host/Startup.cs
+++ b/src/NzbDrone.Host/Startup.cs
@@ -131,7 +131,7 @@ namespace NzbDrone.Host
 
                 c.AddSecurityRequirement(doc => new OpenApiSecurityRequirement
                 {
-                    { new OpenApiSecuritySchemeReference("X-Api-Key"), new List<string>() }
+                    { new OpenApiSecuritySchemeReference("X-Api-Key", doc), new List<string>() }
                 });
 
                 var apikeyQuery = new OpenApiSecurityScheme
@@ -157,7 +157,7 @@ namespace NzbDrone.Host
 
                 c.AddSecurityRequirement(doc => new OpenApiSecurityRequirement
                 {
-                    { new OpenApiSecuritySchemeReference("apikey"), new List<string>() }
+                    { new OpenApiSecuritySchemeReference("apikey", doc), new List<string>() }
                 });
 
                 c.DescribeAllParametersInCamelCase();

--- a/src/NzbDrone.Host/Startup.cs
+++ b/src/NzbDrone.Host/Startup.cs
@@ -129,9 +129,9 @@ namespace NzbDrone.Host
 
                 c.AddSecurityDefinition("X-Api-Key", apiKeyHeader);
 
-                c.AddSecurityRequirement(doc => new OpenApiSecurityRequirement
+                c.AddSecurityRequirement(document => new OpenApiSecurityRequirement
                 {
-                    { new OpenApiSecuritySchemeReference("X-Api-Key", doc), new List<string>() }
+                    [new OpenApiSecuritySchemeReference(apiKeyHeader.Name, document)] = new List<string>(),
                 });
 
                 var apikeyQuery = new OpenApiSecurityScheme
@@ -155,9 +155,9 @@ namespace NzbDrone.Host
 
                 c.AddSecurityDefinition("apikey", apikeyQuery);
 
-                c.AddSecurityRequirement(doc => new OpenApiSecurityRequirement
+                c.AddSecurityRequirement(document => new OpenApiSecurityRequirement
                 {
-                    { new OpenApiSecuritySchemeReference("apikey", doc), new List<string>() }
+                    [new OpenApiSecuritySchemeReference(apikeyQuery.Name, document)] = new List<string>(),
                 });
 
                 c.DescribeAllParametersInCamelCase();

--- a/src/NzbDrone.Integration.Test/OpenApiSecurityFixture.cs
+++ b/src/NzbDrone.Integration.Test/OpenApiSecurityFixture.cs
@@ -1,0 +1,27 @@
+using System.Net.Http;
+using System.Text.Json;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace NzbDrone.Integration.Test
+{
+    [TestFixture]
+    public class OpenApiSecurityFixture : IntegrationTest
+    {
+        private HttpClient _httpClient = new HttpClient();
+
+        [Test]
+        public void should_serve_both_api_key_schemes_in_root_security()
+        {
+            var request = new HttpRequestMessage(HttpMethod.Get, RootUrl + "docs/v3/openapi.json");
+            var response = _httpClient.Send(request);
+            var text = response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
+
+            var security = JsonDocument.Parse(text).RootElement.GetProperty("security");
+
+            security.GetArrayLength().Should().Be(2);
+            security[0].EnumerateObject().Should().ContainSingle(property => property.Name == "X-Api-Key");
+            security[1].EnumerateObject().Should().ContainSingle(property => property.Name == "apikey");
+        }
+    }
+}

--- a/src/NzbDrone.Integration.Test/OpenApiSecurityFixture.cs
+++ b/src/NzbDrone.Integration.Test/OpenApiSecurityFixture.cs
@@ -1,3 +1,6 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
 using System.Net.Http;
 using System.Text.Json;
 using FluentAssertions;
@@ -8,20 +11,30 @@ namespace NzbDrone.Integration.Test
     [TestFixture]
     public class OpenApiSecurityFixture : IntegrationTest
     {
-        private HttpClient _httpClient = new HttpClient();
+        private readonly HttpClient _httpClient = new HttpClient();
 
         [Test]
         public void should_serve_both_api_key_schemes_in_root_security()
         {
             var request = new HttpRequestMessage(HttpMethod.Get, RootUrl + "docs/v3/openapi.json");
-            var response = _httpClient.Send(request);
-            var text = response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
+            using var response = _httpClient.Send(request);
 
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+            var text = response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
             var security = JsonDocument.Parse(text).RootElement.GetProperty("security");
 
-            security.GetArrayLength().Should().Be(2);
-            security[0].EnumerateObject().Should().ContainSingle(property => property.Name == "X-Api-Key");
-            security[1].EnumerateObject().Should().ContainSingle(property => property.Name == "apikey");
+            var requirements = security.EnumerateArray()
+                .Select(requirement => requirement.EnumerateObject().Select(property => property.Name).ToList())
+                .ToList();
+
+            // Two requirements each naming one scheme means either key is sufficient. A single
+            // requirement naming both would mean both are required at once.
+            requirements.Should().HaveCount(2);
+            requirements.Should().OnlyContain(schemeNames => schemeNames.Count == 1);
+
+            requirements.SelectMany(schemeNames => schemeNames)
+                .Should().BeEquivalentTo(new List<string> { "X-Api-Key", "apikey" });
         }
     }
 }


### PR DESCRIPTION
#### Database Migration

NO

#### Description

The served OpenAPI document declares its root `security` block as two empty objects, `[{}, {}]`,
instead of naming the two API-key schemes. An empty security requirement means "no credentials
required", so every consumer of the document concludes the API is unauthenticated: `/docs` renders
no padlocks and its Authorize dialog has no effect on requests, and generated clients
(openapi-generator, NSwag, Kiota) emit no auth parameter at all. The API itself still enforces the
key correctly; only what the document advertises is wrong.

**This is an Eros-only regression, and upstream already has the correct code.**

It was introduced here by 9371179fd, "Chore: Bump Swagger to 10.1.0" (#90). That commit moved to
the `AddSecurityRequirement(Func<OpenApiDocument, ...>)` overload and added the `doc` lambda
parameter, but never passed it to the reference constructor:

```diff
-                c.AddSecurityRequirement(new OpenApiSecurityRequirement
+                c.AddSecurityRequirement(doc => new OpenApiSecurityRequirement
                 {
-                    { apiKeyHeader, Array.Empty<string>() }
+                    { new OpenApiSecuritySchemeReference("X-Api-Key"), new List<string>() }
                 });
```

In Microsoft.OpenApi 2.7.5, pinned transitively by Swashbuckle.AspNetCore 10.2.3,
`OpenApiSecurityRequirement.SerializeInternal` filters each entry through
`CanSerializeSecurityScheme`, which keeps an entry only when the reference has a resolved `Target`
or when `Reference.HostDocument.Components.SecuritySchemes` contains the id. The single-argument
constructor leaves `HostDocument` null, so both entries are dropped and each requirement
serializes as `{}`.

`Whisparr/Whisparr` made the equivalent migration in c45758ec8 ("New: Bump .NET to 10", Whisparr/Whisparr#1197) and
passed the document through. This PR adopts that code verbatim rather than inventing a different
fix, so the block becomes textually identical to upstream and a future sync of this area is a
no-op instead of a conflict:

```diff
-                c.AddSecurityRequirement(doc => new OpenApiSecurityRequirement
+                c.AddSecurityRequirement(document => new OpenApiSecurityRequirement
                 {
-                    { new OpenApiSecuritySchemeReference("X-Api-Key"), new List<string>() }
+                    [new OpenApiSecuritySchemeReference(apiKeyHeader.Name, document)] = new List<string>(),
                 });
```

Before and after, read back from a running instance rather than transcribed:

| | Root `security` |
|---|---|
| Before | `[{}, {}]` |
| After | `[{"X-Api-Key": []}, {"apikey": []}]` |

Two separate requirement objects, not one object holding both keys. Two entries mean either scheme
is sufficient; one entry with two keys would mean both are required at once, which is not the
intent. The added test asserts that distinction rather than just checking both names appear.

Verified on a build from this branch:

- `GET /api/v3/system/status` returns 401 with no key, 200 with the key as an `X-Api-Key` header,
  and 200 with it as an `apikey` query parameter. The 401 is the control; without it the two 200s
  would not show the key was what let the calls through.
- On `/docs`, the Authorize dialog now lists both schemes by name and location. Entering a key
  flips the entry to Authorized and locks the operation padlocks, and "Try it out" on
  `GET /api/v3/system/status` returns 200. Before this change the same dialog had no effect and the
  call returned 401.
- `dotnet build src/NzbDrone.Host/Whisparr.Host.csproj -c Debug -p:Platform=Windows` reports 0
  warnings and 0 errors under the solution-wide `TreatWarningsAsErrors`.

One note on the build check. `./build.sh --backend` does not currently complete on this machine: it
fails at restore in about 1.3s with `NU1510` in `src/NzbDrone/Whisparr.csproj`, the WinForms tray
project. That failure is pre-existing, reproduces on a clean `eros-develop` with no changes, and
looks like an SDK feature-band mismatch, `global.json` pinning `10.0.101` against an installed
`10.0.400`. It is unrelated to this defect and that project has no code path to
`/docs/v3/openapi.json`, so I have left it alone rather than put a second unrelated change in this
PR. Happy to open a separate issue for it if that is useful.

#### Screenshot(s) (if UI related)

<details>

Not a UI change. The `/docs` Authorize behaviour described above is a consequence of the corrected
document, not of any markup or component change.

</details>

#### Todos

- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)

`src/NzbDrone.Integration.Test/OpenApiSecurityFixture.cs` requests `/docs/v3/openapi.json` from a
running instance and asserts the served `security` array has exactly two entries, the first keyed
`X-Api-Key` and the second `apikey`. It follows `IndexHtmlFixture`'s pattern: a raw `HttpClient`
against `RootUrl` rather than the `api/v3/`-scoped REST client.

The test was checked for the failure it is supposed to catch. With the fix reverted and
`Whisparr.Console` rebuilt, it fails with `Expected collection to contain a single item matching
(property.Name == "X-Api-Key"), but the collection is empty`. With the fix in place it passes.

No translation keys are needed: this change adds no user-facing strings.

#### Issues Fixed or Closed by this PR

- Fixes whisparr/whisparr#1252
