### PR TITLE
chore: suppress two non-applicable warnings for .NET

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -162,7 +162,7 @@ dotnet_diagnostic.CA1056.severity = suggestion
 dotnet_diagnostic.CA1058.severity = suggestion
 dotnet_diagnostic.CA1060.severity = suggestion
 dotnet_diagnostic.CA1061.severity = suggestion
-dotnet_diagnostic.CA1062.severity = suggestion
+dotnet_diagnostic.CA1062.severity = none # reviewed 2026-09-12, not valuable since our code isn't a library
 dotnet_diagnostic.CA1063.severity = suggestion
 dotnet_diagnostic.CA1064.severity = suggestion
 dotnet_diagnostic.CA1065.severity = suggestion
@@ -271,7 +271,7 @@ dotnet_diagnostic.CA5385.severity = suggestion
 dotnet_diagnostic.CA5392.severity = suggestion
 dotnet_diagnostic.CA5394.severity = suggestion
 dotnet_diagnostic.CA5397.severity = suggestion
-
+dotnet_diagnostic.IDE0028.severity = none # 2026-09-12 - Suppress from SonarQube, our style convention overrules.
 dotnet_diagnostic.SYSLIB0006.severity = none
 
 [src/*.Test/**.cs] # exempt tests from "Remove the underscores from member name" for SonarQube


### PR DESCRIPTION
- CA1062 - We are not exposing these as a library/SDK
- IDE0028 - Conflicts with our established style convention.  We'd need a massive refactor to clear it

Both of these default to `suggestion`, which causes noise in SonarQube we're not likely to triage.

#### Database Migration

<!-- If you update database schema, the migration number must be noted here -->

NO

#### Description

A few sentences describing the overall goals of the pull request's commits.

#### Screenshot(s) (if UI related)

<details>
<!-- paste screenshots below here.-->

<!-- paste screenshots above here.  MAKE SURE THE ARE SFW -->
</details>

#### Todos

- [n/a] Tests
- [n/a] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)

#### Issues Fixed or Closed by this PR

<!-- If multiple, put each on a separate line -->

- Fixes whisparr/whisparr#XXXX
