### PR TITLE
chore: improve reliability on Collection sort, warning for non-TMDb

### DIFF
--- a/frontend/src/Collection/NoMovieCollections.tsx
+++ b/frontend/src/Collection/NoMovieCollections.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
+import Alert from 'Components/Alert';
 import Button from 'Components/Link/Button';
 import { kinds } from 'Helpers/Props';
+import { useGeneralSettings } from 'Settings/General/useGeneralSettings';
 import translate from 'Utilities/String/translate';
 import styles from './NoMovieCollections.css';
 
@@ -8,7 +10,9 @@ interface NoMovieCollectionsProps {
   totalItems: number;
 }
 
-function NoMovieCollections({ totalItems }: NoMovieCollectionsProps) {
+function NoMovieCollections({ totalItems }: Readonly<NoMovieCollectionsProps>) {
+  const { data: generalSettings } = useGeneralSettings();
+
   if (totalItems > 0) {
     return (
       <div>
@@ -16,6 +20,17 @@ function NoMovieCollections({ totalItems }: NoMovieCollectionsProps) {
           {translate('AllCollectionsHiddenDueToFilter')}
         </div>
       </div>
+    );
+  }
+
+  // Collections only ever come from TMDb: the TPDb movie resource carries no
+  // collection, so with TPDb as the source this page can never fill, and
+  // "add a new movie" would send the user off to do something that won't help.
+  if (generalSettings.whisparrMovieMetadataSource?.toLowerCase() === 'tpdb') {
+    return (
+      <Alert kind={kinds.WARNING}>
+        {translate('CollectionsUnavailableWithTpdb')}
+      </Alert>
     );
   }
 

--- a/frontend/src/Collection/useMovieCollections.ts
+++ b/frontend/src/Collection/useMovieCollections.ts
@@ -43,7 +43,7 @@ export function useCollectionExistingMovies(collections: MovieCollection[]) {
       });
     });
 
-    return Array.from(ids).sort();
+    return Array.from(ids).sort((a, b) => a.localeCompare(b));
   }, [collections]);
 
   const { data } = useApiQuery<Movie[]>({

--- a/src/NzbDrone.Core/Localization/Core/en.json
+++ b/src/NzbDrone.Core/Localization/Core/en.json
@@ -283,6 +283,7 @@
   "CollectionShowOverviewsHelpText": "Show collection overviews",
   "CollectionShowPostersHelpText": "Show Collection item posters",
   "CollectionsSelectedInterp": "{0} Collection(s) Selected",
+  "CollectionsUnavailableWithTpdb": "Collections come from TMDb, and your movie metadata source is TPDb, which doesn't provide them. Switch the movie metadata source to TMDb in Settings > General to use Collections.",
   "ColonReplacement": "Colon Replacement",
   "ColonReplacementFormatHelpText": "Change how {appName} handles colon replacement",
   "Complete": "Complete",


### PR DESCRIPTION
#### Database Migration

<!-- If you update database schema, the migration number must be noted here -->

NO

#### Description

Per SonaeQube:
Provide a compare function that depends on "String.localeCompare", to reliably sort elements alphabetically.

Also added a warning when viewing the Collections tab when metadata source is set to non-TMDb.  TMDb is the only source for that data.

#### Screenshot(s) (if UI related)

<details>
<!-- paste screenshots below here.-->

<!-- paste screenshots above here.  MAKE SURE THE ARE SFW -->
</details>

#### Todos

- [n/a] Tests
- [n/a] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)

#### Issues Fixed or Closed by this PR

<!-- If multiple, put each on a separate line -->

- Fixes whisparr/whisparr#XXXX
