### PR TITLE
Fixed: URL base missing from UI asset paths behind a reverse proxy

### DIFF
--- a/frontend/build/webpack.config.js
+++ b/frontend/build/webpack.config.js
@@ -76,7 +76,10 @@ module.exports = (env) => {
     },
 
     experiments: {
-      topLevelAwait: true
+      topLevelAwait: true,
+      // webpack 5.110 auto-enables native HTML, whose minimizer strips the quotes from
+      // index.html's attributes. html-webpack-plugin already minifies it.
+      html: false
     },
 
     plugins: [

--- a/src/NzbDrone.Api.Test/Frontend/Mappers/HtmlMapperBaseFixture.cs
+++ b/src/NzbDrone.Api.Test/Frontend/Mappers/HtmlMapperBaseFixture.cs
@@ -1,0 +1,93 @@
+using System;
+using System.IO;
+using FluentAssertions;
+using Moq;
+using NLog;
+using NUnit.Framework;
+using NzbDrone.Common.Disk;
+using NzbDrone.Test.Common;
+using Whisparr.Http.Frontend.Mappers;
+
+namespace NzbDrone.Api.Test.Frontend.Mappers
+{
+    [TestFixture]
+    public class HtmlMapperBaseFixture : TestBase
+    {
+        private const string IndexPath = "/ui/index.html";
+
+        private string Render(string html)
+        {
+            Mocker.GetMock<IDiskProvider>()
+                  .Setup(s => s.ReadAllText(IndexPath))
+                  .Returns(html);
+
+            Mocker.GetMock<ICacheBreakerProvider>()
+                  .Setup(s => s.AddCacheBreakerToPath(It.IsAny<string>()))
+                  .Returns<string>(path => path + "?h=hash");
+
+            var subject = new TestMapper(Mocker.GetMock<IDiskProvider>().Object,
+                                         new Lazy<ICacheBreakerProvider>(() => Mocker.GetMock<ICacheBreakerProvider>().Object),
+                                         LogManager.GetCurrentClassLogger());
+
+            return subject.Render();
+        }
+
+        [TestCase("<script src=\"/index.js\"></script>", "<script src=\"/whisparr/index.js?h=hash\"></script>")]
+        [TestCase("<link rel=\"icon\" href=\"/Content/favicon.png\"/>", "<link rel=\"icon\" href=\"/whisparr/Content/favicon.png?h=hash\"/>")]
+        [TestCase("<script src=\"/index.js\" data-no-hash></script>", "<script src=\"/whisparr/index.js\"></script>")]
+        public void should_prefix_quoted_attributes(string html, string expected)
+        {
+            Render(html).Should().Be(expected);
+        }
+
+        [TestCase("<script src=/index-ed23d8e8.js></script>", "<script src=\"/whisparr/index-ed23d8e8.js?h=hash\"></script>")]
+        [TestCase("<link rel=stylesheet href=/Content/styles.css>", "<link rel=stylesheet href=\"/whisparr/Content/styles.css?h=hash\">")]
+        [TestCase("<link rel=manifest href=/Content/manifest.json crossorigin=use-credentials>", "<link rel=manifest href=\"/whisparr/Content/manifest.json?h=hash\" crossorigin=use-credentials>")]
+        [TestCase("<script src=/index-ed23d8e8.js data-no-hash></script>", "<script src=\"/whisparr/index-ed23d8e8.js\"></script>")]
+        public void should_prefix_unquoted_attributes(string html, string expected)
+        {
+            Render(html).Should().Be(expected);
+        }
+
+        [TestCase("<a href=/jsdocs>")]
+        [TestCase("<a href=/styles.css/more>")]
+        public void should_not_rewrite_an_unquoted_value_that_does_not_end_in_an_asset_extension(string html)
+        {
+            Render(html).Should().Be(html);
+        }
+
+        [Test]
+        public void should_replace_the_url_base_placeholder()
+        {
+            Render("<script>window.Whisparr={urlBase:\"__URL_BASE__\"};</script>")
+                .Should().Be("<script>window.Whisparr={urlBase:\"/whisparr\"};</script>");
+        }
+
+        private sealed class TestMapper : HtmlMapperBase
+        {
+            public TestMapper(IDiskProvider diskProvider, Lazy<ICacheBreakerProvider> cacheBreakProviderFactory, Logger logger)
+                : base(diskProvider, cacheBreakProviderFactory, logger)
+            {
+                HtmlPath = IndexPath;
+                UrlBase = "/whisparr";
+            }
+
+            protected override string FolderPath => Path.GetDirectoryName(HtmlPath);
+
+            public string Render()
+            {
+                return GetHtmlText();
+            }
+
+            protected override string MapPath(string resourceUrl)
+            {
+                return HtmlPath;
+            }
+
+            public override bool CanHandle(string resourceUrl)
+            {
+                return true;
+            }
+        }
+    }
+}

--- a/src/Whisparr.Http/Frontend/Mappers/HtmlMapperBase.cs
+++ b/src/Whisparr.Http/Frontend/Mappers/HtmlMapperBase.cs
@@ -12,7 +12,9 @@ namespace Whisparr.Http.Frontend.Mappers
     {
         private readonly IDiskProvider _diskProvider;
         private readonly Lazy<ICacheBreakerProvider> _cacheBreakProviderFactory;
-        private static readonly Regex ReplaceRegex = new Regex(@"(?:(?<attribute>href|src)=\"")(?<path>.*?(?<extension>css|js|png|ico|ics|svg|json))(?:\"")(?:\s(?<nohash>data-no-hash))?", RegexOptions.Compiled | RegexOptions.IgnoreCase, RegexDefaults.Timeout);
+
+        // A minifier may drop the quotes (src=/index.js), so match both forms or the url base is never applied.
+        private static readonly Regex ReplaceRegex = new Regex(@"(?<attribute>href|src)=(?:\""(?<path>.*?(?:css|js|png|ico|ics|svg|json))\""|(?<path>[^\s\""'<>=`]+?(?:css|js|png|ico|ics|svg|json))(?=[\s>]))(?:\s(?<nohash>data-no-hash))?", RegexOptions.Compiled | RegexOptions.IgnoreCase, RegexDefaults.Timeout);
 
         private string _generatedContent;
 


### PR DESCRIPTION
#### Database Migration

NO

#### Description

Since webpack 5.110.2 (#623, first shipped in 3.4.1.1522), the UI fails to load behind a reverse proxy when a URL base is set: fonts, styles and the bundle are requested from the domain root. webpack now auto-enables native HTML, whose minimizer strips the quotes from `index.html`'s attributes, and `HtmlMapperBase` only matched quoted `href`/`src` values. So neither the URL base nor the `?h=` cache breaker was applied.

- `webpack.config.js`: `experiments.html: false`, restoring the quoted output from html-webpack-plugin's own minifier.
- `HtmlMapperBase`: the regex also accepts unquoted values, so a later minifier change can't silently drop the URL base again.

Verified with URL base `/whisparr`: each layer fixes it on its own (served the new build, and separately 1582's shipped unquoted `index.html`). Behind a proxy that only forwards `/whisparr`, all 9 assets return 200. `HtmlMapperBaseFixture` fails 4/10 on the old regex, and all 18 `Frontend.Mappers` tests pass.

Also affects the release branch (3.5.0.1585).

#### Screenshot(s) (if UI related)

<details>
<!-- paste screenshots below here.-->
N/A, no visual change.
<!-- paste screenshots above here.  MAKE SURE THE ARE SFW -->
</details>

#### Todos

- [x] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json) (none needed)

#### Issues Fixed or Closed by this PR

- Fixes Whisparr/Whisparr-Eros#874
