### PR TITLE
Fixed: Scene lookup by studio and date returning other studios' scenes

### DIFF
--- a/src/NzbDrone.Core.Test/MetadataSource/SkyHook/SkyHookProxyStudioDateSearchFixture.cs
+++ b/src/NzbDrone.Core.Test/MetadataSource/SkyHook/SkyHookProxyStudioDateSearchFixture.cs
@@ -1,0 +1,206 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+using NzbDrone.Common.Http;
+using NzbDrone.Common.Serializer;
+using NzbDrone.Core.MetadataSource.SkyHook;
+using NzbDrone.Core.MetadataSource.SkyHook.Resource;
+using NzbDrone.Core.Movies;
+using NzbDrone.Core.Movies.Studios;
+using NzbDrone.Core.Test.Framework;
+
+namespace NzbDrone.Core.Test.MetadataSource.SkyHook
+{
+    [TestFixture]
+    public class SkyHookProxyStudioDateSearchFixture : CoreTest<SkyHookProxy>
+    {
+        private const string BrazzersExxtraId = "39cee498-a9ac-4403-910a-1a0157ad22d8";
+        private const string OtherStudioId = "5b1a7f0c-2a3e-4d7a-9e1b-6c0d8f4a2b3c";
+        private const string FileName = "BrazzersExxtra.2024-05-17.Jane.Doe.Threeway.Tug.Of.War.1080p.mp4";
+
+        private HttpRequest _capturedRequest;
+
+        [SetUp]
+        public void Setup()
+        {
+            _capturedRequest = null;
+
+            GivenSearchReturns();
+        }
+
+        private void GivenSearchReturns(params MovieResource[] scenes)
+        {
+            Mocker.GetMock<IHttpClient>()
+                .Setup(v => v.Get<List<MovieResource>>(It.IsAny<HttpRequest>()))
+                .Returns((HttpRequest request) =>
+                {
+                    _capturedRequest = request;
+
+                    var response = new HttpResponse(request, new HttpHeader(), scenes.ToList().ToJson(), HttpStatusCode.OK);
+
+                    return new HttpResponse<List<MovieResource>>(response);
+                });
+        }
+
+        private void GivenStudioInLibrary(string foreignId)
+        {
+            Mocker.GetMock<IStudioService>()
+                .Setup(v => v.FindByTitle(It.IsAny<string>()))
+                .Returns(new Studio { Title = "Brazzers Exxtra", CleanTitle = "brazzersexxtra", ForeignId = foreignId });
+        }
+
+        private static MovieResource Scene(string stashId, string title, string studioTitle, string studioId, string releaseDate)
+        {
+            return new MovieResource
+            {
+                ItemType = ItemType.Scene,
+                ForeignIds = new ExternalIdResource { StashId = stashId },
+                Title = title,
+                ReleaseDate = releaseDate,
+                Images = new List<ImageResource>(),
+                Genres = new List<string>(),
+                Studio = new StudioResource
+                {
+                    Title = studioTitle,
+                    ForeignIds = new ExternalIdResource { StashId = studioId }
+                }
+            };
+        }
+
+        private List<string> SearchTitles(string term, ItemType itemType = ItemType.Scene)
+        {
+            return Subject.SearchForNewEntity(term, itemType)
+                .Cast<Movie>()
+                .Select(m => m.MovieMetadata.Value.Title)
+                .ToList();
+        }
+
+        private Dictionary<string, string> QueryParams()
+        {
+            _capturedRequest.Should().NotBeNull();
+
+            return _capturedRequest.Url.Query
+                .Split('&')
+                .Select(p => p.Split('='))
+                .ToDictionary(p => p[0], p => WebUtility.UrlDecode(p[1]));
+        }
+
+        [Test]
+        public void should_search_a_library_studio_by_id_and_date()
+        {
+            GivenStudioInLibrary(BrazzersExxtraId);
+
+            SearchTitles(FileName);
+
+            var query = QueryParams();
+            query["studio"].Should().Be(BrazzersExxtraId);
+            query["date"].Should().Be("2024-05-17");
+            query["q"].Should().Be("brazzers exxtra 2024-05-17");
+        }
+
+        [Test]
+        public void should_only_return_the_library_studio_on_the_parsed_date()
+        {
+            GivenStudioInLibrary(BrazzersExxtraId);
+            GivenSearchReturns(
+                Scene("a", "The Brazzers Podcast: Episode 17", "Brazzers Exxtra", BrazzersExxtraId, "2026-05-23"),
+                Scene("b", "May 17, 2024", "CumClinic", OtherStudioId, "2024-05-17"),
+                Scene("c", "Threeway Tug Of War", "Brazzers Exxtra", BrazzersExxtraId, "2024-05-17"),
+                Scene("d", "Step Up! The Best Of Stepsisters", "Brazzers Exxtra", BrazzersExxtraId, "2024-05-17"));
+
+            SearchTitles(FileName).Should().Equal("Threeway Tug Of War", "Step Up! The Best Of Stepsisters");
+        }
+
+        [Test]
+        public void should_not_match_another_studio_with_the_same_name_as_the_library_studio()
+        {
+            GivenStudioInLibrary(BrazzersExxtraId);
+            GivenSearchReturns(
+                Scene("c", "Threeway Tug Of War", "Brazzers Exxtra", OtherStudioId, "2024-05-17"));
+
+            SearchTitles(FileName).Should().BeEmpty();
+        }
+
+        [Test]
+        public void should_search_by_name_when_studio_is_not_in_library()
+        {
+            SearchTitles(FileName);
+
+            var query = QueryParams();
+            query.Should().NotContainKey("studio");
+            query.Should().NotContainKey("date");
+            query["q"].Should().Be("brazzersexxtra 2024-05-17");
+        }
+
+        [Test]
+        public void should_search_by_name_when_library_studio_has_no_stash_id()
+        {
+            GivenStudioInLibrary("tpdb-1234");
+
+            SearchTitles(FileName);
+
+            QueryParams().Should().NotContainKey("studio");
+        }
+
+        [Test]
+        public void should_match_studio_by_clean_title_when_studio_is_not_in_library()
+        {
+            GivenSearchReturns(
+                Scene("b", "May 17, 2024", "CumClinic", OtherStudioId, "2024-05-17"),
+                Scene("a", "The Brazzers Podcast: Episode 17", "Brazzers Exxtra", BrazzersExxtraId, "2026-05-23"),
+                Scene("c", "Threeway Tug Of War", "Brazzers Exxtra", BrazzersExxtraId, "2024-05-17"));
+
+            SearchTitles(FileName).Should().Equal("Threeway Tug Of War");
+        }
+
+        [Test]
+        public void should_return_nothing_when_no_result_is_from_the_parsed_studio()
+        {
+            // What StashDB returns for "brazzersexxtra 2024-05-17": only the date token matches
+            GivenSearchReturns(
+                Scene("e", "SpyTug 244-G17", "SpyTug", OtherStudioId, "2016-11-11"),
+                Scene("b", "May 17, 2024", "CumClinic", OtherStudioId, "2024-05-17"),
+                Scene("f", "May 17, 2024", "Cumpsters", OtherStudioId, "2024-05-17"));
+
+            SearchTitles(FileName).Should().BeEmpty();
+        }
+
+        [Test]
+        public void should_search_two_digit_year_scene_names_by_studio_and_date()
+        {
+            GivenStudioInLibrary(BrazzersExxtraId);
+
+            SearchTitles("BrazzersExxtra.24.05.17.Jane.Doe.Threeway.Tug.Of.War.XXX.1080p.MP4-GROUP.mp4");
+
+            var query = QueryParams();
+            query["studio"].Should().Be(BrazzersExxtraId);
+            query["date"].Should().Be("2024-05-17");
+        }
+
+        [Test]
+        public void should_search_whole_name_without_filtering_when_there_is_no_date()
+        {
+            GivenSearchReturns(
+                Scene("b", "May 17, 2024", "CumClinic", OtherStudioId, "2024-05-17"));
+
+            SearchTitles("BrazzersExxtra.Jane.Doe.Threeway.Tug.Of.War.1080p.mp4").Should().Equal("May 17, 2024");
+
+            var query = QueryParams();
+            query.Should().NotContainKey("studio");
+            query["q"].Should().StartWith("brazzersexxtra jane doe threeway tug of war");
+
+            Mocker.GetMock<IStudioService>().Verify(v => v.FindByTitle(It.IsAny<string>()), Times.Never());
+        }
+
+        [Test]
+        public void should_not_look_up_studio_for_movie_search()
+        {
+            SearchTitles(FileName, ItemType.Movie);
+
+            Mocker.GetMock<IStudioService>().Verify(v => v.FindByTitle(It.IsAny<string>()), Times.Never());
+        }
+    }
+}

--- a/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
+++ b/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
@@ -36,6 +36,7 @@ namespace NzbDrone.Core.MetadataSource.SkyHook
         private readonly IConfigService _configService;
         private readonly IMovieService _movieService;
         private readonly IMovieMetadataService _movieMetadataService;
+        private readonly IStudioService _studioService;
 
         public SkyHookProxy(IHttpClient httpClient,
             IWhisparrCloudRequestBuilder requestBuilder,
@@ -43,6 +44,7 @@ namespace NzbDrone.Core.MetadataSource.SkyHook
             IConfigFileProvider configFileProvider,
             IMovieService movieService,
             IMovieMetadataService movieMetadataService,
+            IStudioService studioService,
             Logger logger)
         {
             _httpClient = httpClient;
@@ -59,6 +61,7 @@ namespace NzbDrone.Core.MetadataSource.SkyHook
             _configService = configService;
             _movieService = movieService;
             _movieMetadataService = movieMetadataService;
+            _studioService = studioService;
 
             _logger = logger;
         }
@@ -777,6 +780,14 @@ namespace NzbDrone.Core.MetadataSource.SkyHook
                 }
             }
 
+            if (movieInfo is { IsScene: true } && itemType != ItemType.Movie &&
+                movieInfo.StashId.IsNullOrWhiteSpace() &&
+                movieInfo.StudioTitle.IsNotNullOrWhiteSpace() &&
+                movieInfo.ReleaseDate.IsNotNullOrWhiteSpace())
+            {
+                return SearchForNewSceneByStudioAndDate(movieInfo).Cast<object>().ToList();
+            }
+
             title = FormatSearchTerm(title, itemType, movieInfo);
             var lowerTitle = title.ToLower();
 
@@ -1085,6 +1096,44 @@ namespace NzbDrone.Core.MetadataSource.SkyHook
 
         public List<Movie> SearchForNewScene(string title)
         {
+            return SearchForNewScene(title, null, null);
+        }
+
+        private List<Movie> SearchForNewSceneByStudioAndDate(ParsedMovieInfo movieInfo)
+        {
+            var releaseDate = movieInfo.ReleaseDate;
+            var studio = _studioService.FindByTitle(movieInfo.StudioTitle);
+
+            List<Movie> results;
+            Func<MovieMetadata, bool> isSameStudio;
+
+            // A studio already in the library is searched by its StashDB id. Anything else can only be matched by name,
+            // and a studio and date search must never return another studio's scene.
+            if (studio != null && Guid.TryParse(studio.ForeignId, out _))
+            {
+                results = SearchForNewScene($"{studio.Title} {releaseDate}", studio.ForeignId, releaseDate);
+                isSameStudio = m => string.Equals(m.StudioForeignId, studio.ForeignId, StringComparison.OrdinalIgnoreCase);
+            }
+            else
+            {
+                var cleanStudioTitle = movieInfo.StudioTitle.CleanStudioTitle();
+
+                results = SearchForNewScene($"{movieInfo.StudioTitle} {releaseDate}", null, null);
+                isSameStudio = m => m.StudioTitle.CleanStudioTitle() == cleanStudioTitle;
+            }
+
+            var matches = results.Where(m => m.MovieMetadata.Value.ReleaseDate == releaseDate && isSameStudio(m.MovieMetadata.Value)).ToList();
+
+            if (matches.Count != results.Count)
+            {
+                _logger.Debug("Dropped {0} of {1} scene search results not from studio '{2}' on {3}", results.Count - matches.Count, results.Count, movieInfo.StudioTitle, releaseDate);
+            }
+
+            return matches;
+        }
+
+        private List<Movie> SearchForNewScene(string title, string studioForeignId, string releaseDate)
+        {
             try
             {
                 var lowerTitle = title.ToLower();
@@ -1126,10 +1175,19 @@ namespace NzbDrone.Core.MetadataSource.SkyHook
 
                 var searchTerm = lowerTitle.Replace("_", " ").Replace(".", " ");
 
-                var request = _whisparrMetadata.Create()
+                var requestBuilder = _whisparrMetadata.Create()
                     .SetSegment("route", "scene/search")
-                    .AddQueryParam("q", searchTerm)
-                    .Build();
+                    .AddQueryParam("q", searchTerm);
+
+                // The metadata server answers a studio and date pair with that studio's scenes on that date.
+                // Older servers ignore the pair and search by q, so q is always sent.
+                if (studioForeignId.IsNotNullOrWhiteSpace() && releaseDate.IsNotNullOrWhiteSpace())
+                {
+                    requestBuilder.AddQueryParam("studio", studioForeignId)
+                        .AddQueryParam("date", releaseDate);
+                }
+
+                var request = requestBuilder.Build();
 
                 request.AllowAutoRedirect = true;
 
@@ -1401,11 +1459,6 @@ namespace NzbDrone.Core.MetadataSource.SkyHook
                 if (movieInfo.StashId.IsNotNullOrWhiteSpace())
                 {
                     return $"stashid:{movieInfo.StashId}";
-                }
-
-                if (movieInfo.ReleaseDate.IsNotNullOrWhiteSpace())
-                {
-                    return $"{movieInfo.StudioTitle} {movieInfo.ReleaseDate}";
                 }
             }
             else if (!movieInfo.IsScene && itemType != ItemType.Scene)


### PR DESCRIPTION
#### Database Migration

NO

#### Description

A dated scene filename was looked up with the free text `{studio} {date}`. StashDB scores those as loose tokens, so `BrazzersExxtra.2024-05-17...` matched only on the date and Import Scenes preselected a scene from an unrelated studio.

- Studio in the library (clean title or alias): looked up by its StashDB id and the date via Whisparr/Whisparr-Eros-Metadata#27, and only results with that studio id on that date are kept.
- Otherwise: the text search still runs, keeping only results from a studio with the same clean title on that date. Another studio's scene is never returned.

Still one call per file, no studio lookups against SkyHook. `q` is sent with the pair, so this works before the metadata change deploys (checked live: the extra params are ignored and the filter leaves the two correct scenes).

Not covered: two scenes from one studio on one day both come back and the first is still preselected (Whisparr/Whisparr-Eros#810). A dated name with no parsed studio now searches the whole filename instead of the bare date.

#### Todos

- [x] Tests — `SkyHookProxyStudioDateSearchFixture` (10, six fail without the fix); Core suite 4452 passed, container fixture passes
- [x] Translation Keys — none needed

#### Issues Fixed or Closed by this PR

- Fixes Whisparr/Whisparr-Eros#859
