### PR TITLE
New: Fuzzy title matching fallback for movies

### DIFF
--- a/src/NzbDrone.Core.Test/Download/CompletedDownloadServiceTests/ProcessFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/CompletedDownloadServiceTests/ProcessFixture.cs
@@ -178,6 +178,59 @@ namespace NzbDrone.Core.Test.Download.CompletedDownloadServiceTests
             AssertNotReadyToImport();
         }
 
+        // The download title no longer parses to a movie, so the grab history decides whether importing unattended is safe.
+        private void GivenGrabbedWithMatchType(MovieMatchType matchType, ReleaseSourceType releaseSource)
+        {
+            var history = new MovieHistory { EventType = MovieHistoryEventType.Grabbed, MovieId = 1 };
+            history.Data[MovieHistory.MOVIE_MATCH_TYPE] = matchType.ToString();
+            history.Data[MovieHistory.RELEASE_SOURCE] = releaseSource.ToString();
+
+            Mocker.GetMock<IHistoryService>()
+                  .Setup(s => s.FindByDownloadId(_trackedDownload.DownloadItem.DownloadId))
+                  .Returns(new List<MovieHistory> { history });
+
+            Mocker.GetMock<IParsingService>()
+                  .Setup(s => s.GetMovie("Drone.S01E01.HDTV", false))
+                  .Returns((Movie)null);
+
+            Mocker.GetMock<IMovieService>()
+                  .Setup(s => s.GetMovie(1))
+                  .Returns(_trackedDownload.RemoteMovie.Movie);
+        }
+
+        [TestCase(MovieMatchType.Id)]
+        [TestCase(MovieMatchType.FuzzyTitle)]
+        public void should_block_import_when_the_movie_was_not_identified_by_name(MovieMatchType matchType)
+        {
+            GivenGrabbedWithMatchType(matchType, ReleaseSourceType.Rss);
+
+            Subject.Check(_trackedDownload);
+
+            _trackedDownload.State.Should().Be(TrackedDownloadState.ImportBlocked);
+        }
+
+        [TestCase(MovieMatchType.Id)]
+        [TestCase(MovieMatchType.FuzzyTitle)]
+        public void should_import_a_weak_match_that_came_from_an_interactive_search(MovieMatchType matchType)
+        {
+            // The user picked this release themselves, so the weak match was already confirmed by a human.
+            GivenGrabbedWithMatchType(matchType, ReleaseSourceType.InteractiveSearch);
+
+            Subject.Check(_trackedDownload);
+
+            AssertReadyToImport();
+        }
+
+        [Test]
+        public void should_import_an_exact_title_match_without_intervention()
+        {
+            GivenGrabbedWithMatchType(MovieMatchType.Title, ReleaseSourceType.Rss);
+
+            Subject.Check(_trackedDownload);
+
+            AssertReadyToImport();
+        }
+
         private void AssertNotReadyToImport()
         {
             _trackedDownload.State.Should().NotBe(TrackedDownloadState.ImportPending);

--- a/src/NzbDrone.Core.Test/MovieTests/MovieServiceTests/FindFuzzyMovieByYearFixture.cs
+++ b/src/NzbDrone.Core.Test/MovieTests/MovieServiceTests/FindFuzzyMovieByYearFixture.cs
@@ -1,0 +1,231 @@
+using System.Collections.Generic;
+using Moq;
+using NUnit.Framework;
+using NzbDrone.Common.Instrumentation;
+using NzbDrone.Core.Configuration;
+using NzbDrone.Core.Movies;
+using NzbDrone.Core.Parser;
+
+namespace NzbDrone.Core.Test.MovieTests.MovieServiceTests
+{
+    [TestFixture]
+    public class FindFuzzyMovieByYearFixture
+    {
+        // Regression: indexers like Knaben/The Pirate Bay (via Prowlarr) prepend an all-caps category tag, e.g. "GAY:", to the release title. Exact-title matching then fails and there was no fallback for non-scene movies, so every such release was rejected as Unknown Movie (whisparr/whisparr#1257).
+        private const int ReleaseYear = 2009;
+
+        private Mock<IMovieRepository> _movieRepositoryMock;
+        private Mock<IConfigService> _configServiceMock;
+        private MovieService _movieService;
+
+        [SetUp]
+        public void Setup()
+        {
+            _movieRepositoryMock = new Mock<IMovieRepository>();
+            _configServiceMock = new Mock<IConfigService>();
+
+            // Constructor order: IMovieRepository, ICreditsService, IStudioService, IEventAggregator, IConfigService, IBuildMoviePaths, IAutoTaggingService, ICacheManager, Logger
+            _movieService = new MovieService(
+                _movieRepositoryMock.Object,
+                null, // ICreditsService
+                null, // IStudioService
+                null, // IEventAggregator
+                _configServiceMock.Object,
+                null, // IBuildMoviePaths
+                null, // IAutoTaggingService
+                null, // ICacheManager
+                NzbDroneLogger.GetLogger(typeof(MovieService)));
+
+            // Mirror the production default (ConfigService.GetValueInt(..., 80)) so these positives prove the fix works for unconfigured users.
+            _configServiceMock.SetupGet(c => c.WhisparrFuzzyTitleMatchingThreshold).Returns(80);
+        }
+
+        private static Movie CreateMovie(string title, int id = 0)
+        {
+            var movie = new Movie { Id = id, Title = title };
+
+            // Populate CleanTitle exactly as AddMovieService and SkyHookProxy do, so these tests exercise the branch production actually takes rather than the Title fallback.
+            movie.MovieMetadata.Value.CleanTitle = title.CleanMovieTitle();
+
+            return movie;
+        }
+
+        [Test]
+        public void Should_match_movie_when_release_has_leading_category_tag_and_exact_match_fails()
+        {
+            // The library entry is stored without the tag; the release carries a 5-char "GAY: " prefix.
+            var movie = CreateMovie("To the Last Man: The Gathering Storm");
+
+            _movieRepositoryMock.Setup(r => r.FindByYear(ItemType.Movie, ReleaseYear))
+                .Returns(new List<Movie> { movie });
+
+            // CleanMovieTitle strips the leading tag and normalizes punctuation/spacing; with the release year appended on both sides the remaining delta is only the "gay" token.
+            var result = _movieService.FindFuzzyMovieByYear("GAY: To the Last Man: The Gathering Storm", ReleaseYear);
+
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result.Title, Is.EqualTo(movie.Title));
+        }
+
+        [Test]
+        public void Should_match_movie_end_to_end_when_real_parser_produces_category_tagged_title()
+        {
+            // Full chain for whisparr/whisparr#1257: the exact release title from a Torznab indexer, parsed by the real parser, then fuzzy-matched. Exact-title matching fails on "GAY: ..." — this proves the fallback resolves it.
+            var parsed = Parser.Parser.ParseMovieTitle("GAY: To the Last Man: The Gathering Storm (2009.xvid)");
+            Assert.That(parsed, Is.Not.Null);
+            Assert.Multiple(() =>
+            {
+                Assert.That(parsed.PrimaryMovieTitle, Does.StartWith("GAY:"));
+                Assert.That(parsed.Year, Is.EqualTo(ReleaseYear));
+            });
+
+            var movie = CreateMovie("To the Last Man: The Gathering Storm");
+            _movieRepositoryMock.Setup(r => r.FindByYear(ItemType.Movie, parsed.Year))
+                .Returns(new List<Movie> { movie });
+
+            var result = _movieService.FindFuzzyMovieByYear(parsed.PrimaryMovieTitle, parsed.Year);
+
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result.Title, Is.EqualTo(movie.Title));
+        }
+
+        [Test]
+        public void Should_match_movie_without_any_prefix_as_before()
+        {
+            var movie = CreateMovie("To the Last Man: The Gathering Storm");
+
+            _movieRepositoryMock.Setup(r => r.FindByYear(ItemType.Movie, ReleaseYear))
+                .Returns(new List<Movie> { movie });
+
+            var result = _movieService.FindFuzzyMovieByYear("To the Last Man: The Gathering Storm", ReleaseYear);
+
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result.Title, Is.EqualTo(movie.Title));
+        }
+
+        [Test]
+        public void Should_not_match_when_fuzzy_matching_is_disabled_below_threshold()
+        {
+            var movie = CreateMovie("To the Last Man: The Gathering Storm");
+
+            _movieRepositoryMock.Setup(r => r.FindByYear(ItemType.Movie, ReleaseYear))
+                .Returns(new List<Movie> { movie });
+            _configServiceMock.SetupGet(c => c.WhisparrFuzzyTitleMatchingThreshold).Returns(0); // below 70 disables fuzzy matching; the shipped default is 80
+
+            var result = _movieService.FindFuzzyMovieByYear("GAY: To the Last Man: The Gathering Storm", ReleaseYear);
+
+            Assert.That(result, Is.Null);
+        }
+
+        [Test]
+        public void Should_not_match_when_no_candidates_for_year()
+        {
+            _movieRepositoryMock.Setup(r => r.FindByYear(ItemType.Movie, ReleaseYear))
+                .Returns(new List<Movie>());
+
+            var result = _movieService.FindFuzzyMovieByYear("GAY: To the Last Man: The Gathering Storm", ReleaseYear);
+
+            Assert.That(result, Is.Null);
+        }
+
+        [Test]
+        public void Should_match_when_clean_title_was_never_populated()
+        {
+            // A movie added without a metadata refresh has a null CleanTitle; the fallback cleans Title instead.
+            var movie = new Movie { Title = "To the Last Man: The Gathering Storm" };
+
+            _movieRepositoryMock.Setup(r => r.FindByYear(ItemType.Movie, ReleaseYear))
+                .Returns(new List<Movie> { movie });
+
+            var result = _movieService.FindFuzzyMovieByYear("GAY: To the Last Man: The Gathering Storm", ReleaseYear);
+
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result.Title, Is.EqualTo(movie.Title));
+        }
+
+        [Test]
+        public void Should_not_match_when_two_candidates_score_within_the_margin()
+        {
+            // Same-year near-duplicates (e.g. the same title from two studios) are ambiguous - returning either one would be a guess.
+            _movieRepositoryMock.Setup(r => r.FindByYear(ItemType.Movie, ReleaseYear))
+                .Returns(new List<Movie>
+                {
+                    CreateMovie("To the Last Man: The Gathering Storm", 1),
+                    CreateMovie("To the Last Man: The Gathering Storms", 2)
+                });
+
+            var result = _movieService.FindFuzzyMovieByYear("GAY: To the Last Man: The Gathering Storm", ReleaseYear);
+
+            Assert.That(result, Is.Null);
+        }
+
+        [Test]
+        public void Should_match_the_clear_winner_when_the_runner_up_is_outside_the_margin()
+        {
+            var winner = CreateMovie("To the Last Man: The Gathering Storm", 1);
+
+            _movieRepositoryMock.Setup(r => r.FindByYear(ItemType.Movie, ReleaseYear))
+                .Returns(new List<Movie> { winner, CreateMovie("To the Last Woman", 2) });
+
+            var result = _movieService.FindFuzzyMovieByYear("GAY: To the Last Man: The Gathering Storm", ReleaseYear);
+
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result.Title, Is.EqualTo(winner.Title));
+        }
+
+        // A sequel scores ~95 against its predecessor, which is well above any usable threshold - only the trailing number tells them apart.
+        [TestCase("Taboo 2", "Taboo")]
+        [TestCase("Taboo", "Taboo 2")]
+        [TestCase("Bad Boys 3", "Bad Boys")]
+        [TestCase("Office Affairs Volume 2", "Office Affairs Volume 1")]
+        [TestCase("Taboo III", "Taboo 2")]
+        public void Should_not_match_across_a_different_sequel_number(string releaseTitle, string libraryTitle)
+        {
+            _movieRepositoryMock.Setup(r => r.FindByYear(ItemType.Movie, ReleaseYear))
+                .Returns(new List<Movie> { CreateMovie(libraryTitle) });
+
+            var result = _movieService.FindFuzzyMovieByYear(releaseTitle, ReleaseYear);
+
+            Assert.That(result, Is.Null);
+        }
+
+        [TestCase("GAY: Taboo 2", "Taboo 2")]
+        [TestCase("GAY: Taboo II", "Taboo II")]
+        public void Should_still_match_when_the_sequel_number_agrees(string releaseTitle, string libraryTitle)
+        {
+            _movieRepositoryMock.Setup(r => r.FindByYear(ItemType.Movie, ReleaseYear))
+                .Returns(new List<Movie> { CreateMovie(libraryTitle) });
+
+            var result = _movieService.FindFuzzyMovieByYear(releaseTitle, ReleaseYear);
+
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result.Title, Is.EqualTo(libraryTitle));
+        }
+
+        // Documents a known limitation rather than asserting desirable behaviour: the sequel guard accepts these (II and 2 are the same number), but the cleaned strings still differ enough that Fuzz.Ratio falls below the threshold. Exact matching already handles roman/arabic pairs, so this only bites a roman-numeral release whose title also failed exact matching.
+        [TestCase("GAY: Taboo II", "Taboo 2")]
+        [TestCase("GAY: Taboo 2", "Taboo II")]
+        public void Should_not_currently_match_roman_and_arabic_forms_of_the_same_sequel(string releaseTitle, string libraryTitle)
+        {
+            _movieRepositoryMock.Setup(r => r.FindByYear(ItemType.Movie, ReleaseYear))
+                .Returns(new List<Movie> { CreateMovie(libraryTitle) });
+
+            var result = _movieService.FindFuzzyMovieByYear(releaseTitle, ReleaseYear);
+
+            Assert.That(result, Is.Null);
+        }
+
+        [Test]
+        public void Should_not_match_unrelated_title_even_when_threshold_low()
+        {
+            var movie = CreateMovie("Some Completely Different Film");
+
+            _movieRepositoryMock.Setup(r => r.FindByYear(ItemType.Movie, ReleaseYear))
+                .Returns(new List<Movie> { movie });
+            _configServiceMock.SetupGet(c => c.WhisparrFuzzyTitleMatchingThreshold).Returns(70);
+
+            var result = _movieService.FindFuzzyMovieByYear("GAY: To the Last Man: The Gathering Storm", ReleaseYear);
+
+            Assert.That(result, Is.Null);
+        }
+    }
+}

--- a/src/NzbDrone.Core.Test/ParserTests/ParsingServiceTests/FuzzyYearFallbackFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/ParsingServiceTests/FuzzyYearFallbackFixture.cs
@@ -1,0 +1,130 @@
+using System.Collections.Generic;
+using FizzWare.NBuilder;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+using NzbDrone.Core.IndexerSearch.Definitions;
+using NzbDrone.Core.Languages;
+using NzbDrone.Core.Movies;
+using NzbDrone.Core.Parser;
+using NzbDrone.Core.Parser.Model;
+using NzbDrone.Test.Common;
+
+namespace NzbDrone.Core.Test.ParserTests.ParsingServiceTests
+{
+    [TestFixture]
+    public class FuzzyYearFallbackFixture : TestBase<ParsingService>
+    {
+        private Movie _movie;
+        private ParsedMovieInfo _taggedRelease;
+
+        [SetUp]
+        public void Setup()
+        {
+            _movie = Builder<Movie>.CreateNew()
+                                   .With(m => m.Id = 1)
+                                   .With(m => m.Title = "To the Last Man: The Gathering Storm")
+                                   .With(m => m.MovieMetadata.Value.CleanTitle = "tolastmangatheringstorm")
+                                   .With(m => m.MovieMetadata.Value.ItemType = ItemType.Movie)
+                                   .With(m => m.Year = 2009)
+                                   .Build();
+
+            _taggedRelease = new ParsedMovieInfo
+            {
+                MovieTitles = new List<string> { "GAY: To the Last Man: The Gathering Storm" },
+                Languages = new List<Language> { Language.English },
+                Year = 2009
+            };
+        }
+
+        private void GivenFuzzyMatch(Movie movie)
+        {
+            Mocker.GetMock<IMovieService>()
+                  .Setup(s => s.FindFuzzyMovieByYear(It.IsAny<string>(), It.IsAny<int>()))
+                  .Returns(movie);
+        }
+
+        [Test]
+        public void should_fall_back_to_fuzzy_match_when_exact_matching_fails()
+        {
+            GivenFuzzyMatch(_movie);
+
+            var result = Subject.Map(_taggedRelease, "", 0, null);
+
+            result.Movie.Should().Be(_movie);
+            result.MovieMatchType.Should().Be(MovieMatchType.FuzzyTitle);
+        }
+
+        [Test]
+        public void should_not_attempt_fuzzy_match_when_exact_matching_succeeds()
+        {
+            Mocker.GetMock<IMovieService>()
+                  .Setup(s => s.FindByTitle(It.IsAny<List<string>>(), It.IsAny<int>(), It.IsAny<List<string>>(), It.IsAny<List<Movie>>()))
+                  .Returns(_movie);
+
+            var result = Subject.Map(_taggedRelease, "", 0, null);
+
+            result.MovieMatchType.Should().Be(MovieMatchType.Title);
+
+            Mocker.GetMock<IMovieService>()
+                  .Verify(v => v.FindFuzzyMovieByYear(It.IsAny<string>(), It.IsAny<int>()), Times.Never());
+        }
+
+        [Test]
+        public void should_not_attempt_fuzzy_match_without_a_reliable_year()
+        {
+            // Without a parsed year there is nothing to scope the candidate set to, so the fallback would be comparing against the whole library.
+            _taggedRelease.Year = 0;
+
+            Subject.Map(_taggedRelease, "", 0, null);
+
+            Mocker.GetMock<IMovieService>()
+                  .Verify(v => v.FindFuzzyMovieByYear(It.IsAny<string>(), It.IsAny<int>()), Times.Never());
+        }
+
+        [Test]
+        public void should_ignore_fuzzy_match_for_a_movie_other_than_the_one_searched_for()
+        {
+            var otherMovie = Builder<Movie>.CreateNew()
+                                           .With(m => m.Id = 2)
+                                           .With(m => m.Title = "Some Other Film")
+                                           .With(m => m.MovieMetadata.Value.ItemType = ItemType.Movie)
+                                           .With(m => m.Year = 2009)
+                                           .Build();
+
+            GivenFuzzyMatch(otherMovie);
+
+            var result = Subject.Map(_taggedRelease, "", 0, new MovieSearchCriteria { Movie = _movie });
+
+            result.Movie.Should().BeNull();
+        }
+
+        [Test]
+        public void should_accept_fuzzy_match_for_the_movie_that_was_searched_for()
+        {
+            GivenFuzzyMatch(_movie);
+
+            var result = Subject.Map(_taggedRelease, "", 0, new MovieSearchCriteria { Movie = _movie });
+
+            result.Movie.Should().Be(_movie);
+            result.MovieMatchType.Should().Be(MovieMatchType.FuzzyTitle);
+        }
+
+        [Test]
+        public void should_ignore_fuzzy_match_that_is_not_a_movie()
+        {
+            var scene = Builder<Movie>.CreateNew()
+                                      .With(m => m.Id = 3)
+                                      .With(m => m.Title = "To the Last Man: The Gathering Storm")
+                                      .With(m => m.MovieMetadata.Value.ItemType = ItemType.Scene)
+                                      .With(m => m.Year = 2009)
+                                      .Build();
+
+            GivenFuzzyMatch(scene);
+
+            var result = Subject.Map(_taggedRelease, "", 0, null);
+
+            result.Movie.Should().BeNull();
+        }
+    }
+}

--- a/src/NzbDrone.Core/Download/CompletedDownloadService.cs
+++ b/src/NzbDrone.Core/Download/CompletedDownloadService.cs
@@ -106,10 +106,19 @@ namespace NzbDrone.Core.Download
                 Enum.TryParse(historyItem.Data.GetValueOrDefault(MovieHistory.MOVIE_MATCH_TYPE, MovieMatchType.Unknown.ToString()), out MovieMatchType movieMatchType);
                 Enum.TryParse(historyItem.Data.GetValueOrDefault(MovieHistory.RELEASE_SOURCE, ReleaseSourceType.Unknown.ToString()), out ReleaseSourceType releaseSource);
 
-                // Show a warning if the release was matched by ID and the source is not interactive search
+                // Show a warning if the release was matched by ID or fuzzy title and the source is not interactive search
                 if (movieMatchType == MovieMatchType.Id && releaseSource != ReleaseSourceType.InteractiveSearch)
                 {
                     trackedDownload.Warn("Found matching movie via grab history, but release was matched to movie by ID. Manual Import required.");
+                    SetStateToImportBlocked(trackedDownload);
+
+                    return;
+                }
+
+                // A fuzzy title match is a best guess, not an identification - don't import it unattended
+                if (movieMatchType == MovieMatchType.FuzzyTitle && releaseSource != ReleaseSourceType.InteractiveSearch)
+                {
+                    trackedDownload.Warn("Found matching movie via grab history, but release was matched to movie by fuzzy title. Manual Import required.");
                     SetStateToImportBlocked(trackedDownload);
 
                     return;

--- a/src/NzbDrone.Core/Movies/MovieRepository.cs
+++ b/src/NzbDrone.Core/Movies/MovieRepository.cs
@@ -17,15 +17,16 @@ namespace NzbDrone.Core.Movies
         bool MoviePathExists(string path);
         List<Movie> FindByTitles(List<string> titles);
         IEnumerable<Movie> FindByIds(List<int> ids);
-        Movie FindByTpdbId(string tpdbid);
         Movie FindByImdbId(string imdbid);
-        Movie FindByTmdbId(int tmdbid);
         Movie FindByForeignId(string foreignId);
         List<Movie> FindByForeignIds(List<string> foreignIds);
+        Movie FindByTpdbId(string tpdbid);
         List<Movie> FindByTpdbId(List<string> tpdbids);
+        Movie FindByTmdbId(int tmdbid);
         List<Movie> FindByTmdbId(List<int> tmdbids);
         List<Movie> FindByStudioAndDate(string studioForeignId, string date);
         List<Movie> GetByStudioForeignId(string studioForeignId);
+        List<Movie> FindByYear(ItemType itemType, int year);
         List<Movie> GetByPerformerForeignId(string performerForeignId);
         List<Movie> MoviesBetweenDates(DateTime start, DateTime end, bool includeUnmonitored);
         PagingSpec<Movie> MoviesWithoutFiles(PagingSpec<Movie> pagingSpec, HashSet<int> movieTags = null);
@@ -342,6 +343,22 @@ namespace NzbDrone.Core.Movies
             var builder = new SqlBuilder(_database.DatabaseType)
                 .Join<Movie, MovieMetadata>((m, p) => m.MovieMetadataId == p.Id)
                 .Where<MovieMetadata>(x => x.StudioForeignId == studioForeignId);
+
+            return _database.QueryJoined<Movie, MovieMetadata>(
+                builder,
+                (movie, metadata) =>
+                {
+                    movie.MovieMetadata = metadata;
+
+                    return movie;
+                }).AsList();
+        }
+
+        public List<Movie> FindByYear(ItemType itemType, int year)
+        {
+            var builder = new SqlBuilder(_database.DatabaseType)
+                .Join<Movie, MovieMetadata>((m, p) => m.MovieMetadataId == p.Id)
+                .Where<MovieMetadata>(x => x.ItemType == itemType && x.Year == year);
 
             return _database.QueryJoined<Movie, MovieMetadata>(
                 builder,

--- a/src/NzbDrone.Core/Movies/MovieService.cs
+++ b/src/NzbDrone.Core/Movies/MovieService.cs
@@ -43,6 +43,7 @@ namespace NzbDrone.Core.Movies
         List<Movie> FindByTitleCandidates(List<string> titles, out List<string> otherTitles);
         Movie FindScene(ParsedMovieInfo parsedMovieInfo, bool interactiveSearch = false, SearchCriteriaBase searchCriteria = null);
         List<Movie> GetByStudioForeignId(string studioForeignId);
+        Movie FindFuzzyMovieByYear(string title, int year);
         List<Movie> GetByPerformerForeignId(string performerForeignId);
         Movie FindByPath(string path);
         Dictionary<int, string> AllMoviePaths();
@@ -80,6 +81,14 @@ namespace NzbDrone.Core.Movies
     public class MovieService : IMovieService, IHandle<MovieFileAddedEvent>,
                                                IHandle<MovieFileDeletedEvent>
     {
+        private const int FuzzyMovieMatchMargin = 5;
+
+        // A trailing number is the difference between a movie and its sequel, so it has to survive title cleaning intact.
+        private static readonly Regex SequelTokenRegex = new Regex(@"\b(?<token>\d{1,4}|[ivx]{1,5})\s*$", RegexOptions.IgnoreCase | RegexOptions.Compiled, RegexDefaults.Timeout);
+
+        private static readonly Dictionary<string, int> RomanSequelTokens =
+            RomanNumeralParser.GetArabicRomanNumeralsMapping().ToDictionary(m => m.RomanNumeralLowerCase, m => m.ArabicNumeral);
+
         private readonly IMovieRepository _movieRepository;
         private readonly ICreditService _creditService;
         private readonly IStudioService _studioService;
@@ -1286,6 +1295,103 @@ namespace NzbDrone.Core.Movies
             _logger.Debug("{0}: Matching [{1}] to movie [{2}]: {3}%", methodName, normalizedTitle, movie.ToString(), score);
 
             return (movie, score);
+        }
+
+        /// <summary>Finds a movie by fuzzy title match among movies released in the given year.</summary>
+        /// <remarks>Compares the parsed title (cleaned, with the release year appended) against each candidate's clean title. The year is included on both sides so a spurious leading tag only shifts similarity by its own length rather than also desynchronizing the year suffix. A margin over the runner-up score disambiguates same-year near-duplicates.</remarks>
+        /// <param name="title">The release title to match. Will be normalized.</param>
+        /// <param name="year">A parsed, reliable release year (1800 or later).</param>
+        /// <returns>The single best matching movie, or null if none clears the threshold with sufficient margin.</returns>
+        public Movie FindFuzzyMovieByYear(string title, int year)
+        {
+            var methodName = "FindFuzzyMovieByYear";
+            var normalizedTitle = $"{title.CleanMovieTitle().StripSpaces()}{year}";
+
+            var threshold = _configService.WhisparrFuzzyTitleMatchingThreshold;
+            if (threshold < 70)
+            {
+                _logger.Trace("{0}: Fuzzy match disabled with a threshold of {1}", methodName, threshold);
+                return null;
+            }
+
+            var candidates = _movieRepository.FindByYear(ItemType.Movie, year) ?? new List<Movie>();
+
+            var titleSequel = GetSequelToken(title);
+
+            var matches = new List<(Movie Movie, int Score)>();
+            foreach (var movie in candidates)
+            {
+                // "Taboo 2" scores ~95 against "Taboo", so without this the fuzzy pass happily grabs the wrong entry whenever only one of a numbered pair is in the library.
+                if (GetSequelToken(movie.Title) != titleSequel)
+                {
+                    _logger.Trace("{0}: Skipping [{1}] - sequel number does not match the release", methodName, movie.ToString());
+                    continue;
+                }
+
+                // Prefer the pipeline's pre-cleaned title; fall back to cleaning Title if CleanTitle was never populated (e.g. a movie added without a metadata refresh).
+                var cleanCandidate = !string.IsNullOrWhiteSpace(movie.CleanTitle)
+                    ? movie.CleanTitle.CleanMovieTitle().StripSpaces()
+                    : movie.Title?.CleanMovieTitle().StripSpaces();
+
+                if (string.IsNullOrWhiteSpace(cleanCandidate))
+                {
+                    continue;
+                }
+
+                // Candidate titles already carry the release year, so compare title-only on both sides.
+                var candidateTitle = $"{cleanCandidate}{year}";
+
+                var score = FuzzySharp.Fuzz.Ratio(normalizedTitle, candidateTitle);
+                _logger.Debug("{0}: Matching [{1}] to movie [{2}]: {3}%", methodName, normalizedTitle, movie.ToString(), score);
+
+                if (score >= threshold)
+                {
+                    matches.Add((Movie: movie, Score: score));
+                }
+            }
+
+            if (matches.Count == 0)
+            {
+                return null;
+            }
+
+            var sorted = matches.OrderByDescending(m => m.Score).ToList();
+            var highest = sorted[0];
+
+            // If another candidate is within the margin, the match is ambiguous (e.g. same title from two studios) - don't guess.
+            if (sorted.Count > 1 && highest.Score - sorted[1].Score < FuzzyMovieMatchMargin)
+            {
+                _logger.Trace("{0}: Ambiguous fuzzy match, top [{1}] score {2} within margin of runner-up {3}", methodName, highest.Movie.Title, highest.Score, sorted[1].Score);
+                return null;
+            }
+
+            _logger.Trace("{0}: Returning fuzzy matched movie [{1} - {2}] with score {3}", methodName, highest.Movie.Title, highest.Movie.ForeignId, highest.Score);
+            return highest.Movie;
+        }
+
+        /// <summary>Extracts the trailing sequel/volume number from a title, normalizing roman numerals to their arabic value.</summary>
+        /// <returns>The number, or null when the title does not end in one.</returns>
+        private static int? GetSequelToken(string title)
+        {
+            if (title.IsNullOrWhiteSpace())
+            {
+                return null;
+            }
+
+            var match = SequelTokenRegex.Match(title.Trim());
+            if (!match.Success)
+            {
+                return null;
+            }
+
+            var token = match.Groups["token"].Value;
+
+            if (int.TryParse(token, out var arabic))
+            {
+                return arabic;
+            }
+
+            return RomanSequelTokens.TryGetValue(token.ToLowerInvariant(), out var roman) ? roman : null;
         }
     }
 }

--- a/src/NzbDrone.Core/Parser/Model/FindMovieResult.cs
+++ b/src/NzbDrone.Core/Parser/Model/FindMovieResult.cs
@@ -19,6 +19,7 @@ namespace NzbDrone.Core.Parser.Model
         Unknown = 0,
         Title = 1,
         Alias = 2,
-        Id = 3
+        Id = 3,
+        FuzzyTitle = 4
     }
 }

--- a/src/NzbDrone.Core/Parser/ParsingService.cs
+++ b/src/NzbDrone.Core/Parser/ParsingService.cs
@@ -164,6 +164,11 @@ namespace NzbDrone.Core.Parser
                     }
                 }
 
+                if (result == null && parsedMovieInfo.Year >= 1800)
+                {
+                    result = TryGetMovieByFuzzyYear(parsedMovieInfo, searchCriteria);
+                }
+
                 if (result == null)
                 {
                     _logger.Debug($"No matching movie for titles '{string.Join(", ", parsedMovieInfo.MovieTitles)} ({parsedMovieInfo.Year})'");
@@ -210,6 +215,34 @@ namespace NzbDrone.Core.Parser
             }
 
             return null;
+        }
+
+        /// <summary>
+        /// Fallback for releases that carry a leading category tag (e.g. "GAY:") or otherwise fail exact-title matching but parse to a reliable release year. Delegates the Levenshtein scoring and margin disambiguation to MovieService.
+        /// </summary>
+        /// <remarks>During a search the fuzzy result is only accepted when it is the movie that was searched for - a near-miss on some other library entry is not a reason to attribute this release to it.</remarks>
+        private FindMovieResult TryGetMovieByFuzzyYear(ParsedMovieInfo parsedMovieInfo, SearchCriteriaBase searchCriteria)
+        {
+            var title = parsedMovieInfo.PrimaryMovieTitle;
+            if (title.IsNullOrWhiteSpace())
+            {
+                return null;
+            }
+
+            var movie = _movieService.FindFuzzyMovieByYear(title, parsedMovieInfo.Year);
+            if (movie == null || movie.MovieMetadata?.Value.ItemType != ItemType.Movie)
+            {
+                return null;
+            }
+
+            if (searchCriteria?.Movie != null && movie.Id != searchCriteria.Movie.Id)
+            {
+                _logger.Debug("Fuzzy match found [{0}] but [{1}] was searched for, ignoring", movie.Title, searchCriteria.Movie.Title);
+
+                return null;
+            }
+
+            return new FindMovieResult(movie, MovieMatchType.FuzzyTitle);
         }
 
         private static FindMovieResult TryGetMovieBySearchCriteria(ParsedMovieInfo parsedMovieInfo, string imdbId, int tmdbId, SearchCriteriaBase searchCriteria)


### PR DESCRIPTION
#### Database Migration

NO

#### Description

Releases from some Torznab indexers (Knaben, TPB via Prowlarr) prepend an all-caps category tag — `GAY: To the Last Man: The Gathering Storm (2009.xvid)`. Exact-title matching fails, and unlike scenes, movies had no fallback, so every such release was rejected as Unknown Movie.

Adds a fuzzy pass for movies, scoped to the parsed release year via a new `MovieRepository.FindByYear` (served by the existing `(ItemType, Year)` index). Scoring reuses `WhisparrFuzzyTitleMatchingThreshold`, so it stays off below 70.

Year-only scoping is a much wider candidate set than the scene path's studio+date, so three guards carry the safety:

- **Sequel guard.** `Taboo 2` scores ~95 against `Taboo`. The trailing number is compared separately, normalized through the existing `RomanNumeralParser`. Without this the fuzzy pass grabs the wrong entry whenever only one of a numbered pair is in the library — verified against the real method before adding it.
- **Runner-up margin.** Same-year near-duplicates resolve to nothing rather than to a guess.
- **`FuzzyTitle` blocks unattended import** the way `Id` already does. Interactive-search grabs still import, having been confirmed by a human.

During a search the fuzzy result is only accepted when it *is* the movie searched for; a near-miss on another library entry is discarded and logged.

**Known limitation:** roman/arabic cross forms (`Taboo II` against a library `Taboo 2`) pass the sequel guard but fall below threshold on the cleaned strings. Exact matching already handles that pair, so it only affects a roman-numeral release that also failed exact matching. Asserted as a known-null so it stays visible.

Full `Whisparr.Core.Test` suite green — 4471 passed, 0 failed.

#### Todos

- [x] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)

#### Issues Fixed or Closed by this PR

- Fixes Whisparr/Whisparr-Eros#876
